### PR TITLE
Throw NYI for PInvoke calls.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3304,6 +3304,16 @@ IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
     }
   }
 
+  if (CallTargetInfo->isIndirect()) {
+    CorInfoCallConv Conv = SigInfo->getCallConv();
+    if (Conv == CORINFO_CALLCONV_STDCALL || Conv == CORINFO_CALLCONV_C ||
+        Conv == CORINFO_CALLCONV_THISCALL ||
+        Conv == CORINFO_CALLCONV_FASTCALL ||
+        Conv == CORINFO_CALLCONV_NATIVEVARARG) {
+      throw NotYetImplementedException("PInvoke call");
+    }
+  }
+
   // Ask GenIR to create return value.
   if (!CallTargetInfo->isNewObj()) {
     ReturnNode = makeCallReturnNode(SigInfo, &HiddenMBParamSize, &GCInfo);
@@ -3384,8 +3394,6 @@ IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
       throw NotYetImplementedException("Call intrinsic");
     }
   }
-
-  // TODO: deal with PInvokes and var args.
 
   Call = (IRNode *)CallInst;
 


### PR DESCRIPTION
We need to throw NYI for PInvoke calls until #282 is implemented.
Not doing so caused a crash when building mini-Roslyn.

This sets our numbers back somewhat:

HelloWorld:
before: 1 tests, 323 methods, 293 good, 30 bad (90% good)
after: 1 tests, 323 methods, 282 good, 41 bad (87% good)

All tests:
before: 129 tests, 37905 methods, 33800 good, 4105 bad (89% good)
after: 129 tests, 37905 methods, 32741 good, 5164 bad (86% good)

Closes #364.
