### PR TITLE
Ensure generic context is kept alive

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -179,7 +179,7 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
     Builder.setOptLevel(CodeGenOpt::Level::Default);
   } else {
     Builder.setOptLevel(CodeGenOpt::Level::None);
-    Options.NoFramePointerElim = 1;
+    Options.NoFramePointerElim = true;
   }
 
   Builder.setTargetOptions(Options);

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -4356,10 +4356,11 @@ ReaderBase::rdrGetStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
       //
       // Again, we happen to know that the results of these helper calls should
       // be interpreted as interior GC pointers.
-      SharedStaticsBaseNode = makePtrNode(Reader_PtrGcInterior);
+      IRNode *TempNode = makePtrNode(Reader_PtrGcInterior);
 
       // Now make the call and attach the arguments.
-      callHelper(FieldInfo->helper, SharedStaticsBaseNode, ClassHandleNode);
+      SharedStaticsBaseNode =
+          callHelper(FieldInfo->helper, TempNode, ClassHandleNode);
     } else {
       CorInfoHelpFunc HelperId = FieldInfo->helper;
       CORINFO_CLASS_HANDLE Class = ResolvedToken->hClass;


### PR DESCRIPTION
Implement support for actually keeping the generic context alive. This gets us the next part of #40.

Use `llvm.frameescape` to indicate that the context-bearing local's address has escaped. This intrinsic requires that the function have a frame pointer, so disable FPO for these methods.

We're still missing the ability to report the context back to the EE via the GC info.Opened #336 for finishing this bit of the work and will link it to the TODO when this PR is in.

Fixed a bug in the static field address computation where we weren't capturing the updated helper call result.

Fixed a bug in PHI placement. Joseph is likely going to put in a similar fix so I'll update this PR when his stuff is merged in.

This unblocks 6 methods per test with no category shuffles. Overall results vs master are:129 tests, 36144 methods, 28969 good, 7175 bad (80% good)
