### PR TITLE
Remove mutually exclusive group

### DIFF
--- a/utils/ccformat.py
+++ b/utils/ccformat.py
@@ -191,7 +191,6 @@ def main(argv):
   parser.add_argument("--checks", default="llvm*,misc*,microsoft*,"\
                       "-llvm-header-guard,-llvm-include-order",
             help="clang-tidy checks to run")
-  group = parser.add_mutually_exclusive_group()
   parser.add_argument("--hide-diffs", action="store_true", default=False,
             help="Don't print formatting diffs (when not automatically fixed)")
   args,unknown = parser.parse_known_args(argv)


### PR DESCRIPTION
The line to add a mutually exclusive group caused ccformat to fail when
passing --help. That line was for when we passed base and noindex, which
were mutually exclusive and needs to be removed.
