### PR TITLE
Add IsPointNode as a flow graph node property.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1187,6 +1187,7 @@ private:
   std::vector<llvm::Value *> Arguments;
   std::vector<CorInfoType> ArgumentCorTypes;
   llvm::DenseMap<uint32_t, llvm::StoreInst *> ContinuationStoreMap;
+  FlowGraphNode *FirstMSILBlock;
   llvm::BasicBlock *UnreachableContinuationBlock;
   CorInfoType ReturnCorType;
   bool HasThis;


### PR DESCRIPTION
This addresses a couple of issues seen in the Roslyn bring-up.

`IsPointNode` is used to mark blocks that don't contain ranges of expanded MSIL instructions.
We'd already introduced this notion implicitly for conditional deref/helper flow and now we track
this explicitly per-block.

In `readerPrePass`, split the current block after the parameter stores and local allocas and other
"run once on entry to the method" IR. The continuation block from this split is the block that corresponds
to MSIL offset 0 and is also the target of branches back to offset 0. Mark all the blocks before this
continuation as point blocks so later processing skips over them. Implement the initial skipping logic in `fgPrePhase`.

Implement the just my code hook, which requires a conditional branch in this "entry IR" sequence.

Closes #272, closes #372.
