### PR TITLE
More fixes from Roslyn.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -226,6 +226,10 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
     Result = CORJIT_OK;
   }
 
+  // Clean up a bit
+  delete Context.EE;
+  Context.EE = nullptr;
+
   return Result;
 }
 

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -5513,7 +5513,7 @@ ReaderBase::rdrGetCodePointerLookupCallTarget(CORINFO_CALL_INFO *CallInfo,
 }
 
 // This is basically a runtime look up for virtual calls. A JIT helper
-// call is invoked at runtime which finds the virutal call target. The
+// call is invoked at runtime which finds the virtual call target. The
 // return value of this helper call is then called indirectly.
 IRNode *ReaderBase::rdrGetIndirectVirtualCallTarget(
     ReaderCallTargetData *CallTargetData, IRNode **ThisPtr) {
@@ -5536,8 +5536,9 @@ IRNode *ReaderBase::rdrGetIndirectVirtualCallTarget(
   IRNode *ThisPtrCopy;
   dup(*ThisPtr, &ThisPtrCopy, ThisPtr);
 
-  // Get the address of the target function by calling helper
-  IRNode *Dst = makePtrNode();
+  // Get the address of the target function by calling helper.
+  // Type it as a native int, it will be recast later.
+  IRNode *Dst = loadConstantI(0);
   return callHelper(CORINFO_HELP_VIRTUAL_FUNC_PTR, Dst, ThisPtrCopy,
                     ClassHandle, MethodHandle);
 }


### PR DESCRIPTION
Delete the LLVM EE when we're done jitting a method. This gets back most of the memory we allocate and brings our leaking down to a much more tolerable level.

Type the result of ldvirtfn as native int so that subsequent processing handles it the same as other function addresses.

Trim type array in the varargs constructor call path so the LLVM function type builder is not confused.

Add extra paranoia around ldlen and strlen since we see cases where the referent type is not an array or string. For now bail out if we hit one of these.

if we see an endfinally and can't locate the enclosing EH region, bail out with an NYI rather than AVing in the jit.
