### PR TITLE
Annotate const loads in derefAddress

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3865,13 +3865,6 @@ IRNode *GenIR::makePtrNode(ReaderPtrType PtrType) { return loadNull(); }
 IRNode *GenIR::derefAddress(IRNode *Address, bool DstIsGCPtr, bool IsConst,
                             bool AddressMayBeNull) {
 
-  // TODO: If IsConst is false, the load could cause a null pointer exception,
-  // so we may need an explicit null check. Not sure if there's a covering
-  // upstream check or not, so be cautious now.
-  if (!IsConst) {
-    throw NotYetImplementedException("non-const derefAddress");
-  }
-
   // We don't know the true referent type so just use a pointer sized
   // integer or GC pointer to i8 for the result.
 
@@ -3898,7 +3891,15 @@ IRNode *GenIR::derefAddress(IRNode *Address, bool DstIsGCPtr, bool IsConst,
     Address = (IRNode *)LLVMBuilder->CreatePointerCast(Address, CastTy);
   }
 
-  Value *Result = makeLoad(Address, false, AddressMayBeNull);
+  LoadInst *Result = makeLoad(Address, false, AddressMayBeNull);
+
+  if (IsConst) {
+    MDNode *EmptyNode =
+        MDNode::get(*JitContext->LLVMContext, ArrayRef<Metadata *>());
+
+    Result->setMetadata(LLVMContext::MD_invariant_load, EmptyNode);
+  }
+
   return (IRNode *)Result;
 }
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11782,13 +11907,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
@@ -12177,13 +12302,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12336,13 +12461,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12441,13 +12566,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12524,7 +12649,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12540,13 +12665,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12688,13 +12813,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12765,13 +12890,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13232,13 +13357,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13352,13 +13477,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13400,13 +13525,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13437,13 +13562,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13463,13 +13588,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13584,13 +13709,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13680,13 +13805,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13784,13 +13909,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13837,13 +13962,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13893,13 +14018,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13915,13 +14040,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14182,13 +14307,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14227,13 +14352,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14274,13 +14399,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14317,13 +14442,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14347,13 +14472,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14521,13 +14646,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14820,13 +14945,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
   br label %21
@@ -15650,13 +15775,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -15837,13 +15962,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -16199,13 +16324,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11794,13 +11919,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12189,13 +12314,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12348,13 +12473,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12453,13 +12578,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12536,7 +12661,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12552,13 +12677,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12700,13 +12825,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12777,13 +12902,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13244,13 +13369,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13364,13 +13489,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13412,13 +13537,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13475,13 +13600,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13596,13 +13721,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13692,13 +13817,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13796,13 +13921,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13849,13 +13974,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13905,13 +14030,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13927,13 +14052,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14194,13 +14319,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14239,13 +14364,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14286,13 +14411,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14329,13 +14454,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14359,13 +14484,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14533,13 +14658,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14832,13 +14957,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14889,13 +15014,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14904,13 +15029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14941,13 +15066,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14957,13 +15082,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17062,13 +17187,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17249,13 +17374,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17611,13 +17736,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17658,13 +17783,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11829,13 +11954,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12224,13 +12349,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12383,13 +12508,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12488,13 +12613,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12571,7 +12696,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12587,13 +12712,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12735,13 +12860,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12812,13 +12937,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13279,13 +13404,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13399,13 +13524,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13447,13 +13572,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13484,13 +13609,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13510,13 +13635,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13631,13 +13756,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13727,13 +13852,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13831,13 +13956,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13884,13 +14009,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13940,13 +14065,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13962,13 +14087,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14229,13 +14354,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14274,13 +14399,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14321,13 +14446,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14364,13 +14489,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14394,13 +14519,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14568,13 +14693,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14867,13 +14992,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14924,13 +15049,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14939,13 +15064,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14976,13 +15101,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14992,13 +15117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17097,13 +17222,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17284,13 +17409,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17646,13 +17771,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17693,13 +17818,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11775,13 +11900,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12170,13 +12295,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12329,13 +12454,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12434,13 +12559,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12517,7 +12642,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12533,13 +12658,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12681,13 +12806,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12758,13 +12883,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13225,13 +13350,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13345,13 +13470,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13393,13 +13518,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13430,13 +13555,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13456,13 +13581,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13577,13 +13702,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13673,13 +13798,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13777,13 +13902,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13830,13 +13955,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13886,13 +14011,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13908,13 +14033,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14175,13 +14300,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14220,13 +14345,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14267,13 +14392,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14310,13 +14435,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14340,13 +14465,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14514,13 +14639,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14813,13 +14938,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14870,13 +14995,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14885,13 +15010,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14922,13 +15047,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14938,13 +15063,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17043,13 +17168,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17230,13 +17355,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17592,13 +17717,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17639,13 +17764,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11791,13 +11916,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12186,13 +12311,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12345,13 +12470,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12450,13 +12575,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12533,7 +12658,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12549,13 +12674,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12697,13 +12822,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12774,13 +12899,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13241,13 +13366,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13361,13 +13486,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13409,13 +13534,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13446,13 +13571,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13472,13 +13597,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13593,13 +13718,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13689,13 +13814,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13793,13 +13918,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13846,13 +13971,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13902,13 +14027,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13924,13 +14049,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14191,13 +14316,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14236,13 +14361,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14283,13 +14408,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14326,13 +14451,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14356,13 +14481,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14530,13 +14655,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14829,13 +14954,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14886,13 +15011,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14901,13 +15026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14938,13 +15063,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14954,13 +15079,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17059,13 +17184,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17246,13 +17371,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17608,13 +17733,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17655,13 +17780,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11788,13 +11913,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12183,13 +12308,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12342,13 +12467,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12447,13 +12572,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12530,7 +12655,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12546,13 +12671,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12694,13 +12819,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12771,13 +12896,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13238,13 +13363,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13358,13 +13483,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13406,13 +13531,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13443,13 +13568,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13469,13 +13594,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13590,13 +13715,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13686,13 +13811,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13790,13 +13915,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13843,13 +13968,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13899,13 +14024,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13921,13 +14046,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14188,13 +14313,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14233,13 +14358,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14280,13 +14405,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14323,13 +14448,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14353,13 +14478,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14527,13 +14652,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14826,13 +14951,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14883,13 +15008,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14898,13 +15023,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14935,13 +15060,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14951,13 +15076,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17056,13 +17181,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17243,13 +17368,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17605,13 +17730,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17652,13 +17777,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11798,13 +11923,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12193,13 +12318,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12352,13 +12477,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12457,13 +12582,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12540,7 +12665,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12556,13 +12681,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12704,13 +12829,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12781,13 +12906,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13248,13 +13373,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13368,13 +13493,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13416,13 +13541,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13453,13 +13578,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13479,13 +13604,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13600,13 +13725,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13696,13 +13821,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13800,13 +13925,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13853,13 +13978,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13909,13 +14034,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13931,13 +14056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14198,13 +14323,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14243,13 +14368,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14290,13 +14415,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14363,13 +14488,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14537,13 +14662,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14836,13 +14961,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14893,13 +15018,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14908,13 +15033,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14945,13 +15070,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14961,13 +15086,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17066,13 +17191,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17253,13 +17378,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17615,13 +17740,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17662,13 +17787,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11793,13 +11918,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12188,13 +12313,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12347,13 +12472,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12452,13 +12577,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12535,7 +12660,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12551,13 +12676,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12699,13 +12824,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12776,13 +12901,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13243,13 +13368,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13363,13 +13488,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13411,13 +13536,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13448,13 +13573,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13474,13 +13599,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13595,13 +13720,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13691,13 +13816,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13795,13 +13920,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13848,13 +13973,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13926,13 +14051,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14193,13 +14318,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14238,13 +14363,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14285,13 +14410,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14328,13 +14453,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14358,13 +14483,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14532,13 +14657,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14831,13 +14956,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14888,13 +15013,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14903,13 +15028,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14940,13 +15065,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14956,13 +15081,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17061,13 +17186,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17248,13 +17373,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17610,13 +17735,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17657,13 +17782,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11842,13 +11967,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12237,13 +12362,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12396,13 +12521,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12501,13 +12626,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12584,7 +12709,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12600,13 +12725,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12748,13 +12873,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12825,13 +12950,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13292,13 +13417,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13412,13 +13537,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13460,13 +13585,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13497,13 +13622,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13523,13 +13648,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13644,13 +13769,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13740,13 +13865,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13844,13 +13969,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13897,13 +14022,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13953,13 +14078,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13975,13 +14100,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14242,13 +14367,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14287,13 +14412,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14334,13 +14459,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14377,13 +14502,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14407,13 +14532,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14581,13 +14706,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14880,13 +15005,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14937,13 +15062,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14952,13 +15077,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14989,13 +15114,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -15005,13 +15130,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17110,13 +17235,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17297,13 +17422,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17659,13 +17784,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17706,13 +17831,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11770,13 +11895,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12165,13 +12290,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12324,13 +12449,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12429,13 +12554,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12512,7 +12637,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12528,13 +12653,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12676,13 +12801,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12753,13 +12878,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13220,13 +13345,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13340,13 +13465,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13388,13 +13513,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13425,13 +13550,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13451,13 +13576,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13572,13 +13697,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13668,13 +13793,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13772,13 +13897,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13825,13 +13950,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13881,13 +14006,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13903,13 +14028,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14170,13 +14295,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14215,13 +14340,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14262,13 +14387,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14305,13 +14430,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14335,13 +14460,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14509,13 +14634,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14808,13 +14933,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14865,13 +14990,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14880,13 +15005,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14917,13 +15042,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14933,13 +15058,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17038,13 +17163,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17225,13 +17350,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17587,13 +17712,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17634,13 +17759,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11794,13 +11919,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %29 = call %System.String addrspace(1)* %28(%System.Object addrspace(1)* %18)
   %30 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
