### PR TITLE
Introduce Statepoint GC

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -80,6 +80,11 @@ public:
   std::string MethodName;          ///< Name of the method (for diagnostics).
   //@}
 
+  /// \name CoreCLR GC information
+  //@{
+  bool ShouldUseConservativeGC; ///< Whether the GC is conservative/precise
+  //@}
+
   /// \name LLVM information
   //@{
   llvm::LLVMContext *LLVMContext; ///< LLVM context for types and similar.
@@ -226,6 +231,12 @@ private:
   /// \param JitContext Context record for the method's jit request.
   /// \returns \p true if GC info was successfully reported.
   bool outputGCInfo(LLILCJitContext *JitContext);
+
+  /// Insert the @gc.safepoint_poll() method
+  /// Inserts the @gc.safepoint_poll() method into the current module.
+  /// This helper is required by the LLVM GC-Statepoint insertion phase.
+  /// \param Context JitContext Context record for the current jit request.
+  void insertSafepointPoll(LLILCJitContext *Context);
 
 public:
   /// A pointer to the singleton jit instance.

--- a/lib/Jit/CMakeLists.txt
+++ b/lib/Jit/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LLVM_LINK_COMPONENTS
   CodeGen
   Core
   ExecutionEngine
+  IPO
   IRReader
   MCJIT
   MC

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -17,6 +17,7 @@
 #include "LLILCJit.h"
 #include "readerir.h"
 #include "EEMemoryManager.h"
+#include "llvm/CodeGen/GCs.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/ExecutionEngine/MCJIT.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
@@ -24,6 +25,7 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IRReader/IRReader.h"
+#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
@@ -35,6 +37,8 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Transforms/Scalar.h"
+#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include <string>
 
 using namespace llvm;
@@ -55,6 +59,20 @@ LLVMDumpLevel dumpLevel() {
     }
   }
   return NODUMP;
+}
+
+// Get the GC-Scheme used by the runtime -- conservative/precise
+// For now this is done by directly accessing environment variable.
+// When CLR config support is included, update it here.
+bool shouldUseConservativeGC() {
+  const char *LevelCStr = getenv("COMPLUS_GCCONSERVATIVE");
+  if (LevelCStr) {
+    std::string Level = LevelCStr;
+    if (Level.compare("1") == 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // The one and only Jit Object.
@@ -86,6 +104,7 @@ LLILCJit::LLILCJit() {
   InitializeNativeTarget();
   InitializeNativeTargetAsmPrinter();
   InitializeNativeTargetAsmParser();
+  llvm::linkStatepointExampleGC();
 }
 
 #ifdef LLVM_ON_WIN32
@@ -163,6 +182,11 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   Context.LLVMContext = &PerThreadState->LLVMContext;
   std::unique_ptr<Module> M = Context.getModuleForMethod(MethodInfo);
   Context.CurrentModule = M.get();
+  Context.ShouldUseConservativeGC = shouldUseConservativeGC();
+
+  if (!Context.ShouldUseConservativeGC) {
+    insertSafepointPoll(&Context);
+  }
 
   EngineBuilder Builder(std::move(M));
   std::string ErrStr;
@@ -173,7 +197,8 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
 
   TargetOptions Options;
 
-  Options.EnableFastISel = true;
+  // Statepoint GC does not support FastIsel yet.
+  Options.EnableFastISel = Context.ShouldUseConservativeGC;
 
   if ((Flags & CORJIT_FLG_DEBUG_CODE) == 0) {
     Builder.setOptLevel(CodeGenOpt::Level::Default);
@@ -201,6 +226,22 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   bool HasMethod = this->readMethod(&Context);
 
   if (HasMethod) {
+
+    if (!Context.ShouldUseConservativeGC) {
+      // If using Precise GC, run the GC-Safepoint insertion
+      // and lowering passes before generating code.
+      legacy::PassManager Passes;
+      Passes.add(createPlaceSafepointsPass());
+
+      PassManagerBuilder PMBuilder;
+      PMBuilder.OptLevel = 0;  // Set optimization level to -O0
+      PMBuilder.SizeLevel = 0; // so that no additional phases are run.
+      PMBuilder.populateModulePassManager(Passes);
+
+      Passes.add(createRewriteStatepointsForGCPass());
+      Passes.run(*Context.CurrentModule);
+    }
+
     Context.EE->generateCodeForModule(Context.CurrentModule);
 
     // You need to pick up the COFFDyld changes from the MS branch of LLVM
@@ -227,6 +268,28 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   }
 
   return Result;
+}
+
+// This is the method invoked by the EE to Jit code.
+void LLILCJit::insertSafepointPoll(LLILCJitContext *Context) {
+  Module *M = Context->CurrentModule;
+
+  FunctionType *VoidFnType =
+      FunctionType::get(Type::getVoidTy(M->getContext()), false);
+
+  Function *SafepointPoll = dyn_cast<Function>(
+      M->getOrInsertFunction("gc.safepoint_poll", VoidFnType));
+
+  assert(SafepointPoll->empty());
+
+  Function *Safepoint =
+      dyn_cast<Function>(M->getOrInsertFunction("do_safepoint", VoidFnType));
+
+  llvm::BasicBlock *EntryBlock =
+      BasicBlock::Create(*Context->LLVMContext, "entry", SafepointPoll);
+
+  CallInst::Create(Safepoint, "", EntryBlock);
+  ReturnInst::Create(*Context->LLVMContext, EntryBlock);
 }
 
 std::unique_ptr<Module>

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -527,6 +527,8 @@ Function *GenIR::getFunction(CORINFO_METHOD_HANDLE MethodHandle,
     F->setCallingConv(CallingConv::CLR_SecretParameter);
   }
 
+  F->setGC("statepoint-example");
+
   return F;
 }
 


### PR DESCRIPTION
This change implementats the insertion and lowering of GC-Statepoints
into the code generated by LLILC.

When not using Conservative GC (COMPLUS_GCCONSERVATICE != 1), the Jit
1)Runs PlaceSafePoints and RewriteStatepointsForGC passes before the
  code generation phases
2) Annotates the generated functions with gc “statepoint example”
3) Emits the special @gc.safepoint_poll() helper function into the module
   along with the function being Jitted. This helper is required by
   the PlaceSafePoints phase.

Testing:

This is a work in progress, there are some failures in
RewriteStatepointsForGC due to incorrect live-sets.

LLILC Issue: #32
