### PR TITLE
Add support for methods with security objects.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -490,9 +490,7 @@ public:
   //
 
   // Base calls to alert client it needs a security check
-  void methodNeedsSecurityCheck() override {
-    throw NotYetImplementedException("methodNeedsSecurityCheck");
-  };
+  void methodNeedsSecurityCheck() override { NeedsSecurityObject = true; }
 
   // Base calls to alert client it needs keep generics context alive
   void
@@ -1183,6 +1181,12 @@ private:
   /// \returns true iff this node is constant null.
   bool isConstantNull(IRNode *Node);
 
+  /// \brief Insert IR to keep the generic context alive
+  void insertIRToKeepGenericContextAlive();
+
+  /// \brief Insert IR to setup the security object
+  void insertIRForSecurityObject();
+
 private:
   LLILCJitContext *JitContext;
   ReaderMethodSignature MethodSignature;
@@ -1212,6 +1216,7 @@ private:
   llvm::BasicBlock *UnreachableContinuationBlock;
   CorInfoType ReturnCorType;
   bool KeepGenericContextAlive;
+  bool NeedsSecurityObject;
   llvm::BasicBlock *EntryBlock;
   llvm::Instruction *TempInsertionPoint;
   uint32_t TargetPointerSizeInBits;


### PR DESCRIPTION
Allocate a local to hold the security object. Zero initialize it and then pass it's address to the prolog helper.

Ultimately we'll need to ensure this slot stays alive and also report it in the GC info. Will update #301 to reflect this once the PR is merged.