@@ -11809,13 +11934,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %20
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 0
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %41 = call %System.String addrspace(1)* %40(%System.Object addrspace(1)* %30)
   %42 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
@@ -11824,13 +11949,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %44
 
 ; <label>:44                                      ; preds = %32
-  %45 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %43
+  %45 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %43, !invariant.load !0
   %46 = getelementptr inbounds i8, i8 addrspace(1)* %45, i32 64
   %47 = bitcast i8 addrspace(1)* %46 to i64 addrspace(1)*
-  %48 = load i64, i64 addrspace(1)* %47
+  %48 = load i64, i64 addrspace(1)* %47, !invariant.load !0
   %49 = add i64 %48, 0
   %50 = inttoptr i64 %49 to i64*
-  %51 = load i64, i64* %50
+  %51 = load i64, i64* %50, !invariant.load !0
   %52 = inttoptr i64 %51 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %53 = call %System.String addrspace(1)* %52(%System.Object addrspace(1)* %42)
   %54 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %41, %System.String addrspace(1)* %53)
@@ -13547,13 +13672,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
@@ -13942,13 +14067,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -14101,13 +14226,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -14206,13 +14331,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -14289,7 +14414,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -14305,13 +14430,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -14453,13 +14578,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -14530,13 +14655,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -14997,13 +15122,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -15117,13 +15242,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -15165,13 +15290,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -15202,13 +15327,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -15228,13 +15353,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -15349,13 +15474,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -15445,13 +15570,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -15549,13 +15674,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -15602,13 +15727,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -15658,13 +15783,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -15680,13 +15805,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -15947,13 +16072,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -15992,13 +16117,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -16039,13 +16164,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -16082,13 +16207,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -16112,13 +16237,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -16286,13 +16411,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -16408,13 +16533,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
   br label %21
@@ -17238,13 +17363,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17425,13 +17550,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17787,13 +17912,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11774,13 +11899,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12169,13 +12294,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12328,13 +12453,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12433,13 +12558,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12516,7 +12641,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12532,13 +12657,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12680,13 +12805,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12757,13 +12882,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13224,13 +13349,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13344,13 +13469,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13392,13 +13517,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13429,13 +13554,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13455,13 +13580,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13576,13 +13701,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13672,13 +13797,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13776,13 +13901,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13829,13 +13954,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13885,13 +14010,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13907,13 +14032,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14174,13 +14299,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14219,13 +14344,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14266,13 +14391,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14309,13 +14434,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14339,13 +14464,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14513,13 +14638,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14812,13 +14937,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14869,13 +14994,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14884,13 +15009,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14921,13 +15046,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14937,13 +15062,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17042,13 +17167,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17229,13 +17354,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17591,13 +17716,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17638,13 +17763,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11794,13 +11919,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12189,13 +12314,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12348,13 +12473,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12453,13 +12578,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12536,7 +12661,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12552,13 +12677,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12700,13 +12825,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12777,13 +12902,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13244,13 +13369,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13364,13 +13489,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13412,13 +13537,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13475,13 +13600,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13596,13 +13721,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13692,13 +13817,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13796,13 +13921,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13849,13 +13974,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13905,13 +14030,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13927,13 +14052,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14194,13 +14319,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14239,13 +14364,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14286,13 +14411,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14329,13 +14454,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14359,13 +14484,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14533,13 +14658,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14832,13 +14957,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14889,13 +15014,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14904,13 +15029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14941,13 +15066,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14957,13 +15082,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17062,13 +17187,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17249,13 +17374,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17611,13 +17736,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17658,13 +17783,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11829,13 +11954,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12224,13 +12349,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12383,13 +12508,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12488,13 +12613,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12571,7 +12696,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12587,13 +12712,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12735,13 +12860,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12812,13 +12937,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13279,13 +13404,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13399,13 +13524,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13447,13 +13572,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13484,13 +13609,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13510,13 +13635,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13631,13 +13756,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13727,13 +13852,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13831,13 +13956,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13884,13 +14009,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13940,13 +14065,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13962,13 +14087,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14229,13 +14354,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14274,13 +14399,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14321,13 +14446,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14364,13 +14489,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14394,13 +14519,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14568,13 +14693,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14867,13 +14992,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14924,13 +15049,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14939,13 +15064,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14976,13 +15101,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14992,13 +15117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17097,13 +17222,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17284,13 +17409,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17646,13 +17771,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17693,13 +17818,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11775,13 +11900,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12170,13 +12295,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12329,13 +12454,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12434,13 +12559,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12517,7 +12642,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12533,13 +12658,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12681,13 +12806,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12758,13 +12883,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13225,13 +13350,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13345,13 +13470,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13393,13 +13518,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13430,13 +13555,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13456,13 +13581,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13577,13 +13702,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13673,13 +13798,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13777,13 +13902,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13830,13 +13955,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13886,13 +14011,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13908,13 +14033,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14175,13 +14300,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14220,13 +14345,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14267,13 +14392,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14310,13 +14435,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14340,13 +14465,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14514,13 +14639,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14813,13 +14938,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14870,13 +14995,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14885,13 +15010,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14922,13 +15047,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14938,13 +15063,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17043,13 +17168,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17230,13 +17355,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17592,13 +17717,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17639,13 +17764,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11791,13 +11916,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12186,13 +12311,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12345,13 +12470,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12450,13 +12575,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12533,7 +12658,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12549,13 +12674,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12697,13 +12822,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12774,13 +12899,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13241,13 +13366,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13361,13 +13486,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13409,13 +13534,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13446,13 +13571,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13472,13 +13597,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13593,13 +13718,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13689,13 +13814,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13793,13 +13918,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13846,13 +13971,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13902,13 +14027,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13924,13 +14049,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14191,13 +14316,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14236,13 +14361,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14283,13 +14408,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14326,13 +14451,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14356,13 +14481,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14530,13 +14655,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14829,13 +14954,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14886,13 +15011,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14901,13 +15026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14938,13 +15063,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14954,13 +15079,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17059,13 +17184,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17246,13 +17371,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17608,13 +17733,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17655,13 +17780,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11788,13 +11913,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12183,13 +12308,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12342,13 +12467,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12447,13 +12572,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12530,7 +12655,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12546,13 +12671,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12694,13 +12819,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12771,13 +12896,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13238,13 +13363,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13358,13 +13483,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13406,13 +13531,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13443,13 +13568,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13469,13 +13594,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13590,13 +13715,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13686,13 +13811,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13790,13 +13915,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13843,13 +13968,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13899,13 +14024,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13921,13 +14046,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14188,13 +14313,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14233,13 +14358,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14280,13 +14405,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14323,13 +14448,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14353,13 +14478,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14527,13 +14652,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14826,13 +14951,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14883,13 +15008,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14898,13 +15023,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14935,13 +15060,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14951,13 +15076,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17056,13 +17181,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17243,13 +17368,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17605,13 +17730,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17652,13 +17777,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11798,13 +11923,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12193,13 +12318,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12352,13 +12477,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12457,13 +12582,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12540,7 +12665,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12556,13 +12681,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12704,13 +12829,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12781,13 +12906,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13248,13 +13373,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13368,13 +13493,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13416,13 +13541,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13453,13 +13578,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13479,13 +13604,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13600,13 +13725,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13696,13 +13821,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13800,13 +13925,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13853,13 +13978,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13909,13 +14034,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13931,13 +14056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14198,13 +14323,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14243,13 +14368,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14290,13 +14415,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14363,13 +14488,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14537,13 +14662,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14836,13 +14961,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14893,13 +15018,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14908,13 +15033,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14945,13 +15070,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14961,13 +15086,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17066,13 +17191,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17253,13 +17378,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17615,13 +17740,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17662,13 +17787,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11819,13 +11944,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
@@ -12214,13 +12339,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12373,13 +12498,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12478,13 +12603,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12561,7 +12686,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12577,13 +12702,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12725,13 +12850,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12802,13 +12927,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13269,13 +13394,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13437,13 +13562,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13474,13 +13599,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13500,13 +13625,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13621,13 +13746,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13717,13 +13842,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13821,13 +13946,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13874,13 +13999,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13930,13 +14055,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13952,13 +14077,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14219,13 +14344,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14264,13 +14389,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14311,13 +14436,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14354,13 +14479,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14384,13 +14509,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14558,13 +14683,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14857,13 +14982,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 32
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
   br label %21
@@ -14914,13 +15039,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14929,13 +15054,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14966,13 +15091,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
@@ -14982,13 +15107,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17087,13 +17212,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17274,13 +17399,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17636,13 +17761,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17683,13 +17808,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
@@ -17929,13 +18054,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
@@ -17981,13 +18106,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 40
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
   br label %21
@@ -18038,13 +18163,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 24
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -18053,13 +18178,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -18090,13 +18215,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
@@ -18106,13 +18231,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
@@ -17878,13 +18003,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -17930,13 +18055,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -17987,13 +18112,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -18002,13 +18127,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -18039,13 +18164,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -18055,13 +18180,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11823,13 +11948,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
@@ -12218,13 +12343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12377,13 +12502,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12482,13 +12607,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12565,7 +12690,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12581,13 +12706,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12729,13 +12854,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12806,13 +12931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13273,13 +13398,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13393,13 +13518,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13441,13 +13566,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13478,13 +13603,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13504,13 +13629,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13625,13 +13750,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13721,13 +13846,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13825,13 +13950,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13878,13 +14003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13934,13 +14059,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13956,13 +14081,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14223,13 +14348,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14268,13 +14393,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14315,13 +14440,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14358,13 +14483,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14388,13 +14513,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14562,13 +14687,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14861,13 +14986,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
   br label %21
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14933,13 +15058,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14970,13 +15095,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
@@ -14986,13 +15111,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17091,13 +17216,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17278,13 +17403,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17640,13 +17765,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17687,13 +17812,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11819,13 +11944,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
@@ -12214,13 +12339,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12373,13 +12498,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12478,13 +12603,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12561,7 +12686,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12577,13 +12702,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12725,13 +12850,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12802,13 +12927,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13269,13 +13394,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13437,13 +13562,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13474,13 +13599,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13500,13 +13625,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13621,13 +13746,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13717,13 +13842,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13821,13 +13946,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13874,13 +13999,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13930,13 +14055,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13952,13 +14077,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14219,13 +14344,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14264,13 +14389,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14311,13 +14436,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14354,13 +14479,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14384,13 +14509,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14558,13 +14683,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14857,13 +14982,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 32
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
   br label %21
