### PR TITLE
Add an ABI abstraction for computing function signatures.

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -22,6 +22,8 @@
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/ThreadLocal.h"
 
+class ABIInfo;
+
 /// \brief Enum for LLVM IR Dump Level
 enum LLVMDumpLevel {
   NODUMP,  ///< Do not dump any LLVM IR or summary.
@@ -86,6 +88,11 @@ public:
   llvm::Module *CurrentModule;    ///< Module holding LLVM IR.
   llvm::ExecutionEngine *EE;      ///< MCJIT execution engine.
   bool HasLoadedBitCode;          ///< Flag for side-loaded LLVM IR.
+  //@}
+
+  /// \name ABI information
+  //@{
+  ABIInfo *TheABIInfo; ///< Target ABI information.
   //@}
 
   /// \name Context management

--- a/include/Reader/abi.h
+++ b/include/Reader/abi.h
@@ -1,0 +1,123 @@
+//===------------------- include/Reader/abi.h -------------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Declares the ABI abstraction used when lowering functions to LLVM IR.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef _READER_ABI_H_
+#define _READER_ABI_H_
+
+/// \brief Information about how a particular argument is passed to a function.
+///
+/// This class encapsulates information such as whether a parameter is passed
+/// by value or by implicit reference, whether it must be coerced to a different
+/// type, etc. This information is used when generating call sequences or
+/// accessing method parameters/results.
+class ABIArgInfo {
+public:
+  /// \brief Describes how a particular argument is passed to a function.
+  enum Kind {
+    Direct, ///< Pass the argument directly, optionally coercing it to a
+            ///< different type.
+
+    Indirect, ///< Pass the argument indirectly via a hidden pointer
+  };
+
+private:
+  Kind TheKind;        ///< How this argument is to be passed
+  llvm::Type *TheType; ///< The type this argument is to be passed as
+  uint32_t Index;      ///< Index of this argument in the argument list of
+                       ///< its containing \p Function. Currently only used by
+                       ///< \p ABIMethodSignature.
+
+  ABIArgInfo(Kind TheKind, llvm::Type *TheType);
+
+public:
+  /// \brief Create an \p ABIIArgInfo value for an argument that is to be
+  ///        passed by value with a particular type.
+  ///
+  /// \param TheType  The type that this argument is passed as.
+  ///
+  /// \returns An \p ABIArgInfo value describing the argument.
+  static ABIArgInfo getDirect(llvm::Type *TheType);
+
+  /// \brief Create an \p ABIIArgInfo value for an argument that is to be
+  ///        passed by an implicit reference to a particular type.
+  ///
+  /// \param TheType  The referent type for this argument.
+  ///
+  /// \returns An \p ABIArgInfo value describing the argument.
+  static ABIArgInfo getIndirect(llvm::Type *TheType);
+
+  /// \brief Empty constructor to allow vectors, data-dependent construction,
+  ///        etc.
+  ///
+  /// Actual values should be created using \p getDirect and \p getIndirect.
+  ABIArgInfo() {}
+
+  /// \brief Get the \p Kind that describes how this argument is passed.
+  ///
+  /// \returns The \p Kind that describes how this argument is passed.
+  Kind getKind() const;
+
+  /// \brief Get the type of this argument.
+  ///
+  /// \returns The type of the argument for direct args or the referent type
+  ///          of the argument for indirect args.
+  llvm::Type *getType() const;
+
+  /// \brief Set the index of this argument in its containing argument list.
+  ///
+  /// \param Index  The index of this argument in its containing agument list.
+  void setIndex(uint32_t Index);
+
+  /// \brief Get the index of this argument in its containing argument list.
+  ///
+  /// \returns The index of this argument in its containing argument list.
+  uint32_t getIndex() const;
+};
+
+/// \brief Encapsulautes ABI-specific functionality.
+///
+/// The \p ABIInfo class provides ABI-specific services. Currently, this is
+/// limited to computing the details of how arguments are passed to functions
+/// for a given platform.
+class ABIInfo {
+public:
+  /// \brief Gets an \p ABIInfo that corresponds to the target of the given
+  ///        \p Module.
+  ///
+  /// \returns An \p ABIInfo instance. This instance belongs to the caller and
+  ///          should be deleted when it is no longer needed.
+  static ABIInfo *get(llvm::Module &M);
+
+  /// \brief Computes argument passing information for the target ABI.
+  ///
+  /// This function is used to determine how the parameters to and result of a
+  /// function are passed for the given calling convention and types for the
+  /// target ABI.
+  ///
+  /// \param CC                    The calling convention for the call target.
+  /// \param ResultType            The type of the target's result.
+  /// \param ArgTypes              The types of the target's arguments.
+  /// \param ResultInfo [out]      Argument passing information for the target's
+  ///                              result.
+  /// \param ArgInfos [out]        Argument passing information for the target's
+  ///                              arguments.
+  virtual void
+  computeSignatureInfo(llvm::CallingConv::ID CC, llvm::Type *ResultType,
+                       llvm::ArrayRef<llvm::Type *> ArgTypes,
+                       ABIArgInfo &ResultInfo,
+                       std::vector<ABIArgInfo> &ArgInfos) const = 0;
+};
+
+#endif

--- a/include/Reader/abisignature.h
+++ b/include/Reader/abisignature.h
@@ -1,0 +1,119 @@
+//===------------------- include/Reader/abisignature.h ----------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Declares ABI signature abstractions used when lowering functions to
+///        LLVM IR.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef _READER_ABISIGNATURE_H_
+#define _READER_ABISIGNATURE_H_
+
+/// \brief Encapsulates ABI-specific argument and result passing information for
+///        a particular function signature.
+class ABISignature {
+protected:
+  llvm::Type *FuncResultType; ///< The return type of this function signature.
+  ABIArgInfo Result; ///< Describes how the result of the function is passed.
+  std::vector<ABIArgInfo> Args; ///< Describes how each argument to the function
+                                ///< is passed.
+
+  ABISignature() {}
+
+  /// \brief Fills in argument and result passing information for the given
+  ///        function signature.
+  ///
+  /// \param Signature   The function signature.
+  /// \param Reader      The \p GenIR instance that will be used to emit IR.
+  /// \oaram TheABIInfo  The target \p ABIInfo.
+  ABISignature(const ReaderCallSignature &Signature, GenIR &Reader,
+               const ABIInfo &TheABIInfo);
+
+public:
+  /// \brief Coerces a value to a particular target type, casting or
+  ///        reinterpreting as necessary.
+  ///
+  /// \param Reader    The \p GenIR instance that will be used to emit IR.
+  /// \param TheType   The target type of the coercion.
+  /// \param TheValue  The value to coerce.
+  ///
+  /// \returns A \p Value that represents the result of the coercion.
+  static llvm::Value *coerce(GenIR &Reader, llvm::Type *TheType,
+                             llvm::Value *TheValue);
+};
+
+/// \brief Encapsulates ABI-specific argument and result passing information for
+///        a particular call target signature and provides facilities to emit
+///        a call to a target with that signature.
+class ABICallSignature : public ABISignature {
+private:
+  const ReaderCallSignature &Signature; ///< The target function signature.
+
+public:
+  ABICallSignature(const ReaderCallSignature &Signature, GenIR &Reader,
+                   const ABIInfo &TheABIInfo);
+
+  /// \brief Emits a call to a function with using the argument and result
+  ///        passing information for the signature provided when this value
+  ///        was created.
+  ///
+  /// \param Reader           The \p GenIR instance that will be used to emit
+  ///                         IR.
+  /// \param Target           The call target.
+  /// \param Args             The arguments to the call.
+  /// \param IndirectionCell  The indirection cell argument for the call, if
+  ///                         any.
+  /// \param CallNode [out]   The call instruction.
+  ///
+  /// \returns The result of the call to the target.
+  llvm::Value *emitCall(GenIR &Reader, llvm::Value *Target,
+                        llvm::ArrayRef<llvm::Value *> Args,
+                        llvm::Value *IndirectionCell,
+                        llvm::Value **CallNode) const;
+};
+
+/// \brief Encapsulates ABI-specific argument and result passing information for
+///        a particular method signature and provides facilites to create an
+//         appropriately-typed function symbol.
+class ABIMethodSignature : public ABISignature {
+private:
+  const ReaderMethodSignature *Signature; ///< The target method signature.
+
+public:
+  ABIMethodSignature() {}
+  ABIMethodSignature(const ReaderMethodSignature &Signature, GenIR &Reader,
+                     const ABIInfo &TheABIInfo);
+
+  /// \brief Creates a function symbol for the method signature provided when
+  ///        this vaule was created.
+  ///
+  /// \param Reader  The \p GenIR instance that will be used to emit IR.
+  /// \param M       The module in which this function is to be created.
+  ///
+  /// \returns The newly-created function symbol.
+  llvm::Function *createFunction(GenIR &Reader, llvm::Module &M);
+
+  /// \brief Gets result passing information for this signature.
+  ///
+  /// \returns Result passing information for this signature.
+  const ABIArgInfo &getResultInfo() const;
+
+  /// \brief Gets argument passing information for the runtime argument at the
+  ///        given index into its parent \p ReaderMethodSignature.
+  ///
+  /// \param I  The index of the runtime argument into its parent
+  ///           \p ReaderMethodSignature.
+  ///
+  /// \returns Argument passing information for the argument.
+  const ABIArgInfo &getArgumentInfo(uint32_t I) const;
+};
+
+#endif

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -16,6 +16,7 @@
 #include "jitpch.h"
 #include "LLILCJit.h"
 #include "readerir.h"
+#include "abi.h"
 #include "EEMemoryManager.h"
 #include "llvm/CodeGen/GCs.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
@@ -178,6 +179,8 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   Context.LLVMContext = &PerThreadState->LLVMContext;
   std::unique_ptr<Module> M = Context.getModuleForMethod(MethodInfo);
   Context.CurrentModule = M.get();
+  Context.CurrentModule->setTargetTriple(LLVM_DEFAULT_TARGET_TRIPLE);
+  Context.TheABIInfo = ABIInfo::get(*Context.CurrentModule);
 
   if (!ShouldUseConservativeGC) {
     createSafepointPoll(&Context);
@@ -265,6 +268,8 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   // Clean up a bit
   delete Context.EE;
   Context.EE = nullptr;
+  delete Context.TheABIInfo;
+  Context.TheABIInfo = nullptr;
 
   return Result;
 }

--- a/lib/Reader/CMakeLists.txt
+++ b/lib/Reader/CMakeLists.txt
@@ -10,6 +10,8 @@ if( WIN32 )
 endif()
 
 add_llilcjit_library(LLILCReader
+  abi.cpp
+  abisignature.cpp
   reader.cpp
   readerir.cpp
   GenIRStubs.cpp

--- a/lib/Reader/abi.cpp
+++ b/lib/Reader/abi.cpp
@@ -1,0 +1,180 @@
+//===------------------- include/Reader/abi.cpp -----------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Defines the ABI abstraction used when lowering functions to LLVM IR.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Module.h"
+#include "reader.h"
+#include "readerir.h"
+#include "abi.h"
+#include <cstdint>
+#include <cassert>
+
+using namespace llvm;
+
+// Static class with helpers for the Microsoft x86-64 ABI.
+class X86_64_Win64 {
+private:
+  X86_64_Win64() {}
+  static ABIArgInfo classify(Type *Ty, const DataLayout &DL);
+
+public:
+  static void computeSignatureInfo(Type *ResultType, ArrayRef<Type *> ArgTypes,
+                                   const DataLayout &DL, ABIArgInfo &ResultInfo,
+                                   std::vector<ABIArgInfo> &ArgInfos);
+};
+
+// Static class wqith helpers for the System V x86-64 ABI.
+class X86_64_SysV {
+private:
+  X86_64_SysV() {}
+
+public:
+  static void computeSignatureInfo(Type *ResultType, ArrayRef<Type *> ArgTypes,
+                                   const DataLayout &DL, ABIArgInfo &ResultInfo,
+                                   std::vector<ABIArgInfo> &ArgInfos);
+};
+
+class X86_64ABIInfo : public ABIInfo {
+private:
+  bool IsWindows;
+  const DataLayout &TheDataLayout;
+
+public:
+  X86_64ABIInfo(Triple TargetTriple, const DataLayout &DL);
+
+  void computeSignatureInfo(CallingConv::ID CC, Type *ResultType,
+                            ArrayRef<Type *> ArgTypes, ABIArgInfo &ResultInfo,
+                            std::vector<ABIArgInfo> &ArgInfos) const override;
+};
+
+ABIArgInfo X86_64_Win64::classify(Type *Ty, const DataLayout &DL) {
+  if (Ty->isAggregateType()) {
+    // If the aggregate's size in bytes is a power of 2 that is less than or
+    // equal to 8, it can be passed directly once coerced to an
+    // appropriately-sized
+    // integer. Otherwise, it must be passed indirectly.
+    uint64_t SizeInBits = DL.getTypeSizeInBits(Ty);
+    uint64_t SizeInBytes = SizeInBits / 8;
+    if (SizeInBytes <= 8 && llvm::isPowerOf2_64(SizeInBytes)) {
+      return ABIArgInfo::getDirect(
+          IntegerType::get(Ty->getContext(), SizeInBits));
+    }
+
+    return ABIArgInfo::getIndirect(Ty);
+  }
+
+  if (Ty->isIntegerTy()) {
+    assert(Ty->getIntegerBitWidth() <= 64);
+    return ABIArgInfo::getDirect(Ty);
+  }
+
+  if (Ty->isFloatingPointTy()) {
+    assert(Ty->isFloatTy() || Ty->isDoubleTy());
+    return ABIArgInfo::getDirect(Ty);
+  }
+
+  // TODO: vector types
+  assert(Ty->isPointerTy() || Ty->isVoidTy());
+  return ABIArgInfo::getDirect(Ty);
+}
+
+void X86_64_Win64::computeSignatureInfo(Type *ResultType,
+                                        ArrayRef<Type *> ArgTypes,
+                                        const DataLayout &DL,
+                                        ABIArgInfo &ResultInfo,
+                                        std::vector<ABIArgInfo> &ArgInfos) {
+  ResultInfo = classify(ResultType, DL);
+
+  for (auto &Arg : ArgTypes) {
+    ArgInfos.push_back(classify(Arg, DL));
+  }
+}
+
+void X86_64_SysV::computeSignatureInfo(Type *ResultType,
+                                       ArrayRef<Type *> ArgTypes,
+                                       const DataLayout &DL,
+                                       ABIArgInfo &ResultInfo,
+                                       std::vector<ABIArgInfo> &ArgInfos) {
+  // TODO: RyuJIT does not implement the SysV ABI rules as decribed in "System V
+  //       Application Binary Interface". For now, agree and just use the Win64
+  //       rules.
+  X86_64_Win64::computeSignatureInfo(ResultType, ArgTypes, DL, ResultInfo,
+                                     ArgInfos);
+}
+
+X86_64ABIInfo::X86_64ABIInfo(Triple TargetTriple, const DataLayout &DL)
+    : TheDataLayout(DL) {
+  assert(TargetTriple.getArch() == Triple::x86_64);
+  IsWindows = TargetTriple.isOSWindows();
+}
+
+void X86_64ABIInfo::computeSignatureInfo(
+    CallingConv::ID CC, Type *ResultType, ArrayRef<Type *> ArgTypes,
+    ABIArgInfo &ResultInfo, std::vector<ABIArgInfo> &ArgInfos) const {
+  if (CC == CallingConv::C) {
+    CC = IsWindows ? CallingConv::X86_64_Win64 : CallingConv::X86_64_SysV;
+  }
+
+  switch (CC) {
+  case CallingConv::X86_64_Win64:
+    X86_64_Win64::computeSignatureInfo(ResultType, ArgTypes, TheDataLayout,
+                                       ResultInfo, ArgInfos);
+    break;
+
+  case CallingConv::X86_64_SysV:
+    X86_64_SysV::computeSignatureInfo(ResultType, ArgTypes, TheDataLayout,
+                                      ResultInfo, ArgInfos);
+    break;
+
+  default:
+    assert(CC != CallingConv::C);
+    assert(false && "Unsupported calling convention");
+  }
+}
+
+ABIInfo *ABIInfo::get(Module &M) {
+  Triple TargetTriple(M.getTargetTriple());
+
+  switch (TargetTriple.getArch()) {
+  case Triple::x86_64:
+    return new X86_64ABIInfo(TargetTriple, M.getDataLayout());
+
+  default:
+    assert(false && "Unsupported architecture");
+  }
+}
+
+ABIArgInfo::ABIArgInfo(Kind TheKind, Type *TheType)
+    : TheKind(TheKind), TheType(TheType) {}
+
+ABIArgInfo ABIArgInfo::getDirect(llvm::Type *TheType) {
+  return ABIArgInfo(Kind::Direct, TheType);
+}
+
+ABIArgInfo ABIArgInfo::getIndirect(llvm::Type *TheType) {
+  return ABIArgInfo(Kind::Indirect, TheType);
+}
+
+ABIArgInfo::Kind ABIArgInfo::getKind() const { return TheKind; }
+
+Type *ABIArgInfo::getType() const { return TheType; }
+
+void ABIArgInfo::setIndex(uint32_t Index) { this->Index = Index; }
+
+uint32_t ABIArgInfo::getIndex() const { return Index; }

--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -1,0 +1,253 @@
+//===------------------- include/Reader/abisignature..cpp -------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Defines ABI signature abstractions used when lowering functions to
+///        LLVM IR.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Module.h"
+#include "reader.h"
+#include "readerir.h"
+#include "abi.h"
+#include "abisignature.h"
+#include <cstdint>
+#include <cassert>
+
+using namespace llvm;
+
+static CallingConv::ID getLLVMCallingConv(CorInfoCallConv CC) {
+  switch (CC) {
+  case CORINFO_CALLCONV_STDCALL:
+    return CallingConv::X86_StdCall;
+  case CORINFO_CALLCONV_THISCALL:
+    return CallingConv::X86_ThisCall;
+  case CORINFO_CALLCONV_FASTCALL:
+    return CallingConv::X86_FastCall;
+  default:
+    return CallingConv::C;
+  }
+}
+
+ABISignature::ABISignature(const ReaderCallSignature &Signature, GenIR &Reader,
+                           const ABIInfo &TheABIInfo) {
+  const CallArgType &ResultType = Signature.getResultType();
+  const std::vector<CallArgType> &ArgTypes = Signature.getArgumentTypes();
+  const uint32_t NumArgs = ArgTypes.size();
+
+  Type *LLVMResultType = Reader.getType(ResultType.CorType, ResultType.Class);
+
+  SmallVector<Type *, 16> LLVMArgTypes(NumArgs);
+  uint32_t I = 0;
+  for (const CallArgType &Arg : ArgTypes) {
+    LLVMArgTypes[I++] = Reader.getType(Arg.CorType, Arg.Class);
+  }
+
+  CallingConv::ID CC = getLLVMCallingConv(Signature.getCallingConvention());
+  TheABIInfo.computeSignatureInfo(CC, LLVMResultType, LLVMArgTypes, Result,
+                                  Args);
+
+  if (Result.getKind() == ABIArgInfo::Indirect) {
+    FuncResultType = Reader.getManagedPointerType(Result.getType());
+  } else {
+    FuncResultType = Result.getType();
+  }
+}
+
+Value *ABISignature::coerce(GenIR &Reader, Type *TheType, Value *TheValue) {
+  Type *ValueType = TheValue->getType();
+
+  if (TheType == ValueType) {
+    return TheValue;
+  }
+
+  // TODO: the code spit could probably be better here.
+  IRBuilder<> &Builder = *Reader.LLVMBuilder;
+  Type *TargetPtrTy = TheType->getPointerTo();
+  Value *ValuePtr = (Value *)Reader.addressOfValue((IRNode *)TheValue);
+  Value *TargetPtr = Builder.CreatePointerCast(ValuePtr, TargetPtrTy);
+  return Builder.CreateLoad(TargetPtr);
+}
+
+ABICallSignature::ABICallSignature(const ReaderCallSignature &TheSignature,
+                                   GenIR &Reader, const ABIInfo &TheABIInfo)
+    : ABISignature(TheSignature, Reader, TheABIInfo), Signature(TheSignature) {}
+
+Value *ABICallSignature::emitCall(GenIR &Reader, llvm::Value *Target,
+                                  llvm::ArrayRef<Value *> Args,
+                                  llvm::Value *IndirectionCell,
+                                  llvm::Value **CallNode) const {
+  assert(Target->getType()->isIntegerTy(Reader.TargetPointerSizeInBits));
+
+  // Compute the function type
+  bool HasIndirectResult = Result.getKind() == ABIArgInfo::Indirect;
+  bool HasIndirectionCell = IndirectionCell != nullptr;
+  uint32_t NumExtraArgs =
+      (HasIndirectResult ? 1 : 0) + (HasIndirectionCell ? 1 : 0);
+  int32_t ResultIndex = -1;
+  Value *ResultNode = nullptr;
+  SmallVector<Type *, 16> ArgumentTypes(Args.size() + NumExtraArgs);
+  SmallVector<Value *, 16> Arguments(Args.size() + NumExtraArgs);
+  IRBuilder<> &Builder = *Reader.LLVMBuilder;
+
+  // Check for VSD calls.
+  if (HasIndirectionCell) {
+    // The indirection cell is passed as the first argument. The backend will
+    // place it in the appropriate register. The indirection cell should be
+    // integer-typed.
+    assert(IndirectionCell->getType()->isIntegerTy(
+        Reader.TargetPointerSizeInBits));
+    ArgumentTypes[0] = IndirectionCell->getType();
+    Arguments[0] = IndirectionCell;
+  }
+
+  if (HasIndirectResult) {
+    ResultIndex = (HasIndirectionCell ? 1 : 0) + (Signature.hasThis() ? 1 : 0);
+    ArgumentTypes[ResultIndex] =
+        Reader.getUnmanagedPointerType(Result.getType());
+    Arguments[ResultIndex] = ResultNode =
+        Reader.createTemporary(Result.getType());
+  }
+
+  uint32_t I = HasIndirectionCell ? 1 : 0, J = 0;
+  for (auto Arg : Args) {
+    if (ResultIndex >= 0 && I == (uint32_t)ResultIndex) {
+      I++;
+    }
+
+    const ABIArgInfo &ArgInfo = this->Args[J];
+    Type *ArgType = Arg->getType();
+
+    if (ArgInfo.getKind() == ABIArgInfo::Indirect) {
+      // TODO: byval attribute support
+      ArgumentTypes[I] = ArgType->getPointerTo();
+      Value *Temp = Reader.createTemporary(ArgType);
+      Builder.CreateStore(Arg, Temp);
+      Arguments[I] = Temp;
+    } else {
+      ArgumentTypes[I] = ArgInfo.getType();
+      Arguments[I] = coerce(Reader, ArgInfo.getType(), Arg);
+    }
+
+    I++, J++;
+  }
+
+  const bool IsVarArg = false;
+  Type *FunctionTy = FunctionType::get(FuncResultType, ArgumentTypes, IsVarArg);
+  Type *FunctionPtrTy = Reader.getUnmanagedPointerType(FunctionTy);
+
+  Target = Builder.CreateIntToPtr(Target, FunctionPtrTy);
+  CallInst *Call = Builder.CreateCall(Target, Arguments);
+
+  CallingConv::ID CC;
+  if (HasIndirectionCell) {
+    assert(Signature.getCallingConvention() == CORINFO_CALLCONV_DEFAULT);
+    CC = CallingConv::CLR_VirtualDispatchStub;
+  } else {
+    CC = getLLVMCallingConv(Signature.getCallingConvention());
+  }
+  Call->setCallingConv(CC);
+
+  if (ResultNode == nullptr) {
+    assert(!HasIndirectResult);
+    const CallArgType &SigResultType = Signature.getResultType();
+    Type *Ty = Reader.getType(SigResultType.CorType, SigResultType.Class);
+    ResultNode = coerce(Reader, Ty, Call);
+  } else {
+    ResultNode = Builder.CreateLoad(ResultNode);
+  }
+
+  *CallNode = Call;
+  return ResultNode;
+}
+
+ABIMethodSignature::ABIMethodSignature(
+    const ReaderMethodSignature &TheSignature, GenIR &Reader,
+    const ABIInfo &TheABIInfo)
+    : ABISignature(TheSignature, Reader, TheABIInfo), Signature(&TheSignature) {
+}
+
+Function *ABIMethodSignature::createFunction(GenIR &Reader, Module &M) {
+  // Compute the function type
+  LLVMContext &Context = M.getContext();
+  bool HasIndirectResult = Result.getKind() == ABIArgInfo::Indirect;
+  uint32_t NumExtraArgs = HasIndirectResult ? 1 : 0;
+  int32_t ResultIndex = -1;
+  SmallVector<Type *, 16> ArgumentTypes(Args.size() + NumExtraArgs);
+
+  if (HasIndirectResult) {
+    ResultIndex = Signature->hasThis() ? 1 : 0;
+    Result.setIndex((uint32_t)ResultIndex);
+    ArgumentTypes[ResultIndex] = Reader.getManagedPointerType(Result.getType());
+  }
+
+  uint32_t I = 0;
+  for (auto &Arg : Args) {
+    if (ResultIndex >= 0 && I == (uint32_t)ResultIndex) {
+      I++;
+    }
+
+    if (Arg.getKind() == ABIArgInfo::Indirect) {
+      // TODO: byval attribute support
+      ArgumentTypes[I] = Reader.getManagedPointerType(Arg.getType());
+    } else {
+      ArgumentTypes[I] = Arg.getType();
+    }
+    Arg.setIndex(I);
+
+    I++;
+  }
+
+  const bool IsVarArg = false;
+  FunctionType *FunctionTy =
+      FunctionType::get(FuncResultType, ArgumentTypes, IsVarArg);
+  Function *F = Function::Create(FunctionTy, Function::ExternalLinkage,
+                                 M.getModuleIdentifier(), &M);
+
+  // Use "param" for these initial parameter values. Numbering here
+  // is strictly positional (hence includes implicit parameters).
+  uint32_t N = 0;
+  for (Function::arg_iterator Args = F->arg_begin(); Args != F->arg_end();
+       Args++) {
+    Args->setName(Twine("param") + Twine(N++));
+  }
+
+  CallingConv::ID CC;
+  if (Signature->hasSecretParameter()) {
+    assert((--F->arg_end())->getType()->isIntegerTy());
+
+    AttributeSet Attrs = F->getAttributes();
+    F->setAttributes(
+        Attrs.addAttribute(Context, F->arg_size(), "CLR_SecretParameter"));
+    CC = CallingConv::CLR_SecretParameter;
+  } else {
+    CC = CallingConv::C;
+  }
+  F->setCallingConv(CC);
+
+  if (!LLILCJit::TheJit->ShouldUseConservativeGC) {
+    F->setGC("statepoint-example");
+  }
+
+  return F;
+}
+
+const ABIArgInfo &ABIMethodSignature::getResultInfo() const { return Result; }
+
+const ABIArgInfo &ABIMethodSignature::getArgumentInfo(uint32_t I) const {
+  assert(I < Args.size());
+  return Args[I];
+}


### PR DESCRIPTION
LLVM's support for calling conventions does not handle aggregate
parameters or return values in a way that is consistent with the
rules for a particular calling convention. Instead of applying
whatever rules are particular to a given calling convention, it
simply recursively decomposes aggregates into a linear sequence
of arguments of non-aggregate type. It is the frontend's
responsibility, then, to emit calls such that the backend will
lower them appropriately for the target calling convention.

Practically speaking, this means that the frontend must do the
work to determine how each argument to a function--aggregate or
otherwise--should be passed (e.g. directly/indirectly, as an
expanded series of arguments, etc.) when generating calls and
function symbols. To this end, this change adds abstractions
to encapsulate ABI information and compute argument and result
passing information for a function signature (i.e. a calling
convention, result type, and argument types). These abstractions
are then used to emit function calls, home method arguments, and
return method results in a way that is compatible with the
backend.
