### PR TITLE
Implement overflow forms of binary arithmetic

### DIFF
--- a/Documentation/llilc-jit-eh.md
+++ b/Documentation/llilc-jit-eh.md
@@ -530,7 +530,7 @@ In summary, the plan/status is:
    - [ ] Implicit exceptions expanded to explicit test/throw sequences
      - [x] Null dereference
      - [ ] Divide by zero
-     - [ ] Arithmetic overflow
+     - [x] Arithmetic overflow
      - [ ] Convert with overflow
      - [x] Array bounds checks
      - [x] Array store checks


### PR DESCRIPTION
Implement overflow forms of binary arithmetic

Map these to the appropriate LLVM intrinsics that detect overflow and compute results together.

Also annotate the invalid type/opcode combinations in the operator map (floats don't have bitwise operations or unsigned or overflow variants).

Closes #65

The two methods in each bring-up test currently failing on binary op overflow now fail on localAlloc instead.
