### PR TITLE
Support VSD calls and methods with a secret parameter.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -281,6 +281,7 @@ enum ReaderSpecialSymbolType {
   Reader_UnmodifiedThisPtr,    ///< This pointer param passed to method
   Reader_VarArgsToken,         ///< Special param for varargs support
   Reader_InstParam,            ///< Special param for shared generics
+  Reader_SecretParam,          ///< Special param for IL stubs
   Reader_SecurityObject,       ///< Local used for security checking
   Reader_GenericsContext       ///< Local holding shared generics context
 };
@@ -963,26 +964,34 @@ public:
   /// direct client processing for the method parameters and the local
   /// variables of the method.
   ///
-  /// \params NumParams   Number of parameters to the method. Note this may
-  ///                     include implicit parameters like the this pointer.
-  /// \params NumAutos    Number of locals described in the local signature.
-  void initParamsAndAutos(uint32_t NumParam, uint32_t NumAuto);
+  /// \param NumParams           Number of parameters to the method. Note this
+  ///                            includes implicit parameters like the this
+  ///                            pointer.
+  /// \param NumAutos            Number of locals described in the local
+  ///                            signature.
+  /// \param HasSecretParameter  Indicates whether or not the terminal parameter
+  ///                            is the secret parameter of an IL stub.
+  void initParamsAndAutos(uint32_t NumParam, uint32_t NumAuto,
+                          bool HasSecretParameter);
 
   /// \brief Set up parameters
   ///
   /// Uses the method signature and information from the EE to direct the
   /// client to set up processing for method parameters.
   ///
-  /// \params NumParams   Number of parameters to the method. Note this may
-  ///                     include implicit parameters like the this pointer.
-  void buildUpParams(uint32_t NumParams);
+  /// \param NumParams           Number of parameters to the method. Note this
+  ///                            includes implicit parameters like the this
+  ///                            pointer.
+  /// \param HasSecretParameter  Indicates whether or not the terminal parameter
+  ///                            is the secret parameter of an IL stub.
+  void buildUpParams(uint32_t NumParams, bool HasSecretParameter);
 
   /// \brief Set up locals (autos)
   ///
   /// Uses the local signature to direct the client to set up processing
   /// for local variables in the method.
   ///
-  /// \params NumAutos   Number of locals described in the signature.
+  /// \param NumAutos   Number of locals described in the signature.
   void buildUpAutos(uint32_t NumAutos);
 
   /// \brief Process the next element (argument or local) in a signature
@@ -991,7 +1000,7 @@ public:
   /// through a signature and obtain more detailed information about each
   /// element.
   ///
-  /// \params ArgListHandle  Handle for the current element of the signature
+  /// \param ArgListHandle   Handle for the current element of the signature
   /// \param Sig             The signature being iterated over.
   /// \param CorType [out]   Optional; the CorInfoType of the current element.
   /// \param Class [out]     Optional; the class handle of the current element.
@@ -2514,8 +2523,8 @@ public:
             ReaderSpecialSymbolType Type = Reader_NotSpecialSymbol) = 0;
 
   virtual IRNode *derefAddress(IRNode *Address, bool DestIsGCPtr, bool IsConst,
-
                                bool AddressMayBeNull = true) = 0;
+
   IRNode *derefAddressNonNull(IRNode *Address, bool DestIsGCPtr, bool IsConst) {
     return derefAddress(Address, DestIsGCPtr, IsConst, false);
   }

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -279,9 +279,7 @@ public:
   IRNode *argList() override;
   IRNode *instParam() override;
 
-  IRNode *secretParam() override {
-    throw NotYetImplementedException("secretParam");
-  };
+  IRNode *secretParam() override;
   IRNode *thisObj() override;
 
   void boolBranch(ReaderBaseNS::BoolBranchOpcode Opcode, IRNode *Arg1) override;
@@ -805,8 +803,11 @@ public:
   // newobj
   bool canonNewObjCall(IRNode *CallNode, ReaderCallTargetData *CallTargetData,
                        IRNode **OutResult);
-  void canonNewArrayCall(IRNode *CallNode, ReaderCallTargetData *CallTargetData,
-                         IRNode **OutResult);
+  IRNode *canonNewArrayCall(IRNode *CallNode,
+                            ReaderCallTargetData *CallTargetData);
+
+  // stubs
+  IRNode *canonStubCall(IRNode *CallNode, ReaderCallTargetData *CallTargetData);
 #endif
 
   // Used to expand multidimensional array access intrinsics
@@ -837,11 +838,14 @@ private:
   llvm::Type *getType(CorInfoType Type, CORINFO_CLASS_HANDLE ClassHandle,
                       bool GetRefClassFields = true);
 
-  llvm::Function *getFunction(CORINFO_METHOD_HANDLE Method);
+  llvm::Function *getFunction(CORINFO_METHOD_HANDLE Method,
+                              bool HasSecretParameter);
 
-  llvm::FunctionType *getFunctionType(CORINFO_METHOD_HANDLE Method);
+  llvm::FunctionType *getFunctionType(CORINFO_METHOD_HANDLE Method,
+                                      bool HasSecretParameter = false);
   llvm::FunctionType *getFunctionType(CORINFO_SIG_INFO &Sig,
-                                      CORINFO_CLASS_HANDLE ThisClass);
+                                      CORINFO_CLASS_HANDLE ThisClass,
+                                      bool HasSecretParameter = false);
 
   llvm::Type *getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
                            bool GetRefClassFields);
@@ -1101,6 +1105,7 @@ private:
   bool HasThis;
   bool HasTypeParameter;
   bool HasVarargsToken;
+  bool HasSecretParameter;
   bool KeepGenericContextAlive;
   llvm::BasicBlock *EntryBlock;
   llvm::Instruction *TempInsertionPoint;


### PR DESCRIPTION
- For VSD calls, pass the indirection cell as the first parameter and
  set the calling convention to CLR_VirtualDispatchStub, which will pass
  the first parameter in the appropriate register (EAX/R11 on X86/AMD64,
  respectively).
- For methods with a secret parameter, add a synthetic parameter to the
  end of the argument list and mark it with the "CLR_SecretParameter"
  attribute, which will be placed in the appropraite register (EAX/R10
  on X86/AMD64, respectively).
