### PR TITLE
Insert divide-by-zero checks

### DIFF
--- a/Documentation/llilc-jit-eh.md
+++ b/Documentation/llilc-jit-eh.md
@@ -520,16 +520,16 @@ Once correct EH support is enabled and pushed back up to the master branch,
 EH-centric optimizations and support for other targets will follow.
 
 The current status is that the stub EH support is implemented with support
-for explicit throws and some but not all implicit exceptions.
+for both explicit throws and implicit exceptions.
 
 In summary, the plan/status is:
- 1. [ ] Stub EH support
+ 1. [x] Stub EH support
    - [x] Reader discards catch/filter/fault handlers
    - [x] Explicit throw becomes helper call
    - [x] Continuation passing for finally handlers invoked by `leave`
-   - [ ] Implicit exceptions expanded to explicit test/throw sequences
+   - [x] Implicit exceptions expanded to explicit test/throw sequences
      - [x] Null dereference
-     - [ ] Divide by zero
+     - [x] Divide by zero
      - [x] Arithmetic overflow
      - [x] Convert with overflow
      - [x] Array bounds checks

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1137,6 +1137,14 @@ protected:
   // could look like with null checks folded onto loads/stores.
   static const bool UseExplicitNullChecks = true;
 
+  // \brief Indicates that divide-by-zero checks use explicit compare+branch IR
+  //
+  // Compiling with this set to false isn't really supported (the generated IR
+  // would not have sufficient EH annotations), but it is provided as a mock
+  // configuration flag to facilitate experimenting with what the IR/codegen
+  // could look like with divide-by-zero checks folded onto divides.
+  static const bool UseExplicitZeroDivideChecks = true;
+
   // Verification Info
 public:
   bool VerificationNeeded;


### PR DESCRIPTION
Generate an explicit compare+branch+conditional-throw before each integer
divide.

Add a mock configuration flag UseExplicitZeroDivideChecks alongside
UseExplicitNullChecks to facilitate future experiments on what code
size/shape would look like with checks implicit in divide operations.

Closes #64 
