### PR TITLE
Throw NYI for methods that return structs.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -269,18 +269,21 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
     ASSERTNR(UNREACHED);
   }
 
-  const uint32_t JitFlags = JitContext->Flags;
-
-  HasSecretParameter = (JitFlags & CORJIT_FLG_PUBLISH_SECRET_PARAM) != 0;
-
   CORINFO_METHOD_HANDLE MethodHandle = JitContext->MethodInfo->ftn;
-  Function = getFunction(MethodHandle, HasSecretParameter);
 
   // Capture low-level info about the return type for use in Return.
   CORINFO_SIG_INFO Sig;
   getMethodSig(MethodHandle, &Sig);
   ReturnCorType = Sig.retType;
 
+  if ((ReturnCorType == CORINFO_TYPE_REFANY) ||
+      (ReturnCorType == CORINFO_TYPE_VALUECLASS)) {
+    throw NotYetImplementedException("Return refany or value class");
+  }
+
+  const uint32_t JitFlags = JitContext->Flags;
+  HasSecretParameter = (JitFlags & CORJIT_FLG_PUBLISH_SECRET_PARAM) != 0;
+  Function = getFunction(MethodHandle, HasSecretParameter);
   EntryBlock = BasicBlock::Create(*JitContext->LLVMContext, "entry", Function);
 
   LLVMBuilder = new IRBuilder<>(*this->JitContext->LLVMContext);


### PR DESCRIPTION
We don't handle methods that return structs correctly yet so we need to throw NYI.
Failure to do so resulted in a runtime failure when trying to build "Baby Roslyn".
LLVM assumes that the first parameter to methods returning structs is a pointer to the return buffer.

This reduces our percentages somewhat:
All tests:
129 tests, 38679 methods, 34482 good, 4197 bad (89% good)
goes down to
129 tests, 38163 methods, 33708 good, 4455 bad (88% good)
HelloWorld:
1 tests, 328 methods, 294 good, 34 bad (89% good)
goes down to
1 tests, 325 methods, 289 good, 36 bad (88% good)

@pagavlin is working on struct params/returns so we should get these back soon.

Closes #378.
