### PR TITLE
Implement convertToHelperArgumentType and AddressOfValue

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2761,8 +2761,13 @@ public:
                                           IRNode *Arg2,
                                           IRNode *NullCheckArg) = 0;
 
-  virtual IRNode *convertToHelperArgumentType(IRNode *Opr,
-                                              uint32_t DestinationSize) = 0;
+  /// Converts the operand to an argument type understood by the boxing helper
+  ///
+  /// \param Opr Operand
+  /// \param CorType CorInfoType of the operand.
+  /// \returns Converted operand
+  virtual IRNode *convertToBoxHelperArgumentType(IRNode *Opr,
+                                                 CorInfoType CorType) = 0;
 
   virtual IRNode *genNullCheck(IRNode *Node) = 0;
 
@@ -2792,7 +2797,12 @@ public:
                                  bool IsCallTarget,
                                  bool IsFrozenObject = false) = 0;
 
-  // Create an operand that will be used to hold a pointer.
+  /// Create an operand that will be used to pass to the boxing helper
+  ///
+  /// \param Class CORINFO_CLASS_HANDLE of the type to be boxed
+  /// \returns Operand
+  virtual IRNode *makeBoxDstOperand(CORINFO_CLASS_HANDLE Class) = 0;
+
   virtual IRNode *makePtrDstGCOperand(bool IsInteriorGC) = 0;
   virtual IRNode *makePtrNode(ReaderPtrType PointerType = Reader_PtrNotGc) = 0;
   virtual IRNode *makeStackTypeNode(IRNode *Node) = 0;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -738,10 +738,10 @@ public:
   IRNode *callRuntimeHandleHelper(CorInfoHelpFunc Helper, IRNode *Arg1,
                                   IRNode *Arg2, IRNode *NullCheckArg);
 
-  IRNode *convertToHelperArgumentType(IRNode *Opr,
-                                      uint32_t DestinationSize) override {
-    throw NotYetImplementedException("convertToHelperArgumentType");
-  };
+  IRNode *convertToBoxHelperArgumentType(IRNode *Opr,
+                                         CorInfoType CorType) override;
+
+  IRNode *makeBoxDstOperand(CORINFO_CLASS_HANDLE Class) override;
 
   IRNode *genNullCheck(IRNode *Node) override;
 


### PR DESCRIPTION
This fixes #44 

Result from failure:

Found 129 results
129 tests, 38034 methods, 34765 good, 3269 bad (91% good)
[Return refany or value class]                  903
[convertHandle]                                 578
[Struct parameter]                              517
[localAlloc]                                    258
[methodNeedsSecurityCheck]                      258
[PHI type mismatch]                             186
[loadNonPrimitiveObj]                           186
[unbox]                                         130
[conditionalDerefAddress]                       129
[Volatile store]                                114
[sqrt]                                          6
[Call intrinsic]                                2
[Convert Overflow]                              1
[Call has value type args]                      1
