### PR TITLE
Change CLRRuntime version to 1.0.2

### DIFF
--- a/utils/packages.config
+++ b/utils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Microsoft.DotNet.CoreCLR.Development" version="1.0.0-prerelease" />
+    <package id="Microsoft.DotNet.CoreCLR.Development" version="1.0.2-prerelease" />
 </packages>


### PR DESCRIPTION
The 1.0.0-prerelease package has been removed. We need to switch to
1.0.2 to get our jobs working.
