### PR TITLE
Implement GenIR::callRuntimeHandleHelper.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2318,8 +2318,7 @@ public:
   virtual void endFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrentOffset) = 0;
 
   // Used to maintain operand stack.
-  virtual void maintainOperandStack(IRNode **Opr1, IRNode **Opr2,
-                                    FlowGraphNode *CurrentBlock) = 0;
+  virtual void maintainOperandStack(FlowGraphNode *CurrentBlock) = 0;
   virtual void assignToSuccessorStackNode(FlowGraphNode *, IRNode *Destination,
                                           IRNode *Source, bool *) = 0;
   virtual bool typesCompatible(IRNode *Src1, IRNode *Src2) = 0;

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -6457,7 +6457,7 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
       Arg1 = ReaderOperandStack->pop();
 
       if (!ReaderOperandStack->empty()) {
-        maintainOperandStack(&Arg1, &Arg2, Fg);
+        maintainOperandStack(Fg);
         ReaderOperandStack->clearStack();
       }
 
@@ -6484,7 +6484,7 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
 
       Arg1 = ReaderOperandStack->pop();
       if (!ReaderOperandStack->empty()) {
-        maintainOperandStack(&Arg1, nullptr, Fg);
+        maintainOperandStack(Fg);
         ReaderOperandStack->clearStack();
       }
       boolBranch((ReaderBaseNS::BoolBranchOpcode)MappedValue, Arg1);
@@ -6508,7 +6508,7 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
       // Assumes first pass created branch label, here we just assist
       // any live stack operands across the block boundary.
       if (!ReaderOperandStack->empty()) {
-        maintainOperandStack(nullptr, nullptr, Fg);
+        maintainOperandStack(Fg);
         ReaderOperandStack->clearStack();
       }
       branch();
@@ -7499,7 +7499,7 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
         // If the operand stack is non-empty then it must be ushered
         // across the block boundaries.
         if (!ReaderOperandStack->empty()) {
-          maintainOperandStack(nullptr, nullptr, Fg);
+          maintainOperandStack(Fg);
         }
       } else {
         // consume the operand
@@ -7736,7 +7736,7 @@ void ReaderBase::readBytesForFlowGraphNode(FlowGraphNode *Fg,
     // successor edges to be cut, so live operand stack has nowhere
     // to be propagated to.
     if (!(TheParam.LocalFault || ReaderOperandStack->empty())) {
-      maintainOperandStack(nullptr, nullptr, Fg);
+      maintainOperandStack(Fg);
     }
   }
 }


### PR DESCRIPTION
GenIR::callRuntimeHandleHelper needs to insert a conditional helper call:

 x = NullCheckArg;
 if (NullCheckArg == nullptr) {
   x = callhelper(Arg1, Arg2);
 }
 return x;

To implement that I generalized genConditionalThrow into genConditionalHelperCall. This complicated stack maintenance code since ContinueBlock has edges from the old block and the block containing the call instruction. To deal with that I added NoOperandStackBlocks set to GenIR and inserted all such call blocks there. These blocks have no msil and don't need to use or propagate operand stacks.

Remove unused parameters from maintainOperandStack.

Factor createPhiNode that works for inserting PHI into blocks that may or may not have terminators.

The number of successfully compiled methods didn't change.

Closes #310.