@@ -14914,13 +15039,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14929,13 +15054,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14966,13 +15091,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
@@ -14982,13 +15107,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17087,13 +17212,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17274,13 +17399,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17636,13 +17761,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17683,13 +17808,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
@@ -17929,13 +18054,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
@@ -17981,13 +18106,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 40
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
   br label %21
@@ -18038,13 +18163,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 24
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -18053,13 +18178,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -18090,13 +18215,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
@@ -18106,13 +18231,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
@@ -17878,13 +18003,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -17930,13 +18055,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -17987,13 +18112,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -18002,13 +18127,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -18039,13 +18164,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -18055,13 +18180,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11758,13 +11883,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12153,13 +12278,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12312,13 +12437,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12417,13 +12542,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12500,7 +12625,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12516,13 +12641,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12664,13 +12789,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12741,13 +12866,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13208,13 +13333,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13328,13 +13453,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13376,13 +13501,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13413,13 +13538,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13439,13 +13564,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13560,13 +13685,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13656,13 +13781,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13760,13 +13885,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13813,13 +13938,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13869,13 +13994,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13891,13 +14016,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14158,13 +14283,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14203,13 +14328,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14250,13 +14375,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14293,13 +14418,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14323,13 +14448,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14497,13 +14622,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14796,13 +14921,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14853,13 +14978,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14868,13 +14993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14905,13 +15030,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14921,13 +15046,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17026,13 +17151,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17213,13 +17338,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17575,13 +17700,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17622,13 +17747,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11775,13 +11900,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12170,13 +12295,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12329,13 +12454,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12434,13 +12559,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12517,7 +12642,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12533,13 +12658,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12681,13 +12806,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12758,13 +12883,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13225,13 +13350,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13345,13 +13470,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13393,13 +13518,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13430,13 +13555,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13456,13 +13581,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13577,13 +13702,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13673,13 +13798,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13777,13 +13902,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13830,13 +13955,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13886,13 +14011,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13908,13 +14033,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14175,13 +14300,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14220,13 +14345,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14267,13 +14392,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14310,13 +14435,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14340,13 +14465,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14514,13 +14639,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14813,13 +14938,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14870,13 +14995,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14885,13 +15010,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14922,13 +15047,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14938,13 +15063,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17043,13 +17168,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17230,13 +17355,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17592,13 +17717,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17639,13 +17764,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11842,13 +11967,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12237,13 +12362,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12396,13 +12521,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12501,13 +12626,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12584,7 +12709,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12600,13 +12725,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12748,13 +12873,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12825,13 +12950,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13292,13 +13417,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13412,13 +13537,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13460,13 +13585,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13497,13 +13622,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13523,13 +13648,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13644,13 +13769,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13740,13 +13865,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13844,13 +13969,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13897,13 +14022,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13953,13 +14078,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13975,13 +14100,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14242,13 +14367,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14287,13 +14412,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14334,13 +14459,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14377,13 +14502,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14407,13 +14532,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14581,13 +14706,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14880,13 +15005,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14937,13 +15062,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14952,13 +15077,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14989,13 +15114,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -15005,13 +15130,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17110,13 +17235,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17297,13 +17422,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17659,13 +17784,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17706,13 +17831,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11760,13 +11885,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   ret void
@@ -12155,13 +12280,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12314,13 +12439,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12419,13 +12544,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12502,7 +12627,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12518,13 +12643,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12666,13 +12791,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12743,13 +12868,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13210,13 +13335,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13330,13 +13455,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13378,13 +13503,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13415,13 +13540,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13441,13 +13566,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13562,13 +13687,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13658,13 +13783,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13762,13 +13887,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13815,13 +13940,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13871,13 +13996,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13893,13 +14018,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14160,13 +14285,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14205,13 +14330,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14252,13 +14377,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14295,13 +14420,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14325,13 +14450,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14499,13 +14624,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14798,13 +14923,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, double %10)
   br label %21
@@ -14855,13 +14980,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14870,13 +14995,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14907,13 +15032,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
@@ -14923,13 +15048,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17028,13 +17153,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17215,13 +17340,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17577,13 +17702,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17624,13 +17749,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11770,13 +11895,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12165,13 +12290,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12324,13 +12449,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12429,13 +12554,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12512,7 +12637,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12528,13 +12653,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12676,13 +12801,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12753,13 +12878,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13220,13 +13345,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13340,13 +13465,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13388,13 +13513,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13425,13 +13550,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13451,13 +13576,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13572,13 +13697,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13668,13 +13793,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13772,13 +13897,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13825,13 +13950,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13881,13 +14006,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13903,13 +14028,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14170,13 +14295,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14215,13 +14340,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14262,13 +14387,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14305,13 +14430,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14335,13 +14460,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14509,13 +14634,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14808,13 +14933,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14865,13 +14990,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14880,13 +15005,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14917,13 +15042,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14933,13 +15058,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17038,13 +17163,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17225,13 +17350,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17587,13 +17712,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17634,13 +17759,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11758,13 +11883,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12153,13 +12278,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12312,13 +12437,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12417,13 +12542,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12500,7 +12625,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12516,13 +12641,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12664,13 +12789,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12741,13 +12866,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13208,13 +13333,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13328,13 +13453,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13376,13 +13501,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13413,13 +13538,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13439,13 +13564,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13560,13 +13685,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13656,13 +13781,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13760,13 +13885,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13813,13 +13938,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13869,13 +13994,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13891,13 +14016,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14158,13 +14283,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14203,13 +14328,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14250,13 +14375,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14293,13 +14418,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14323,13 +14448,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14497,13 +14622,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14796,13 +14921,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14853,13 +14978,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14868,13 +14993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14905,13 +15030,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14921,13 +15046,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17026,13 +17151,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17213,13 +17338,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17575,13 +17700,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17622,13 +17747,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
@@ -17892,13 +18017,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %29 = call %System.String addrspace(1)* %28(%System.Object addrspace(1)* %18)
   %30 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
@@ -17907,13 +18032,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %20
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 0
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %41 = call %System.String addrspace(1)* %40(%System.Object addrspace(1)* %30)
   %42 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
@@ -17922,13 +18047,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %44
 
 ; <label>:44                                      ; preds = %32
-  %45 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %43
+  %45 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %43, !invariant.load !0
   %46 = getelementptr inbounds i8, i8 addrspace(1)* %45, i32 64
   %47 = bitcast i8 addrspace(1)* %46 to i64 addrspace(1)*
-  %48 = load i64, i64 addrspace(1)* %47
+  %48 = load i64, i64 addrspace(1)* %47, !invariant.load !0
   %49 = add i64 %48, 0
   %50 = inttoptr i64 %49 to i64*
-  %51 = load i64, i64* %50
+  %51 = load i64, i64* %50, !invariant.load !0
   %52 = inttoptr i64 %51 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %53 = call %System.String addrspace(1)* %52(%System.Object addrspace(1)* %42)
   %54 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %29, %System.String addrspace(1)* %41, %System.String addrspace(1)* %53)
@@ -18145,13 +18270,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
@@ -18197,13 +18322,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
   br label %21

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11786,13 +11911,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12181,13 +12306,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12340,13 +12465,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12445,13 +12570,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12528,7 +12653,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12544,13 +12669,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12692,13 +12817,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12769,13 +12894,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13236,13 +13361,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13356,13 +13481,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13404,13 +13529,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13441,13 +13566,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13467,13 +13592,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13588,13 +13713,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13684,13 +13809,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13788,13 +13913,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13841,13 +13966,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13897,13 +14022,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13919,13 +14044,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14186,13 +14311,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14231,13 +14356,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14278,13 +14403,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14321,13 +14446,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14351,13 +14476,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14525,13 +14650,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14824,13 +14949,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14896,13 +15021,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14933,13 +15058,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14949,13 +15074,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17054,13 +17179,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17241,13 +17366,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17603,13 +17728,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17650,13 +17775,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11771,13 +11896,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12166,13 +12291,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12325,13 +12450,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12430,13 +12555,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12513,7 +12638,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12529,13 +12654,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12677,13 +12802,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12754,13 +12879,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13221,13 +13346,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13341,13 +13466,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13389,13 +13514,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13426,13 +13551,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13452,13 +13577,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13573,13 +13698,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13669,13 +13794,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13773,13 +13898,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13826,13 +13951,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13882,13 +14007,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13904,13 +14029,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14171,13 +14296,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14216,13 +14341,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14263,13 +14388,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14306,13 +14431,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14336,13 +14461,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14510,13 +14635,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14809,13 +14934,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14866,13 +14991,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14881,13 +15006,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14918,13 +15043,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14934,13 +15059,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17039,13 +17164,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17226,13 +17351,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17588,13 +17713,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17635,13 +17760,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11768,13 +11893,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12163,13 +12288,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12322,13 +12447,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12427,13 +12552,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12510,7 +12635,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12526,13 +12651,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12674,13 +12799,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12751,13 +12876,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13218,13 +13343,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13338,13 +13463,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13386,13 +13511,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13449,13 +13574,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13570,13 +13695,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13666,13 +13791,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13770,13 +13895,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13823,13 +13948,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13879,13 +14004,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13901,13 +14026,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14168,13 +14293,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14213,13 +14338,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14260,13 +14385,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14303,13 +14428,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14333,13 +14458,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14507,13 +14632,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14806,13 +14931,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14863,13 +14988,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14878,13 +15003,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14931,13 +15056,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17036,13 +17161,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17223,13 +17348,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17585,13 +17710,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17632,13 +17757,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11774,13 +11899,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   ret void
@@ -12169,13 +12294,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12328,13 +12453,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12433,13 +12558,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12516,7 +12641,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12532,13 +12657,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12680,13 +12805,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12757,13 +12882,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13224,13 +13349,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13344,13 +13469,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13392,13 +13517,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13429,13 +13554,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13455,13 +13580,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13576,13 +13701,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13672,13 +13797,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13776,13 +13901,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13829,13 +13954,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13885,13 +14010,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13907,13 +14032,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14174,13 +14299,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14219,13 +14344,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14266,13 +14391,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14309,13 +14434,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14339,13 +14464,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14513,13 +14638,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14812,13 +14937,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, float %10)
   br label %21
