### PR TITLE
Implement convertHandle and getTypeFromHandle.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2686,7 +2686,13 @@ public:
   IRNode *loadLenNonNull(IRNode *Array) { return loadLen(Array, false); }
   virtual bool arrayAddress(CORINFO_SIG_INFO *Aig, IRNode **RetVal) = 0;
   virtual IRNode *loadStringLen(IRNode *Arg1) = 0;
-  virtual IRNode *getTypeFromHandle(IRNode *Arg1) = 0;
+
+  /// \brief Get RuntimeType from RuntimeTypeHandle.
+  ///
+  /// \param HandleNode  RuntimeTypeHandle node.
+  ///
+  /// \returns RuntimeType node.
+  virtual IRNode *getTypeFromHandle(IRNode *HandleNode) = 0;
   virtual IRNode *getValueFromRuntimeHandle(IRNode *Arg1) = 0;
   virtual IRNode *arrayGetDimLength(IRNode *Arg1, IRNode *Arg2,
                                     CORINFO_CALL_INFO *CallInfo) = 0;
@@ -2703,7 +2709,16 @@ public:
   virtual IRNode *loadAndBox(CORINFO_RESOLVED_TOKEN *ResolvedToken,
                              IRNode *Address,
                              ReaderAlignType AlignmentPrefix) = 0;
-  virtual IRNode *convertHandle(IRNode *GetTokenNumeric,
+
+  /// \brief Get a runtime handle corresponding to the token node.
+  ///
+  /// \param RuntimeTokenNode  Node corresponding to the runtime token lookup.
+  /// \param HelperID  Helper to call to get the runtime type, method, or field.
+  /// \param Class  Class handle that corresponds to RuntimeTypeHandle,
+  ///               RuntimeMethodHandle, or RuntimeFieldHandle.
+  ///
+  /// \returns Runtime handle corresponding to the token node..
+  virtual IRNode *convertHandle(IRNode *RuntimeTokenNode,
                                 CorInfoHelpFunc HelperID,
                                 CORINFO_CLASS_HANDLE Class) = 0;
   virtual void

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -373,9 +373,8 @@ public:
   };
   IRNode *loadStringLen(IRNode *Arg1) override;
 
-  IRNode *getTypeFromHandle(IRNode *Arg1) override {
-    throw NotYetImplementedException("getTypeFromHandle");
-  };
+  IRNode *getTypeFromHandle(IRNode *HandleNode) override;
+
   IRNode *getValueFromRuntimeHandle(IRNode *Arg1) override {
     throw NotYetImplementedException("getValueFromRuntimeHandle");
   };
@@ -388,10 +387,8 @@ public:
                      ReaderAlignType AlignmentPrefix) override {
     throw NotYetImplementedException("loadAndBox");
   };
-  IRNode *convertHandle(IRNode *GetTokenNumericNode, CorInfoHelpFunc HelperID,
-                        CORINFO_CLASS_HANDLE ClassHandle) override {
-    throw NotYetImplementedException("convertHandle");
-  };
+  IRNode *convertHandle(IRNode *RuntimeTokenNode, CorInfoHelpFunc HelperID,
+                        CORINFO_CLASS_HANDLE ClassHandle) override;
   void
   convertTypeHandleLookupHelperToIntrinsic(bool CanCompareToGetType) override {
     throw NotYetImplementedException(


### PR DESCRIPTION
This unblocks ldtoken (today) and refanytype (in the future) instructions.

HelloWorld
before: 1 tests, 352 methods, 312 good, 40 bad (88% good)
after:    1 tests, 354 methods, 318 good, 36 bad (89% good)

All Tests:
before: 130 tests, 40063 methods, 35218 good, 4845 bad (87% good)
after:    130 tests, 40323 methods, 35933 good, 4390 bad (89% good)

Closes #374.
