### PR TITLE
Handle mismatching types when merging operand stacks.

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -114,8 +114,8 @@ struct LLILCJitPerThreadState {
 public:
   /// Construct a new state.
   LLILCJitPerThreadState()
-      : LLVMContext(), ClassTypeMap(), BoxedTypeMap(), ArrayTypeMap(),
-        FieldIndexMap(), JitContext(nullptr) {}
+      : LLVMContext(), ClassTypeMap(), ReverseClassTypeMap(), BoxedTypeMap(),
+        ArrayTypeMap(), FieldIndexMap(), JitContext(nullptr) {}
 
   /// Each thread maintains its own \p LLVMContext. This is where
   /// LLVM keeps definitions of types and similar constructs.
@@ -126,6 +126,9 @@ public:
 
   /// Map from class handles to the LLVM types that represent them.
   std::map<CORINFO_CLASS_HANDLE, llvm::Type *> ClassTypeMap;
+
+  /// Map from LLVM types to the corresponding class handles.
+  std::map<llvm::Type *, CORINFO_CLASS_HANDLE> ReverseClassTypeMap;
 
   /// Map from class handles for value types to the LLVM types that represent
   /// their boxed versions.

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -285,6 +285,7 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
 
   LLILCJitPerThreadState *PerThreadState = State.get();
   GenIR Reader(JitContext, &PerThreadState->ClassTypeMap,
+               &PerThreadState->ReverseClassTypeMap,
                &PerThreadState->BoxedTypeMap, &PerThreadState->ArrayTypeMap,
                &PerThreadState->FieldIndexMap);
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -952,6 +952,7 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
                                       ArrayRank)] = ResultTy;
     } else {
       (*ClassTypeMap)[ClassHandle] = ResultTy;
+      (*ReverseClassTypeMap)[ResultTy] = ClassHandle;
     }
 
     // Fetch the name of this type for use in dumps.
@@ -1995,12 +1996,16 @@ ReaderStack *GenIR::fgNodeGetOperandStack(FlowGraphNode *Fg) {
   return FlowGraphInfoMap[Fg].TheReaderStack;
 }
 