@@ -14869,13 +14994,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14884,13 +15009,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14921,13 +15046,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
@@ -14937,13 +15062,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17042,13 +17167,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17229,13 +17354,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17591,13 +17716,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17638,13 +17763,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11805,13 +11930,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
@@ -12200,13 +12325,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12359,13 +12484,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12464,13 +12589,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12547,7 +12672,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12563,13 +12688,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12711,13 +12836,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12788,13 +12913,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13255,13 +13380,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13375,13 +13500,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13423,13 +13548,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13460,13 +13585,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13486,13 +13611,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13607,13 +13732,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13703,13 +13828,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13807,13 +13932,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13860,13 +13985,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13916,13 +14041,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13938,13 +14063,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14205,13 +14330,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14250,13 +14375,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14297,13 +14422,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14340,13 +14465,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14370,13 +14495,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14544,13 +14669,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14843,13 +14968,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
   br label %21
@@ -14900,13 +15025,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14915,13 +15040,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -14952,13 +15077,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
@@ -14968,13 +15093,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17073,13 +17198,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17260,13 +17385,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17622,13 +17747,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17669,13 +17794,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -13457,13 +13582,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
@@ -13852,13 +13977,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -14011,13 +14136,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -14116,13 +14241,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -14199,7 +14324,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -14215,13 +14340,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -14363,13 +14488,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -14440,13 +14565,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -14907,13 +15032,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -15027,13 +15152,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -15075,13 +15200,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -15112,13 +15237,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -15138,13 +15263,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -15259,13 +15384,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -15355,13 +15480,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -15459,13 +15584,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -15512,13 +15637,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -15568,13 +15693,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -15590,13 +15715,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -15857,13 +15982,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -15902,13 +16027,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -15949,13 +16074,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -15992,13 +16117,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -16022,13 +16147,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -16196,13 +16321,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -16318,13 +16443,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
   br label %21
@@ -17148,13 +17273,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17335,13 +17460,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17697,13 +17822,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17761,13 +17886,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %11
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 64
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 0
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %23 = call %System.String addrspace(1)* %22(%System.Object addrspace(1)* %12)
   %24 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
@@ -17776,13 +17901,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %26
 
 ; <label>:26                                      ; preds = %14
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 0
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %35 = call %System.String addrspace(1)* %34(%System.Object addrspace(1)* %24)
   %36 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %23, %System.String addrspace(1)* %35)

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11854,13 +11979,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   ret void
@@ -12249,13 +12374,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12408,13 +12533,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12513,13 +12638,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12596,7 +12721,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12612,13 +12737,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12760,13 +12885,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12837,13 +12962,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13304,13 +13429,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13424,13 +13549,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13472,13 +13597,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13509,13 +13634,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13535,13 +13660,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13656,13 +13781,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13752,13 +13877,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13856,13 +13981,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13909,13 +14034,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13965,13 +14090,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13987,13 +14112,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14254,13 +14379,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14299,13 +14424,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14346,13 +14471,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14389,13 +14514,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14419,13 +14544,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14593,13 +14718,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14892,13 +15017,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 32
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i64 %10)
   br label %21
@@ -14949,13 +15074,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -14964,13 +15089,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -15001,13 +15126,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
@@ -15017,13 +15142,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17122,13 +17247,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17309,13 +17434,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17671,13 +17796,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17718,13 +17843,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
@@ -17976,13 +18101,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
@@ -18028,13 +18153,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
   br label %21
@@ -18085,13 +18210,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -18100,13 +18225,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -18137,13 +18262,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
@@ -18153,13 +18278,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -18252,13 +18377,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 24
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
@@ -18304,13 +18429,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 24
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
   br label %21
@@ -18361,13 +18486,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -18376,13 +18501,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -18413,13 +18538,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
@@ -18429,13 +18554,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11931,13 +12056,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 24
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
@@ -12326,13 +12451,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12485,13 +12610,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12590,13 +12715,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12673,7 +12798,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12689,13 +12814,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12837,13 +12962,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12914,13 +13039,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13381,13 +13506,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13501,13 +13626,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13549,13 +13674,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13586,13 +13711,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13612,13 +13737,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13733,13 +13858,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13829,13 +13954,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13933,13 +14058,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13986,13 +14111,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -14042,13 +14167,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -14064,13 +14189,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14331,13 +14456,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14376,13 +14501,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14423,13 +14548,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14466,13 +14591,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14496,13 +14621,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14670,13 +14795,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14969,13 +15094,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 24
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
   br label %21
@@ -15026,13 +15151,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -15041,13 +15166,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -15078,13 +15203,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
@@ -15094,13 +15219,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17199,13 +17324,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17386,13 +17511,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17748,13 +17873,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -17795,13 +17920,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void
@@ -18056,13 +18181,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
@@ -18108,13 +18233,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
   br label %21
@@ -18165,13 +18290,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -18180,13 +18305,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -18217,13 +18342,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
@@ -18233,13 +18358,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -12345,13 +12470,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   ret void
@@ -12740,13 +12865,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12899,13 +13024,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -13004,13 +13129,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -13087,7 +13212,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -13103,13 +13228,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -13251,13 +13376,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -13328,13 +13453,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13795,13 +13920,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13915,13 +14040,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13963,13 +14088,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -14000,13 +14125,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -14026,13 +14151,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -14147,13 +14272,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -14243,13 +14368,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -14347,13 +14472,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -14400,13 +14525,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -14456,13 +14581,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -14478,13 +14603,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14745,13 +14870,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14790,13 +14915,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14837,13 +14962,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14880,13 +15005,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14910,13 +15035,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -15084,13 +15209,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -15383,13 +15508,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, i32 %10)
   br label %21
@@ -15440,13 +15565,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
@@ -15455,13 +15580,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.IO.TextWriter addrspace(1)*)*
   call void %22(%System.IO.TextWriter addrspace(1)* %12)
   ret void
@@ -15492,13 +15617,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
@@ -15508,13 +15633,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %25(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %15)
   ret void
@@ -17613,13 +17738,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17800,13 +17925,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -18162,13 +18287,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)
@@ -18209,13 +18334,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to void (%System.IO.TextWriter addrspace(1)*, %"System.Char[]" addrspace(1)*)*
   call void %14(%System.IO.TextWriter addrspace(1)* %0, %"System.Char[]" addrspace(1)* %4)
   ret void

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -13406,13 +13531,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
@@ -13801,13 +13926,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -13960,13 +14085,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -14065,13 +14190,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -14148,7 +14273,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -14164,13 +14289,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -14312,13 +14437,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -14389,13 +14514,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -14856,13 +14981,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -14976,13 +15101,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -15024,13 +15149,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -15061,13 +15186,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -15087,13 +15212,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -15208,13 +15333,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -15304,13 +15429,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -15408,13 +15533,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -15461,13 +15586,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -15517,13 +15642,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -15539,13 +15664,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -15806,13 +15931,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -15851,13 +15976,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -15898,13 +16023,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -15941,13 +16066,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -15971,13 +16096,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -16145,13 +16270,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -16267,13 +16392,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
   br label %21
@@ -17097,13 +17222,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -17284,13 +17409,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -17646,13 +17771,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11756,13 +11881,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
@@ -12151,13 +12276,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12310,13 +12435,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12415,13 +12540,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12498,7 +12623,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12514,13 +12639,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12662,13 +12787,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12739,13 +12864,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13206,13 +13331,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13326,13 +13451,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13374,13 +13499,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13411,13 +13536,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13437,13 +13562,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13558,13 +13683,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13654,13 +13779,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13758,13 +13883,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13811,13 +13936,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13867,13 +13992,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13889,13 +14014,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14156,13 +14281,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14201,13 +14326,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14248,13 +14373,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14291,13 +14416,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14321,13 +14446,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14495,13 +14620,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14794,13 +14919,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
   br label %21
@@ -15624,13 +15749,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -15811,13 +15936,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -16173,13 +16298,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -2288,13 +2288,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26, !invariant.load !0
   %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
   %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
-  %31 = load i64, i64 addrspace(1)* %30
+  %31 = load i64, i64 addrspace(1)* %30, !invariant.load !0
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
-  %34 = load i64, i64* %33
+  %34 = load i64, i64* %33, !invariant.load !0
   %35 = inttoptr i64 %34 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2304,13 +2304,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39, !invariant.load !0
   %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
   %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
