### PR TITLE
Remove coreclr from path to test results

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -863,7 +863,7 @@ function Global:BuildTest([string]$Arch="x64", [string]$Build="Debug")
 function Global:CheckFailure([string]$Arch="x64", [string]$Build="Release")
 {
   $CoreCLRTestAssets = CoreCLRTestAssets
-  $RunResult = "$CoreCLRTestAssets\coreclr\bin\Logs\TestRunResults_Windows_NT__"
+  $RunResult = "$CoreCLRTestAssets\bin\Logs\TestRunResults_Windows_NT__"
   $RunResult  = $RunResult + "$Arch"
   $RunResult  = $RunResult + "__$Build.log"
   $RunResultsExists = Test-Path $RunResult


### PR DESCRIPTION
CoreCLRTestAssets points to CoreCLRSource, which includes the bin
directory, not coreclr/bin. Remove coreclr from the path.
