### PR TITLE
Fix broken links in README.md.  Issue #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ Contributions
 
 LLILC is just starting up.  Only a few tests are working and there are lots
 of places where we need help.  Please see our [issues](https://github.com/dotnet/llilc/issues)
-or the [contributing page](https://github.com/dotnet/llilc/wiki/Contributing)
+or the [contributing page](https://github.com/dotnet/llilc/wiki/Areas-To-Contribute)
 for how to pitch in.


### PR DESCRIPTION
Fix two broken links in README.md; one to the LINUX/MAC quickstart; the other to the 'Contributing Page'.