-  %44 = load i64, i64 addrspace(1)* %43
+  %44 = load i64, i64 addrspace(1)* %43, !invariant.load !0
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %47 = load i64, i64* %46, !invariant.load !0
   %48 = inttoptr i64 %47 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %49 = call i32 %48(%System.Globalization.CompareInfo addrspace(1)* %36, %System.String addrspace(1)* %37, %System.String addrspace(1)* %38, i32 0)
   ret i32 %49
@@ -2322,13 +2322,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52, !invariant.load !0
   %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
   %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
-  %57 = load i64, i64 addrspace(1)* %56
+  %57 = load i64, i64 addrspace(1)* %56, !invariant.load !0
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
-  %60 = load i64, i64* %59
+  %60 = load i64, i64* %59, !invariant.load !0
   %61 = inttoptr i64 %60 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2338,13 +2338,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %75 = call i32 %74(%System.Globalization.CompareInfo addrspace(1)* %62, %System.String addrspace(1)* %63, %System.String addrspace(1)* %64, i32 1)
   ret i32 %75
@@ -2356,13 +2356,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78, !invariant.load !0
   %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
   %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
-  %83 = load i64, i64 addrspace(1)* %82
+  %83 = load i64, i64 addrspace(1)* %82, !invariant.load !0
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
-  %86 = load i64, i64* %85
+  %86 = load i64, i64* %85, !invariant.load !0
   %87 = inttoptr i64 %86 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2372,13 +2372,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91, !invariant.load !0
   %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
   %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
-  %96 = load i64, i64 addrspace(1)* %95
+  %96 = load i64, i64 addrspace(1)* %95, !invariant.load !0
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
-  %99 = load i64, i64* %98
+  %99 = load i64, i64* %98, !invariant.load !0
   %100 = inttoptr i64 %99 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %101 = call i32 %100(%System.Globalization.CompareInfo addrspace(1)* %88, %System.String addrspace(1)* %89, %System.String addrspace(1)* %90, i32 0)
   ret i32 %101
@@ -2390,13 +2390,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104, !invariant.load !0
   %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
   %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
-  %109 = load i64, i64 addrspace(1)* %108
+  %109 = load i64, i64 addrspace(1)* %108, !invariant.load !0
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
-  %112 = load i64, i64* %111
+  %112 = load i64, i64* %111, !invariant.load !0
   %113 = inttoptr i64 %112 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -2406,13 +2406,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117, !invariant.load !0
   %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
   %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
-  %122 = load i64, i64 addrspace(1)* %121
+  %122 = load i64, i64 addrspace(1)* %121, !invariant.load !0
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
-  %125 = load i64, i64* %124
+  %125 = load i64, i64* %124, !invariant.load !0
   %126 = inttoptr i64 %125 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %127 = call i32 %126(%System.Globalization.CompareInfo addrspace(1)* %114, %System.String addrspace(1)* %115, %System.String addrspace(1)* %116, i32 1)
   ret i32 %127
@@ -2908,7 +2908,7 @@ ThrowNullRef10:                                   ; preds = %24
 }
 
 INFO:  jitting method List`1::set_Capacity using LLILCJit
-Failed to read List`1.set_Capacity[non-const derefAddress]
+Failed to read List`1.set_Capacity[callRuntimeHandleHelper]
 INFO:  jitting method AppDomainSetup::SetCompatibilitySwitches using LLILCJit
 Failed to read AppDomainSetup.SetCompatibilitySwitches[Leave: nontrivial finally invocation]
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
@@ -2956,13 +2956,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to %System.Type addrspace(1)* (%System.Type addrspace(1)*)*
   %24 = call %System.Type addrspace(1)* %23(%System.Type addrspace(1)* %13)
   %25 = call %System.RuntimeType addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.RuntimeType addrspace(1)* (i64, %System.Type addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Type addrspace(1)* %24)
@@ -2993,13 +2993,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = bitcast %System.RuntimeType addrspace(1)* %40 to %System.Type addrspace(1)*
   %51 = inttoptr i64 %49 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %52 = call i8 %51(%System.Type addrspace(1)* %39, %System.Type addrspace(1)* %50)
@@ -3038,13 +3038,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72, !invariant.load !0
   %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
   %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
-  %77 = load i64, i64 addrspace(1)* %76
+  %77 = load i64, i64 addrspace(1)* %76, !invariant.load !0
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
-  %80 = load i64, i64* %79
+  %80 = load i64, i64* %79, !invariant.load !0
   %81 = bitcast %System.RuntimeType addrspace(1)* %71 to %System.Type addrspace(1)*
   %82 = inttoptr i64 %80 to i8 (%System.Type addrspace(1)*)*
   %83 = call i8 %82(%System.Type addrspace(1)* %81)
@@ -3059,13 +3059,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88, !invariant.load !0
   %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
   %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
-  %93 = load i64, i64 addrspace(1)* %92
+  %93 = load i64, i64 addrspace(1)* %92, !invariant.load !0
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %96 = load i64, i64* %95, !invariant.load !0
   %97 = bitcast %System.RuntimeType addrspace(1)* %87 to %System.Type addrspace(1)*
   %98 = inttoptr i64 %96 to %"System.Type[]" addrspace(1)* (%System.Type addrspace(1)*)*
   %99 = call %"System.Type[]" addrspace(1)* %98(%System.Type addrspace(1)* %97)
@@ -3096,13 +3096,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112, !invariant.load !0
   %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
   %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
-  %117 = load i64, i64 addrspace(1)* %116
+  %117 = load i64, i64 addrspace(1)* %116, !invariant.load !0
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %120 = load i64, i64* %119, !invariant.load !0
   %121 = inttoptr i64 %120 to i8 (%System.Type addrspace(1)*, %System.Type addrspace(1)*)*
   %122 = call i8 %121(%System.Type addrspace(1)* %110, %System.Type addrspace(1)* %111)
   %123 = zext i8 %122 to i32
@@ -3751,13 +3751,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49, !invariant.load !0
   %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
   %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
-  %54 = load i64, i64 addrspace(1)* %53
+  %54 = load i64, i64 addrspace(1)* %53, !invariant.load !0
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %57 = load i64, i64* %56, !invariant.load !0
   %58 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to %System.Object addrspace(1)*
   %59 = inttoptr i64 %57 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %60 = call %System.String addrspace(1)* %59(%System.Object addrspace(1)* %58)
@@ -4406,9 +4406,9 @@ entry:
 INFO:  jitting method Dictionary`2::System.Collections.ICollection.get_SyncRoot using LLILCJit
 Failed to read Dictionary`2.System.Collections.ICollection.get_SyncRoot[Call HasTypeArg]
 INFO:  jitting method Dictionary`2::Insert using LLILCJit
