### PR TITLE
Implement the simple case of unbox.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -473,9 +473,7 @@ public:
   IRNode *unaryOp(ReaderBaseNS::UnaryOpcode Opcode, IRNode *Arg1) override;
   IRNode *unbox(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg2,
                 bool AndLoad, ReaderAlignType Alignment,
-                bool IsVolatile) override {
-    throw NotYetImplementedException("unbox");
-  };
+                bool IsVolatile) override;
 
   void nop() override;
 
@@ -764,8 +762,9 @@ public:
 
   // Create an operand that will be used to hold a pointer.
   IRNode *makePtrDstGCOperand(bool IsInteriorGC) override {
-    throw NotYetImplementedException("makePtrDstGCOperand");
-  };
+    return makePtrNode(IsInteriorGC ? Reader_PtrGcInterior : Reader_PtrGcBase);
+  }
+
   IRNode *makePtrNode(ReaderPtrType PtrType = Reader_PtrNotGc) override;
 
   IRNode *makeStackTypeNode(IRNode *Node) override {


### PR DESCRIPTION
Fixes part of #45.

Leave the nullable case NYI since we don't have a test case for it yet.

Unblocks one method, which then leads us to compile a couple more.

Before: 129 tests, 37260 methods, 33024 good, 4236 bad (88% good)
After: 129 tests, 37905 methods, 33799 good, 4106 bad (89% good)
