### PR TITLE
Make CMake 2.8.12 default version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # If we are not building as a part of LLVM, build LLILCJit as an
 # standalone project, using LLVM as an external library:
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
-  cmake_minimum_required(VERSION 2.8.8)
+  cmake_minimum_required(VERSION 2.8.12)
 
   project(LLILC)
   if( APPLE )

--- a/lib/Jit/CMakeLists.txt
+++ b/lib/Jit/CMakeLists.txt
@@ -60,6 +60,6 @@ add_dependencies(llilcjit LLILCReader)
 
 target_link_libraries(
   llilcjit
-  ${cmake_2_8_12_PRIVATE}
+  PRIVATE
   ${LLILCJIT_LINK_LIBRARIES}
   )


### PR DESCRIPTION
LLVM changed to make CMake 2.8.12 to be the default, so we need to
follow suit.