-Failed to read Dictionary`2.Insert[non-const derefAddress]
+Failed to read Dictionary`2.Insert[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::Initialize using LLILCJit
-Failed to read Dictionary`2.Initialize[non-const derefAddress]
+Failed to read Dictionary`2.Initialize[callRuntimeHandleHelper]
 INFO:  jitting method HashHelpers::GetPrime using LLILCJit
 Successfully read HashHelpers.GetPrime
 
@@ -4568,13 +4568,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = bitcast %System.__Canon addrspace(1)* %6 to %System.Object addrspace(1)*
   %17 = inttoptr i64 %15 to i32 (%System.Object addrspace(1)*)*
   %18 = call i32 %17(%System.Object addrspace(1)* %16)
@@ -4739,13 +4739,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3, !invariant.load !0
   %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
   %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
-  %8 = load i64, i64 addrspace(1)* %7
+  %8 = load i64, i64 addrspace(1)* %7, !invariant.load !0
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %11 = load i64, i64* %10, !invariant.load !0
   %12 = inttoptr i64 %11 to %System.String addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %13 = call %System.String addrspace(1)* %12(%System.Globalization.CultureInfo addrspace(1)* %2)
   %14 = call i8 inttoptr (i64 NORMALIZED_ADDRESS to i8 (%System.String addrspace(1)*, %System.String addrspace(1)*)*)(%System.String addrspace(1)* %1, %System.String addrspace(1)* %13)
@@ -5244,13 +5244,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %14 = call %System.Globalization.CompareInfo addrspace(1)* %13(%System.Globalization.CultureInfo addrspace(1)* %3)
   %NullCheck1 = icmp eq %System.CultureAwareComparer addrspace(1)* %2, null
@@ -5342,13 +5342,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %29 = call %System.Globalization.CompareInfo addrspace(1)* %28(%System.Globalization.CultureInfo addrspace(1)* %18)
   br label %30
@@ -7401,13 +7401,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79, !invariant.load !0
   %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
   %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
-  %84 = load i64, i64 addrspace(1)* %83
+  %84 = load i64, i64 addrspace(1)* %83, !invariant.load !0
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
-  %87 = load i64, i64* %86
+  %87 = load i64, i64* %86, !invariant.load !0
   %88 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to %System.Object addrspace(1)*
   %89 = inttoptr i64 %87 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %90 = call %System.String addrspace(1)* %89(%System.Object addrspace(1)* %88)
@@ -7434,13 +7434,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101, !invariant.load !0
   %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
   %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
-  %106 = load i64, i64 addrspace(1)* %105
+  %106 = load i64, i64 addrspace(1)* %105, !invariant.load !0
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %109 = load i64, i64* %108, !invariant.load !0
   %110 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to %System.Object addrspace(1)*
   %111 = inttoptr i64 %109 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %112 = call %System.String addrspace(1)* %111(%System.Object addrspace(1)* %110)
@@ -7609,13 +7609,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to %System.Object addrspace(1)*
   %29 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %30 = call %System.String addrspace(1)* %29(%System.Object addrspace(1)* %28)
@@ -7831,13 +7831,13 @@ entry:
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28, !invariant.load !0
   %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
   %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
-  %33 = load i64, i64 addrspace(1)* %32
+  %33 = load i64, i64 addrspace(1)* %32, !invariant.load !0
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %36 = load i64, i64* %35, !invariant.load !0
   %37 = inttoptr i64 %36 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7847,13 +7847,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41, !invariant.load !0
   %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
   %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
-  %46 = load i64, i64 addrspace(1)* %45
+  %46 = load i64, i64 addrspace(1)* %45, !invariant.load !0
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
-  %49 = load i64, i64* %48
+  %49 = load i64, i64* %48, !invariant.load !0
   %50 = inttoptr i64 %49 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %51 = call i32 %50(%System.Globalization.CompareInfo addrspace(1)* %38, %System.String addrspace(1)* %39, %System.String addrspace(1)* %40, i32 0)
   %52 = icmp eq i32 %51, 0
@@ -7868,13 +7868,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7884,13 +7884,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %80 = call i32 %79(%System.Globalization.CompareInfo addrspace(1)* %67, %System.String addrspace(1)* %68, %System.String addrspace(1)* %69, i32 1)
   %81 = icmp eq i32 %80, 0
@@ -7905,13 +7905,13 @@ entry:
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86, !invariant.load !0
   %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
   %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
-  %91 = load i64, i64 addrspace(1)* %90
+  %91 = load i64, i64 addrspace(1)* %90, !invariant.load !0
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
-  %94 = load i64, i64* %93
+  %94 = load i64, i64* %93, !invariant.load !0
   %95 = inttoptr i64 %94 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7921,13 +7921,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = inttoptr i64 %107 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %109 = call i32 %108(%System.Globalization.CompareInfo addrspace(1)* %96, %System.String addrspace(1)* %97, %System.String addrspace(1)* %98, i32 0)
   %110 = icmp eq i32 %109, 0
@@ -7942,13 +7942,13 @@ entry:
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115, !invariant.load !0
   %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
   %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
-  %120 = load i64, i64 addrspace(1)* %119
+  %120 = load i64, i64 addrspace(1)* %119, !invariant.load !0
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
-  %123 = load i64, i64* %122
+  %123 = load i64, i64* %122, !invariant.load !0
   %124 = inttoptr i64 %123 to %System.Globalization.CompareInfo addrspace(1)* (%System.Globalization.CultureInfo addrspace(1)*)*
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
@@ -7958,13 +7958,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128, !invariant.load !0
   %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
   %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
-  %133 = load i64, i64 addrspace(1)* %132
+  %133 = load i64, i64 addrspace(1)* %132, !invariant.load !0
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
-  %136 = load i64, i64* %135
+  %136 = load i64, i64* %135, !invariant.load !0
   %137 = inttoptr i64 %136 to i32 (%System.Globalization.CompareInfo addrspace(1)*, %System.String addrspace(1)*, %System.String addrspace(1)*, i32)*
   %138 = call i32 %137(%System.Globalization.CompareInfo addrspace(1)* %125, %System.String addrspace(1)* %126, %System.String addrspace(1)* %127, i32 1)
   %139 = icmp eq i32 %138, 0
@@ -9583,7 +9583,7 @@ ThrowNullRef4:                                    ; preds = %17
 }
 
 INFO:  jitting method Dictionary`2::FindEntry using LLILCJit
-Failed to read Dictionary`2.FindEntry[non-const derefAddress]
+Failed to read Dictionary`2.FindEntry[callRuntimeHandleHelper]
 INFO:  jitting method Path::NormalizePath using LLILCJit
 Successfully read Path.NormalizePath
 
@@ -9634,7 +9634,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::Resize using LLILCJit
-Failed to read Dictionary`2.Resize[non-const derefAddress]
+Failed to read Dictionary`2.Resize[callRuntimeHandleHelper]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[publish secret param]
 INFO:  jitting method AppDomain::CreateAppDomainManager using LLILCJit
@@ -9797,7 +9797,7 @@ ThrowNullRef2:                                    ; preds = %19
 }
 
 INFO:  jitting method GenericEqualityComparer`1::Equals using LLILCJit
-Failed to read GenericEqualityComparer`1.Equals[non-const derefAddress]
+Failed to read GenericEqualityComparer`1.Equals[callRuntimeHandleHelper]
 INFO:  jitting method AppDomain::SetupBindingPaths using LLILCJit
 Successfully read AppDomain.SetupBindingPaths
 
@@ -10033,7 +10033,7 @@ entry:
 }
 
 INFO:  jitting method Dictionary`2::.ctor using LLILCJit
-Failed to read Dictionary`2..ctor[non-const derefAddress]
+Failed to read Dictionary`2..ctor[callRuntimeHandleHelper]
 INFO:  jitting method Dictionary`2::get_Count using LLILCJit
 Successfully read Dictionary`2.get_Count
 
@@ -10117,13 +10117,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = bitcast %System.String addrspace(1)* %16 to %System.Object addrspace(1)*
   %27 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %28 = call i32 %27(%System.Object addrspace(1)* %26)
@@ -11117,13 +11117,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12, !invariant.load !0
   %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
   %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
-  %17 = load i64, i64 addrspace(1)* %16
+  %17 = load i64, i64 addrspace(1)* %16, !invariant.load !0
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19
+  %20 = load i64, i64* %19, !invariant.load !0
   %21 = inttoptr i64 %20 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %22 = call %System.Security.PermissionSet addrspace(1)* %21(%System.Security.PermissionSet addrspace(1)* %11)
   %NullCheck5 = icmp eq %System.Security.Policy.PolicyStatement addrspace(1)* %10, null
@@ -11363,7 +11363,7 @@ entry:
   %87 = load %System.Security.Util.TokenBasedSet addrspace(1)*, %System.Security.Util.TokenBasedSet addrspace(1)* addrspace(1)* %86, align 8
   %88 = load i32, i32* %loc0
   %89 = load %System.Security.IPermission addrspace(1)*, %System.Security.IPermission addrspace(1)** %loc2
-  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %90 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck39 = icmp eq %System.Security.IPermission addrspace(1)* %89, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %91
 
@@ -11631,13 +11631,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to %System.Security.PermissionSet addrspace(1)* (%System.Security.PermissionSet addrspace(1)*)*
   %17 = call %System.Security.PermissionSet addrspace(1)* %16(%System.Security.PermissionSet addrspace(1)* %6)
   store %System.Security.PermissionSet addrspace(1)* %17, %System.Security.PermissionSet addrspace(1)** %loc1
@@ -11674,9 +11674,9 @@ ThrowNullRef2:                                    ; preds = %4
 INFO:  jitting method SecurityManager::GetSpecialFlags using LLILCJit
 Failed to read SecurityManager.GetSpecialFlags[storeElem]
 INFO:  jitting method List`1::.ctor using LLILCJit
