### PR TITLE
Make ccformat --formatall compatible with Python 3

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -835,7 +835,7 @@ public:
   FlowGraphNode *CurrentFgNode;
 
   /// True if this method contains the 'localloc' MSIL opcode.
-  bool HasLocAlloc;                          
+  bool HasLocAlloc;
 
   /// True if the client has optimistically transformed tail.
   /// recursion into a branch.

--- a/utils/ccformat.py
+++ b/utils/ccformat.py
@@ -135,16 +135,17 @@ def runFormat(args):
           if not args.fix:
             with open(filepath) as f:
               code = f.read().splitlines()
-            formatted_code = io.StringIO(output).read().splitlines()
+            formatted_code = io.StringIO(output.decode('utf-8')).read().splitlines()
             diff = difflib.unified_diff(code, formatted_code,
                                         filepath, filepath,
                                         '(before formatting)', '(after formatting)')
-            diff_string = string.join(diff, '\n')
+            diff_string = "\n".join(x for x in diff)
             if len(diff_string) > 0:
               # If there was a diff, print out the file name.
               print(filepath)
               if args.print_diffs:
                 sys.stdout.write(diff_string)
+                sys.stdout.write("\n")
               returncode = -1
   else:
     noindex = ""
@@ -167,6 +168,7 @@ def runFormat(args):
     if output.decode('utf-8') != "":
       if args.print_diffs:
         sys.stdout.write(output.decode('utf-8'))
+        sys.stdout.write("\n")
       returncode = -1
 
   if returncode == -1:


### PR DESCRIPTION
Format all was incompatible with Python 3 because proc.communicate()
returns bytes. This change fixes formatall so that we are compatible
with python 3. This change also makes the join call in formatall
compatible with Python 3 and prints a new line at the end of diffs for
diff reability.

This change also fixes a formatting error that was checked in in
reader.h
