### PR TITLE
Add additional detail to CheckDiff output

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -1084,6 +1084,7 @@ function Global:CheckDiff
     $TotalCount = 0
     $DiffCount = 0
     $NewlyFailedMethods = 0
+    $NewlyPassedMethods = 0
     Get-ChildItem -recurse -path $LLILCTestResult\$Diff | Where {$_.FullName -match "error.txt"} | `
     Foreach-Object {
       $TotalCount = $TotalCount + 1
@@ -1101,6 +1102,9 @@ function Global:CheckDiff
         if ($SummaryLine -match 'Successfully(.*)(<=)') {
           $NewlyFailedMethods++
         }
+        if ($SummaryLine -match 'Successfully(.*)(=>)') {
+          $NewlyPassedMethods++
+        }
       }
     }
 
@@ -1112,11 +1116,13 @@ function Global:CheckDiff
       Write-Host ("$DiffCount out of $TotalCount have diff.")
       if ($NewlyFailedMethods -eq 0) {
         Write-Host ("All previously successfully jitted methods passed jitting with diff jit.")
-        Write-Host ("More methods passed jitting in diff jit than in base jit.")
       }
       else {
         Write-Host ("$NewlyFailedMethods methods successfully jitted by base jit now FAILED in diff jit.")
       }
+      
+      Write-Host ("$NewlyPassedMethods methods now successfully jitted in diff jit.")
+      
       if ($UseDiffTool) {
         & sgdm -t1=Base -t2=Diff $LLILCTestResult\Compare\$Base $LLILCTestResult\Compare\$Diff
       }


### PR DESCRIPTION
When we have newly passing methods jitted by the new jit, we should call
out how many new methods we jit. This change updates LLILCEnv to count
the number of newly successfully jitted methods, and outputs the number
for the developer. We output the number of newly jitted methods when
there are no new failing methods and when there are newly failed methods
so the developer has all the information about their change.
