### PR TITLE
Fix GenIR::castOp for isinst [valuetype].

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -114,8 +114,8 @@ struct LLILCJitPerThreadState {
 public:
   /// Construct a new state.
   LLILCJitPerThreadState()
-      : LLVMContext(), ClassTypeMap(), ArrayTypeMap(), FieldIndexMap(),
-        JitContext(nullptr) {}
+      : LLVMContext(), ClassTypeMap(), BoxedTypeMap(), ArrayTypeMap(),
+        FieldIndexMap(), JitContext(nullptr) {}
 
   /// Each thread maintains its own \p LLVMContext. This is where
   /// LLVM keeps definitions of types and similar constructs.
@@ -126,6 +126,10 @@ public:
 
   /// Map from class handles to the LLVM types that represent them.
   std::map<CORINFO_CLASS_HANDLE, llvm::Type *> ClassTypeMap;
+
+  /// Map from class handles for value types to the LLVM types that represent
+  /// their boxed versions.
+  std::map<CORINFO_CLASS_HANDLE, llvm::Type *> BoxedTypeMap;
 
   /// \brief Map from class handles for arrays to the LLVM types that represent
   /// them.

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -240,6 +240,7 @@ class GenIR : public ReaderBase {
 public:
   GenIR(LLILCJitContext *JitContext,
         std::map<CORINFO_CLASS_HANDLE, llvm::Type *> *ClassTypeMap,
+        std::map<CORINFO_CLASS_HANDLE, llvm::Type *> *BoxedTypeMap,
         std::map<std::tuple<CorInfoType, CORINFO_CLASS_HANDLE, uint32_t>,
                  llvm::Type *> *ArrayTypeMap,
         std::map<CORINFO_FIELD_HANDLE, uint32_t> *FieldIndexMap)
@@ -247,6 +248,7 @@ public:
                    JitContext->Flags) {
     this->JitContext = JitContext;
     this->ClassTypeMap = ClassTypeMap;
+    this->BoxedTypeMap = BoxedTypeMap;
     this->ArrayTypeMap = ArrayTypeMap;
     this->FieldIndexMap = FieldIndexMap;
   }
@@ -847,6 +849,13 @@ private:
   llvm::Type *getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
                            bool GetRefClassFields);
 
+  /// \brief Construct the LLVM type of the boxed representation of the given
+  ///        value type.
+  ///
+  /// \param Class The handle to the value type's class.
+  /// \returns The LLVM type of the boxed representation of the value type.
+  llvm::Type *getBoxedType(CORINFO_CLASS_HANDLE Class);
+
   /// Convert node to the desired type.
   /// May reinterpret, truncate, or extend as needed.
   /// \param Type Desired type
@@ -1168,6 +1177,7 @@ private:
   // insertion point parameters).
   llvm::IRBuilder<> *LLVMBuilder;
   std::map<CORINFO_CLASS_HANDLE, llvm::Type *> *ClassTypeMap;
+  std::map<CORINFO_CLASS_HANDLE, llvm::Type *> *BoxedTypeMap;
   std::map<std::tuple<CorInfoType, CORINFO_CLASS_HANDLE, uint32_t>,
            llvm::Type *> *ArrayTypeMap;
   std::map<CORINFO_FIELD_HANDLE, uint32_t> *FieldIndexMap;

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -285,7 +285,8 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
 
   LLILCJitPerThreadState *PerThreadState = State.get();
   GenIR Reader(JitContext, &PerThreadState->ClassTypeMap,
-               &PerThreadState->ArrayTypeMap, &PerThreadState->FieldIndexMap);
+               &PerThreadState->BoxedTypeMap, &PerThreadState->ArrayTypeMap,
+               &PerThreadState->FieldIndexMap);
 
   std::string FuncName = JitContext->CurrentModule->getModuleIdentifier();
 


### PR DESCRIPTION
GenIR::castOp incorrectly assumed that the target type of a cast operation (i.e.
castclass or isinst) must be a reference type. This constraint only holds for
castclass; it is legal (and common) to have "isinst [valuetype]".