-Failed to read List`1..ctor[non-const derefAddress]
+Failed to read List`1..ctor[callRuntimeHandleHelper]
 INFO:  jitting method List`1::AsReadOnly using LLILCJit
-Failed to read List`1.AsReadOnly[non-const derefAddress]
+Failed to read List`1.AsReadOnly[callRuntimeHandleHelper]
 INFO:  jitting method ReadOnlyCollection`1::.ctor using LLILCJit
 Successfully read ReadOnlyCollection`1..ctor
 
@@ -11720,7 +11720,132 @@ Failed to read AppDomain.SetupDomainSecurity[Return refany or value class]
 INFO:  jitting method DomainNeutralILStubClass::IL_STUB_PInvoke using LLILCJit
 Failed to read DomainNeutralILStubClass.IL_STUB_PInvoke[Struct parameter]
 INFO:  jitting method AppDomain::RunInitializer using LLILCJit
-Failed to read AppDomain.RunInitializer[non-const derefAddress]
+Successfully read AppDomain.RunInitializer
+
+define void @AppDomain.RunInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %arg0 = alloca %System.AppDomainSetup addrspace(1)*
+  %loc0 = alloca %"System.String[]" addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %arg0
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %0)
+  %3 = icmp eq %System.AppDomainInitializer addrspace(1)* %2, null
+  br i1 %3, label %34, label %4
+
+; <label>:4                                       ; preds = %1
+  store %"System.String[]" addrspace(1)* null, %"System.String[]" addrspace(1)** %loc0
+  %5 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck1 = icmp eq %System.AppDomainSetup addrspace(1)* %5, null
+  br i1 %NullCheck1, label %ThrowNullRef2, label %6
+
+; <label>:6                                       ; preds = %4
+  %7 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %5)
+  %8 = icmp eq %"System.String[]" addrspace(1)* %7, null
+  br i1 %8, label %17, label %9
+
+; <label>:9                                       ; preds = %6
+  %10 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck3 = icmp eq %System.AppDomainSetup addrspace(1)* %10, null
+  br i1 %NullCheck3, label %ThrowNullRef4, label %11
+
+; <label>:11                                      ; preds = %9
+  %12 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %10)
+  %NullCheck5 = icmp eq %"System.String[]" addrspace(1)* %12, null
+  br i1 %NullCheck5, label %ThrowNullRef6, label %13
+
+; <label>:13                                      ; preds = %11
+  %14 = bitcast %"System.String[]" addrspace(1)* %12 to %System.Array addrspace(1)*
+  %15 = call %System.Object addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Object addrspace(1)* (%System.Array addrspace(1)*)*)(%System.Array addrspace(1)* %14)
+  %16 = call %"System.String[]" addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %"System.String[]" addrspace(1)* (i64, %System.Object addrspace(1)*)*)(i64 NORMALIZED_ADDRESS, %System.Object addrspace(1)* %15)
+  store %"System.String[]" addrspace(1)* %16, %"System.String[]" addrspace(1)** %loc0
+  br label %17
+
+; <label>:17                                      ; preds = %6, %13
+  %18 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %arg0
+  %NullCheck7 = icmp eq %System.AppDomainSetup addrspace(1)* %18, null
+  br i1 %NullCheck7, label %ThrowNullRef8, label %19
+
+; <label>:19                                      ; preds = %17
+  %20 = call %System.AppDomainInitializer addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.AppDomainInitializer addrspace(1)* (%System.AppDomainSetup addrspace(1)*)*)(%System.AppDomainSetup addrspace(1)* %18)
+  %21 = load %"System.String[]" addrspace(1)*, %"System.String[]" addrspace(1)** %loc0
+  %22 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %23 = getelementptr inbounds i8, i8 addrspace(1)* %22, i32 8
+  %24 = bitcast i8 addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %24, null
+  br i1 %NullCheck9, label %ThrowNullRef10, label %25
+
+; <label>:25                                      ; preds = %19
+  %26 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %24
+  %27 = bitcast %System.AppDomainInitializer addrspace(1)* %20 to i8 addrspace(1)*
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 24
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %NullCheck11 = icmp eq i64 addrspace(1)* %29, null
+  br i1 %NullCheck11, label %ThrowNullRef12, label %30
+
+; <label>:30                                      ; preds = %25
+  %31 = load i64, i64 addrspace(1)* %29, !invariant.load !0
+  %32 = bitcast i8 addrspace(1)* %26 to %System.AppDomainInitializer addrspace(1)*
+  %33 = inttoptr i64 %31 to void (%System.AppDomainInitializer addrspace(1)*, %"System.String[]" addrspace(1)*)*
+  call void %33(%System.AppDomainInitializer addrspace(1)* %32, %"System.String[]" addrspace(1)* %21)
+  br label %34
+
+; <label>:34                                      ; preds = %1, %30
+  ret void
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef2:                                    ; preds = %4
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef4:                                    ; preds = %9
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef6:                                    ; preds = %11
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef8:                                    ; preds = %17
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef10:                                   ; preds = %19
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+
+ThrowNullRef12:                                   ; preds = %25
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
+INFO:  jitting method AppDomainSetup::get_AppDomainInitializer using LLILCJit
+Successfully read AppDomainSetup.get_AppDomainInitializer
+
+define %System.AppDomainInitializer addrspace(1)* @AppDomainSetup.get_AppDomainInitializer(%System.AppDomainSetup addrspace(1)* %param0) {
+entry:
+  %this = alloca %System.AppDomainSetup addrspace(1)*
+  store %System.AppDomainSetup addrspace(1)* %param0, %System.AppDomainSetup addrspace(1)** %this
+  %0 = load %System.AppDomainSetup addrspace(1)*, %System.AppDomainSetup addrspace(1)** %this
+  %NullCheck = icmp eq %System.AppDomainSetup addrspace(1)* %0, null
+  br i1 %NullCheck, label %ThrowNullRef, label %1
+
+; <label>:1                                       ; preds = %entry
+  %2 = getelementptr inbounds %System.AppDomainSetup, %System.AppDomainSetup addrspace(1)* %0, i32 0, i32 3
+  %3 = load %System.AppDomainInitializer addrspace(1)*, %System.AppDomainInitializer addrspace(1)* addrspace(1)* %2, align 8
+  ret %System.AppDomainInitializer addrspace(1)* %3
+
+ThrowNullRef:                                     ; preds = %entry
+  call void inttoptr (i64 NORMALIZED_ADDRESS to void ()*)() #0
+  unreachable
+}
+
 INFO:  jitting method PermissionSet::.ctor using LLILCJit
 Successfully read PermissionSet..ctor
 
@@ -11756,13 +11881,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, %System.String addrspace(1)* %1)
   ret void
@@ -12151,13 +12276,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7, !invariant.load !0
   %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
   %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
-  %12 = load i64, i64 addrspace(1)* %11
+  %12 = load i64, i64 addrspace(1)* %11, !invariant.load !0
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
-  %15 = load i64, i64* %14
+  %15 = load i64, i64* %14, !invariant.load !0
   %16 = inttoptr i64 %15 to void (%System.IO.StreamWriter addrspace(1)*, i8)*
   call void %16(%System.IO.StreamWriter addrspace(1)* %6, i8 1)
   br label %19
@@ -12310,13 +12435,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25, !invariant.load !0
   %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
   %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
-  %30 = load i64, i64 addrspace(1)* %29
+  %30 = load i64, i64 addrspace(1)* %29, !invariant.load !0
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %33 = load i64, i64* %32, !invariant.load !0
   %34 = inttoptr i64 %33 to %System.Text.Encoding addrspace(1)* (%System.Text.EncodingProvider addrspace(1)*, i32)*
   %35 = call %System.Text.Encoding addrspace(1)* %34(%System.Text.EncodingProvider addrspace(1)* %23, i32 %24)
   store %System.Text.Encoding addrspace(1)* %35, %System.Text.Encoding addrspace(1)** %loc2
@@ -12415,13 +12540,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2, !invariant.load !0
   %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
   %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
-  %7 = load i64, i64 addrspace(1)* %6
+  %7 = load i64, i64 addrspace(1)* %6, !invariant.load !0
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %10 = load i64, i64* %9, !invariant.load !0
   %11 = inttoptr i64 %10 to i32 (%System.Collections.Hashtable addrspace(1)*, %System.Object addrspace(1)*)*
   %12 = call i32 %11(%System.Collections.Hashtable addrspace(1)* %0, %System.Object addrspace(1)* %1)
   %13 = and i32 %12, 2147483647
@@ -12498,7 +12623,7 @@ entry:
   %8 = getelementptr inbounds %System.Collections.Hashtable, %System.Collections.Hashtable addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.Collections.IEqualityComparer addrspace(1)*, %System.Collections.IEqualityComparer addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*)
+  %11 = load i64, i64* inttoptr (i64 NORMALIZED_ADDRESS to i64*), !invariant.load !0
   %NullCheck3 = icmp eq %System.Collections.IEqualityComparer addrspace(1)* %9, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
@@ -12514,13 +12639,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17, !invariant.load !0
   %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
   %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
-  %22 = load i64, i64 addrspace(1)* %21
+  %22 = load i64, i64 addrspace(1)* %21, !invariant.load !0
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
-  %25 = load i64, i64* %24
+  %25 = load i64, i64* %24, !invariant.load !0
   %26 = inttoptr i64 %25 to i32 (%System.Object addrspace(1)*)*
   %27 = call i32 %26(%System.Object addrspace(1)* %16)
   ret i32 %27
@@ -12662,13 +12787,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22, !invariant.load !0
   %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
   %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
-  %27 = load i64, i64 addrspace(1)* %26
+  %27 = load i64, i64 addrspace(1)* %26, !invariant.load !0
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %30 = load i64, i64* %29, !invariant.load !0
   %31 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to %System.Text.Encoding addrspace(1)*
   %32 = inttoptr i64 %30 to void (%System.Text.Encoding addrspace(1)*)*
   call void %32(%System.Text.Encoding addrspace(1)* %31)
@@ -12739,13 +12864,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = inttoptr i64 %24 to void (%System.Text.Encoding addrspace(1)*)*
   call void %25(%System.Text.Encoding addrspace(1)* %15)
   ret void
@@ -13206,13 +13331,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19, !invariant.load !0
   %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
   %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
-  %24 = load i64, i64 addrspace(1)* %23
+  %24 = load i64, i64 addrspace(1)* %23, !invariant.load !0
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %27 = load i64, i64* %26, !invariant.load !0
   %28 = inttoptr i64 %27 to i8 (%System.IO.Stream addrspace(1)*)*
   %29 = call i8 %28(%System.IO.Stream addrspace(1)* %18)
   %30 = zext i8 %29 to i32
@@ -13326,13 +13451,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %23 = call %System.Text.Encoder addrspace(1)* %22(%System.Text.Encoding addrspace(1)* %12)
   %NullCheck7 = icmp eq %System.IO.StreamWriter addrspace(1)* %8, null
@@ -13374,13 +13499,13 @@ entry:
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42, !invariant.load !0
   %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
   %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
-  %47 = load i64, i64 addrspace(1)* %46
+  %47 = load i64, i64 addrspace(1)* %46, !invariant.load !0
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
-  %50 = load i64, i64* %49
+  %50 = load i64, i64* %49, !invariant.load !0
   %51 = inttoptr i64 %50 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %52 = call i32 %51(%System.Text.Encoding addrspace(1)* %40, i32 %41)
   %53 = sext i32 %52 to i64
@@ -13411,13 +13536,13 @@ entry:
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65, !invariant.load !0
   %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
   %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
-  %70 = load i64, i64 addrspace(1)* %69
+  %70 = load i64, i64 addrspace(1)* %69, !invariant.load !0
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
-  %73 = load i64, i64* %72
+  %73 = load i64, i64* %72, !invariant.load !0
   %74 = inttoptr i64 %73 to i8 (%System.IO.Stream addrspace(1)*)*
   %75 = call i8 %74(%System.IO.Stream addrspace(1)* %64)
   %76 = zext i8 %75 to i32
@@ -13437,13 +13562,13 @@ entry:
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83, !invariant.load !0
   %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
   %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
-  %88 = load i64, i64 addrspace(1)* %87
+  %88 = load i64, i64 addrspace(1)* %87, !invariant.load !0
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %91 = load i64, i64* %90, !invariant.load !0
   %92 = inttoptr i64 %91 to i64 (%System.IO.Stream addrspace(1)*)*
   %93 = call i64 %92(%System.IO.Stream addrspace(1)* %82)
   %94 = icmp sle i64 %93, 0
@@ -13558,13 +13683,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4, !invariant.load !0
   %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
   %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
-  %9 = load i64, i64 addrspace(1)* %8
+  %9 = load i64, i64 addrspace(1)* %8, !invariant.load !0
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %12 = load i64, i64* %11, !invariant.load !0
   %13 = inttoptr i64 %12 to %System.Text.Encoder addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %14 = call %System.Text.Encoder addrspace(1)* %13(%System.Text.Encoding addrspace(1)* %3)
   ret %System.Text.Encoder addrspace(1)* %14
@@ -13654,13 +13779,13 @@ entry:
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16, !invariant.load !0
   %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
   %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
-  %21 = load i64, i64 addrspace(1)* %20
+  %21 = load i64, i64 addrspace(1)* %20, !invariant.load !0
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %24 = load i64, i64* %23, !invariant.load !0
   %25 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to %System.Text.Encoder addrspace(1)*
   %26 = inttoptr i64 %24 to void (%System.Text.Encoder addrspace(1)*)*
   call void %26(%System.Text.Encoder addrspace(1)* %25)
@@ -13758,13 +13883,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13, !invariant.load !0
   %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
   %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
-  %18 = load i64, i64 addrspace(1)* %17
+  %18 = load i64, i64 addrspace(1)* %17, !invariant.load !0
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %21 = load i64, i64* %20, !invariant.load !0
   %22 = inttoptr i64 %21 to void (%System.Text.EncoderFallbackBuffer addrspace(1)*)*
   call void %22(%System.Text.EncoderFallbackBuffer addrspace(1)* %12)
   br label %23
@@ -13811,13 +13936,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5, !invariant.load !0
   %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
   %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
-  %10 = load i64, i64 addrspace(1)* %9
+  %10 = load i64, i64 addrspace(1)* %9, !invariant.load !0
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
-  %13 = load i64, i64* %12
+  %13 = load i64, i64* %12, !invariant.load !0
   %14 = inttoptr i64 %13 to i32 (%System.Text.Encoding addrspace(1)*, i32)*
   %15 = call i32 %14(%System.Text.Encoding addrspace(1)* %3, i32 %4)
   ret i32 %15
@@ -13867,13 +13992,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14, !invariant.load !0
   %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
   %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
-  %19 = load i64, i64 addrspace(1)* %18
+  %19 = load i64, i64 addrspace(1)* %18, !invariant.load !0
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %22 = load i64, i64* %21, !invariant.load !0
   %23 = inttoptr i64 %22 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %24 = call i32 %23(%System.Text.EncoderFallback addrspace(1)* %13)
   %25 = icmp sle i32 %24, 1
@@ -13889,13 +14014,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31, !invariant.load !0
   %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
   %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
-  %36 = load i64, i64 addrspace(1)* %35
+  %36 = load i64, i64 addrspace(1)* %35, !invariant.load !0
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
-  %39 = load i64, i64* %38
+  %39 = load i64, i64* %38, !invariant.load !0
   %40 = inttoptr i64 %39 to i32 (%System.Text.EncoderFallback addrspace(1)*)*
   %41 = call i32 %40(%System.Text.EncoderFallback addrspace(1)* %30)
   %42 = sext i32 %41 to i64
@@ -14156,13 +14281,13 @@ entry:
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40, !invariant.load !0
   %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
   %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
-  %45 = load i64, i64 addrspace(1)* %44
+  %45 = load i64, i64 addrspace(1)* %44, !invariant.load !0
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %48 = load i64, i64* %47, !invariant.load !0
   %49 = inttoptr i64 %48 to %"System.Byte[]" addrspace(1)* (%System.Text.Encoding addrspace(1)*)*
   %50 = call %"System.Byte[]" addrspace(1)* %49(%System.Text.Encoding addrspace(1)* %39)
   store %"System.Byte[]" addrspace(1)* %50, %"System.Byte[]" addrspace(1)** %loc0
@@ -14201,13 +14326,13 @@ entry:
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70, !invariant.load !0
   %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
   %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
-  %75 = load i64, i64 addrspace(1)* %74
+  %75 = load i64, i64 addrspace(1)* %74, !invariant.load !0
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
-  %78 = load i64, i64* %77
+  %78 = load i64, i64* %77, !invariant.load !0
   %79 = inttoptr i64 %78 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %79(%System.IO.Stream addrspace(1)* %62, %"System.Byte[]" addrspace(1)* %63, i32 0, i32 %69)
   br label %80
@@ -14248,13 +14373,13 @@ entry:
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99, !invariant.load !0
   %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
   %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
-  %104 = load i64, i64 addrspace(1)* %103
+  %104 = load i64, i64 addrspace(1)* %103, !invariant.load !0
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
-  %107 = load i64, i64* %106
+  %107 = load i64, i64* %106, !invariant.load !0
   %108 = trunc i32 %98 to i8
   %109 = inttoptr i64 %107 to i32 (%System.Text.Encoder addrspace(1)*, %"System.Char[]" addrspace(1)*, i32, i32, %"System.Byte[]" addrspace(1)*, i32, i8)*
   %110 = call i32 %109(%System.Text.Encoder addrspace(1)* %84, %"System.Char[]" addrspace(1)* %88, i32 0, i32 %92, %"System.Byte[]" addrspace(1)* %96, i32 0, i8 %108)
@@ -14291,13 +14416,13 @@ entry:
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126, !invariant.load !0
   %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
   %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
-  %131 = load i64, i64 addrspace(1)* %130
+  %131 = load i64, i64 addrspace(1)* %130, !invariant.load !0
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
-  %134 = load i64, i64* %133
+  %134 = load i64, i64* %133, !invariant.load !0
   %135 = inttoptr i64 %134 to void (%System.IO.Stream addrspace(1)*, %"System.Byte[]" addrspace(1)*, i32, i32)*
   call void %135(%System.IO.Stream addrspace(1)* %120, %"System.Byte[]" addrspace(1)* %124, i32 0, i32 %125)
   br label %136
@@ -14321,13 +14446,13 @@ entry:
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145, !invariant.load !0
   %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
   %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
-  %150 = load i64, i64 addrspace(1)* %149
+  %150 = load i64, i64 addrspace(1)* %149, !invariant.load !0
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
-  %153 = load i64, i64* %152
+  %153 = load i64, i64* %152, !invariant.load !0
   %154 = inttoptr i64 %153 to void (%System.IO.Stream addrspace(1)*)*
   call void %154(%System.IO.Stream addrspace(1)* %144)
   br label %155
@@ -14495,13 +14620,13 @@ entry:
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6, !invariant.load !0
   %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
   %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
-  %11 = load i64, i64 addrspace(1)* %10
+  %11 = load i64, i64 addrspace(1)* %10, !invariant.load !0
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
-  %14 = load i64, i64* %13
+  %14 = load i64, i64* %13, !invariant.load !0
   %15 = inttoptr i64 %14 to %System.IFormatProvider addrspace(1)* (%System.IO.TextWriter addrspace(1)*)*
   %16 = call %System.IFormatProvider addrspace(1)* %15(%System.IO.TextWriter addrspace(1)* %5)
   %17 = bitcast %System.IO.SyncTextWriter addrspace(1)* %4 to %System.IO.TextWriter addrspace(1)*
@@ -14794,13 +14919,13 @@ entry:
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11, !invariant.load !0
   %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
   %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
-  %16 = load i64, i64 addrspace(1)* %15
+  %16 = load i64, i64 addrspace(1)* %15, !invariant.load !0
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %19 = load i64, i64* %18, !invariant.load !0
   %20 = inttoptr i64 %19 to void (%System.IO.TextWriter addrspace(1)*, %System.String addrspace(1)*)*
   call void %20(%System.IO.TextWriter addrspace(1)* %9, %System.String addrspace(1)* %10)
   br label %21
@@ -15624,13 +15749,13 @@ entry:
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153, !invariant.load !0
   %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
   %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
-  %158 = load i64, i64 addrspace(1)* %157
+  %158 = load i64, i64 addrspace(1)* %157, !invariant.load !0
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
-  %161 = load i64, i64* %160
+  %161 = load i64, i64* %160, !invariant.load !0
   %162 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to %System.Text.Encoder addrspace(1)*
   %163 = inttoptr i64 %143 to i16*
   %164 = inttoptr i64 %149 to i8*
@@ -15811,13 +15936,13 @@ entry:
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57, !invariant.load !0
   %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
   %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
-  %62 = load i64, i64 addrspace(1)* %61
+  %62 = load i64, i64 addrspace(1)* %61, !invariant.load !0
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
-  %65 = load i64, i64* %64
+  %65 = load i64, i64* %64, !invariant.load !0
   %66 = inttoptr i64 %65 to i32 (%System.Text.Encoding addrspace(1)*, i16*, i32, i8*, i32, %System.Text.EncoderNLS addrspace(1)*)*
   %67 = call i32 %66(%System.Text.Encoding addrspace(1)* %51, i16* %52, i32 %53, i8* %54, i32 %55, %System.Text.EncoderNLS addrspace(1)* %56)
   ret i32 %67
@@ -16173,13 +16298,13 @@ entry:
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1, !invariant.load !0
   %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
   %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
-  %6 = load i64, i64 addrspace(1)* %5
+  %6 = load i64, i64 addrspace(1)* %5, !invariant.load !0
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %9 = load i64, i64* %8, !invariant.load !0
   %10 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to %System.IO.Stream addrspace(1)*
   %11 = inttoptr i64 %9 to i8 (%System.IO.Stream addrspace(1)*)*
   %12 = call i8 %11(%System.IO.Stream addrspace(1)* %10)


### PR DESCRIPTION
Remove the exclusion for non-const loads.
Annotate const loads with the !invariant.load annotation.

Closes #257 

Of the 10 [non-const derefAddress] rejections currently in each bring-up test, 9 change to [callRuntimeHandleHelper] and 1 succeeds.

I'll wait until #306 goes in to merge this since it depends on that.