-bool GenIR::fgNodeIsVisited(FlowGraphNode *Fg) {
-  return FlowGraphInfoMap[Fg].IsVisited;
+bool GenIR::fgNodeIsDiscovered(FlowGraphNode *Fg) {
+  return FlowGraphInfoMap[Fg].State != Undiscovered;
 }
 
-void GenIR::fgNodeSetVisited(FlowGraphNode *Fg, bool Visited) {
-  FlowGraphInfoMap[Fg].IsVisited = Visited;
+bool GenIR::fgNodeIsVisited(FlowGraphNode *Fg) {
+  return FlowGraphInfoMap[Fg].State == Visited;
+}
+
+void GenIR::fgNodeSetState(FlowGraphNode *Fg, FlowGraphNodeState State) {
+  FlowGraphInfoMap[Fg].State = State;
 }
 
 // Check whether this node propagates operand stack.
@@ -5178,26 +5183,7 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
   while (SuccessorList != nullptr) {
     FlowGraphNode *SuccessorBlock = fgEdgeListGetSink(SuccessorList);
 
-    int NumberOfPredecessorsPropagatingStack = 0;
-    for (FlowGraphEdgeList *SuccessorPredecessorList =
-             fgNodeGetPredecessorListActual(SuccessorBlock);
-         SuccessorPredecessorList != nullptr;
-         SuccessorPredecessorList =
-             fgEdgeListGetNextPredecessorActual(SuccessorPredecessorList)) {
-      FlowGraphNode *SuccessorPredecessorNode =
-          fgEdgeListGetSource(SuccessorPredecessorList);
-      if (fgNodePropagatesOperandStack(SuccessorPredecessorNode)) {
-        ++NumberOfPredecessorsPropagatingStack;
-        // We don't need the exact number of predecessors propagating operand
-        // stack; we are only interested if there are more than one.
-        if (NumberOfPredecessorsPropagatingStack > 1) {
-          break;
-        }
-      }
-    }
-
-    ASSERTNR(NumberOfPredecessorsPropagatingStack >= 1);
-    if (NumberOfPredecessorsPropagatingStack == 1) {
+    if (!fgNodeHasMultiplePredsPropagatingStack(SuccessorBlock)) {
       // The current node is the only relevant predecessor of this Successor.
       ASSERTNR(fgNodePropagatesOperandStack(CurrentBlock));
       // We need to create a stack for the Successor and copy the items from the
@@ -5236,10 +5222,7 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
           PHI = cast<PHINode>(CurrentInst);
           CurrentInst = CurrentInst->getNextNode();
         }
-        if (PHI->getType() != CurrentValue->getType()) {
-          throw NotYetImplementedException("PHI type mismatch");
-        }
-        PHI->addIncoming(CurrentValue, (BasicBlock *)CurrentBlock);
+        AddPHIOperand(PHI, CurrentValue, (BasicBlock *)CurrentBlock);
         if (CreatePHIs) {
           SuccessorStack->push((IRNode *)PHI);
         }
@@ -5253,6 +5236,109 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
   }
 
   clearStack();
+}
+
+void GenIR::AddPHIOperand(PHINode *PHI, Value *NewOperand,
+                          BasicBlock *NewBlock) {
+  Type *PHITy = PHI->getType();
+  Type *NewOperandTy = NewOperand->getType();
+
+  if (PHITy != NewOperandTy) {
+    Type *NewPHITy = getStackMergeType(PHITy, NewOperandTy);
+    IRBuilder<>::InsertPoint SavedInsertPoint = LLVMBuilder->saveIP();
+    if (NewPHITy != PHITy) {
+      // Change the type of the PHI instruction and the types of all of its
+      // operands.
+      PHI->mutateType(NewPHITy);
+      for (int i = 0; i < PHI->getNumOperands(); ++i) {
+        Value *Operand = PHI->getIncomingValue(i);
+        BasicBlock *OperandBlock = PHI->getIncomingBlock(i);
+        Operand = ChangePHIOperandType(Operand, OperandBlock, NewPHITy);
+        PHI->setIncomingValue(i, Operand);
+      }
+    }
+    if (NewPHITy != NewOperandTy) {
+      // Change the type of the new PHI operand.
+      NewOperand = ChangePHIOperandType(NewOperand, NewBlock, NewPHITy);
+    }
+    LLVMBuilder->restoreIP(SavedInsertPoint);
+  }
+
+  PHI->addIncoming(NewOperand, NewBlock);
+}
+
+Value *GenIR::ChangePHIOperandType(Value *Operand, BasicBlock *OperandBlock,
+                                   Type *NewTy) {
+  LLVMBuilder->SetInsertPoint(OperandBlock->getTerminator());
+  if (NewTy->isIntegerTy()) {
+    bool IsSigned = true;
+    return LLVMBuilder->CreateIntCast(Operand, NewTy, IsSigned);
+  } else if (NewTy->isFloatingPointTy()) {
+    return LLVMBuilder->CreateFPCast(Operand, NewTy);
+  } else {
+    return LLVMBuilder->CreatePointerCast(Operand, NewTy);
+  }
+}
+
+Type *GenIR::getStackMergeType(Type *Ty1, Type *Ty2) {
+  if (Ty1 == Ty2) {
+    return Ty1;
+  }
+
+  LLVMContext &LLVMContext = *this->JitContext->LLVMContext;
+
+  // If we have nativeint and int32 the result is nativeint.
+  Type *NativeIntTy = Type::getIntNTy(LLVMContext, TargetPointerSizeInBits);
+  Type *Int32Ty = Type::getInt32Ty(LLVMContext);
+  if (((Ty1 == NativeIntTy) && (Ty2 == Int32Ty)) ||
+      ((Ty2 == NativeIntTy) && (Ty1 == Int32Ty))) {
+    return NativeIntTy;
+  }
+
+  // If we have float and double the result is double.
+  Type *FloatTy = Type::getFloatTy(LLVMContext);
+  Type *DoubleTy = Type::getDoubleTy(LLVMContext);
+  if (((Ty1 == FloatTy) && (Ty2 == DoubleTy)) ||
+      ((Ty2 == FloatTy) && (Ty1 == DoubleTy))) {
+    return DoubleTy;
+  }
+
+  // If we have GC pointers, the result is the closest common supertype.
+  PointerType *PointerTy1 = dyn_cast<PointerType>(Ty1);
+  PointerType *PointerTy2 = dyn_cast<PointerType>(Ty2);
+  if ((PointerTy1 != nullptr) && (PointerTy2 != nullptr) &&
+      (isManagedPointerType(PointerTy1)) &&
+      (isManagedPointerType(PointerTy2))) {
+
+    CORINFO_CLASS_HANDLE Class1 = nullptr;
+    auto MapElement1 = ReverseClassTypeMap->find(PointerTy1);
+    if (MapElement1 != ReverseClassTypeMap->end()) {
+      Class1 = MapElement1->second;
+    }
+
+    CORINFO_CLASS_HANDLE Class2 = nullptr;
+    auto MapElement2 = ReverseClassTypeMap->find(PointerTy2);
+    if (MapElement2 != ReverseClassTypeMap->end()) {
+      Class2 = MapElement2->second;
+    }
+
+    CORINFO_CLASS_HANDLE MergedClass = nullptr;
+    if ((Class1 != nullptr) && (Class2 != nullptr)) {
+      MergedClass = JitContext->JitInfo->mergeClasses(Class1, Class2);
+      ASSERT(!JitContext->JitInfo->isValueClass(MergedClass));
+    } else {
+      // We can get here if one of the types is an array or a boxed type.
+      // We can't map arrays back to its handles because an array can be
+      // identified by one of two handles: the actual array handle and the
+      // handle for its MethodTable. mergeClasses will only work correctly with
+      // the former.
+      // Use System.Object as the result for these cases.
+      MergedClass = getBuiltinClass(CorInfoClassId::CLASSID_SYSTEM_OBJECT);
+    }
+    return getType(CORINFO_TYPE_CLASS, MergedClass);
+  }
+  ASSERT(UNREACHED);
+  return nullptr;
 }
 
 // Create a PHI node in a block that may or may not have a terminator.


### PR DESCRIPTION
When merging operand stacks the types of the corresponding values may be
different. The CLI spec allows merging of nativeint and int32 (resulting in nativeint),
float and double (resulting in double), and GC pointers (resulting in the closest
common supertype).

In order to be able to use JitInfo->mergeClasses (that handles finding closest common
supertype) we need to be able to map back from llvm types to class handles. I added
ReverseClassTypeMap for that.

Since our processing of basic blocks depends on the types of values on the stack we
need to complete stack merging and finalize PHI instructions before processing
join blocks. To do that I changes the order of flow graph processing from depth-first
preorder to reverse postorder.

We get 1 more method in HelloWorld and 245 more methods in all tests:

HelloWorld
before: 1 tests, 352 methods, 311 good, 41 bad (88% good)
after:    1 tests, 352 methods, 312 good, 40 bad (88% good)

All Tests
before: 130 tests, 40006 methods, 34973 good, 5033 bad (87% good)
after:    130 tests, 40063 methods, 35218 good, 4845 bad (87% good)
