### PR TITLE
Implement .ovf forms of conv instruction

### DIFF
--- a/Documentation/llilc-jit-eh.md
+++ b/Documentation/llilc-jit-eh.md
@@ -531,7 +531,7 @@ In summary, the plan/status is:
      - [x] Null dereference
      - [ ] Divide by zero
      - [x] Arithmetic overflow
-     - [ ] Convert with overflow
+     - [x] Convert with overflow
      - [x] Array bounds checks
      - [x] Array store checks
  2. [ ] Handler bring-up in EH branch

--- a/Documentation/llilc-reader.md
+++ b/Documentation/llilc-reader.md
@@ -190,6 +190,8 @@ The instructions currently implemented:
 
 -   Conversion instructions (conv variants)
 
+-   Overflow conversion instructions (conv.ovf variants)
+
 -   Logical condition check instructions (ceq, cgt, clt and their
     variants)
 
@@ -220,8 +222,6 @@ The instructions currently implemented:
 -   Stack manipulation (nop, dup, pop)
 
 <a name="Not implemented"></a>The instructions not yet implemented:
-
--   Overflow conversion instructions (conv.ovf variants)
 
 -   Local block allocation (localloc)
 

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2361,7 +2361,7 @@ public:
                       IRNode *Arg2) = 0;
   virtual void condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,
                           IRNode *Arg2) = 0;
-  virtual IRNode *conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1) = 0;
+  virtual IRNode *conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Source) = 0;
   virtual void cpBlk(IRNode *ByteCount, IRNode *SourceAddress,
                      IRNode *DestinationAddress, ReaderAlignType Alignment,
                      bool IsVolatile);

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -304,7 +304,7 @@ public:
               IRNode *Arg2) override;
   void condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,
                   IRNode *Arg2) override;
-  IRNode *conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Arg1) override;
+  IRNode *conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Source) override;
 
   void dup(IRNode *Opr, IRNode **Result1, IRNode **Result2) override;
   void endFilter(IRNode *Arg1) override {
@@ -957,6 +957,27 @@ private:
   /// \param Index Index to be accessed.
   /// \returns The input array.
   IRNode *genBoundsCheck(IRNode *Array, IRNode *Index);
+
+  /// \brief Generate conditional throw for conv.ovf.
+  ///
+  /// As part of the overflow test sequence, this method may generate code that
+  /// produces an intermediate result (specifically, the overflow tests for a
+  /// conversion from floating-point to narrow int produces an intermediate
+  /// wide int).  The value returned is the value to convert, and
+  /// \p SourceIsSigned will be updated to reflect the new source if necessary.
+  ///
+  /// \param Source         Source of the conv.ovf
+  /// \param TargetTy       LLVM type being converted to
+  /// \param SourceIsSigned [in/out] Indicates whether an integer source should
+  ///                       be considered signed; meaningless for non-integer
+  ///                       sources
+  /// \param DestIsSigned   Indicates whether the target type should be
+  ///                       interpreted as signed
+  /// \returns The value to convert to the destination.  May be the original
+  ///          \p Source or may be a new intermediate value of another type.
+  llvm::Value *genConvertOverflowCheck(llvm::Value *Source,
+                                       llvm::IntegerType *TargetTy,
+                                       bool &SourceIsSigned, bool DestIsSigned);
 
   uint32_t size(CorInfoType CorType);
   uint32_t stackSize(CorInfoType CorType);


### PR DESCRIPTION
For integer cases, add explicit inline tests immediately prior to
conversion that branch to a block that throws OverflowException if the
source is out-of-bounds.
For floating-point cases, invoke the appropriate runtime helper (with
possibly an up-conversion from float to double first and possibly an
integer narrowing after).

Resolves #48 

We now successfully read the bring-up test method that was failing on this (IntPtr.op_explicit [to i32] in test LngConv).
