### PR TITLE
Use normal lowering for volatile stores.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2834,12 +2834,10 @@ void GenIR::storePrimitiveType(IRNode *Value, IRNode *Addr,
 // Helper used to wrap CreateStore
 StoreInst *GenIR::makeStore(Value *ValueToStore, Value *Address,
                             bool IsVolatile, bool AddressMayBeNull) {
-  if (IsVolatile) {
-    // TODO: There is a JitConfig call back which can alter
-    // how volatile stores are handled.
-    throw NotYetImplementedException("Volatile store");
-  }
-
+  // TODO: There is a JitConfig setting JitLockWrite which can alter how
+  // volatile stores are handled for x86 architectures. When this is set we
+  // should emit a (lock) xchg intead of mov. RyuJit doesn't to look at this
+  // config setting, so we also ignore it.
   if (AddressMayBeNull) {
     if (UseExplicitNullChecks) {
       Address = genNullCheck((IRNode *)Address);


### PR DESCRIPTION
There's a JitConfig setting JitLockWrite that should force the jit to emit lock prefixed stores for volatiles, but RyuJit doesn't look at this. So we'll also ignore it for now. Issue #278 will remain open to track implementing the option, if we decide to do so.

Instead just allow volatile stores to lower normally (with IsVolatile true in LLVM IR).

Hello world now at the 90% mark...

1 tests, 354 methods, 321 good, 33 bad (90% good)
