### PR TITLE
Fix two issues found when running Roslyn.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2686,8 +2686,9 @@ IRNode *GenIR::loadAtAddress(IRNode *Address, Type *Ty, CorInfoType CorType,
                              ReaderAlignType AlignmentPrefix, bool IsVolatile,
                              bool AddressMayBeNull) {
   if (Ty->isStructTy()) {
-    return loadObj(ResolvedToken, Address, AlignmentPrefix, IsVolatile, true,
-                   AddressMayBeNull);
+    bool IsFieldAccess = ResolvedToken->hField != nullptr;
+    return loadObj(ResolvedToken, Address, AlignmentPrefix, IsVolatile,
+                   IsFieldAccess, AddressMayBeNull);
   } else {
     LoadInst *LoadInst = makeLoad(Address, IsVolatile, AddressMayBeNull);
     uint32_t Align = convertReaderAlignment(AlignmentPrefix);
@@ -4715,7 +4716,7 @@ IRNode *GenIR::conditionalDerefAddress(IRNode *Address) {
 
   // Merge the two addresses and return the result.
   PHINode *Result = mergeConditionalResults(ContinueBlock, Address, TestBlock,
-                                            UpdatedAddress, ContinueBlock);
+                                            UpdatedAddress, IndirectionBlock);
 
   return (IRNode *)Result;
 }


### PR DESCRIPTION
`loadAtAddress` of a struct type was always passing true for IsField when it is also used for array accesses. This caused failures for arrays of structs. Fix is to look at the ResolvedToken to determine whether the access is a field or not.

`conditionalDerefAddress` had a bug introduced when I refactored it. Since the method that hits this fails later in the reader the IR validation error hasn't yet surfaced. But Roslyn has methods where this bug causes validation errors.
