### PR TITLE
Add parentheses to print statement

### DIFF
--- a/utils/ccformat.py
+++ b/utils/ccformat.py
@@ -164,9 +164,9 @@ def runFormat(args):
         "-p1", formatFix]), shell=True, stdout=subprocess.PIPE)
 
     output,error = proc.communicate()
-    if output != "":
+    if output.decode('utf-8') != "":
       if args.print_diffs:
-        sys.stdout.write(output)
+        sys.stdout.write(output.decode('utf-8'))
       returncode = -1
 
   if returncode == -1:


### PR DESCRIPTION
In Python 3._, print is a function call. This change adds parentheses
around the string to fix the syntax error for 3._
