### PR TITLE
Fix bug in GenIR::storeElem.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1112,9 +1112,9 @@ private:
   /// \param Array Array that the element belongs to.
   /// \param Index Index of the element.
   /// \param ElementTy Type of the element.
-  /// \returns Value representing the address of the element.
-  llvm::Value *genArrayElemAddress(IRNode *Array, IRNode *Index,
-                                   llvm::Type *ElementTy);
+  /// \returns Node representing the address of the element.
+  IRNode *genArrayElemAddress(IRNode *Array, IRNode *Index,
+                              llvm::Type *ElementTy);
 
   /// Convert ReaderAlignType to byte alighnment to byte alignment.
   ///


### PR DESCRIPTION
When storing an element of struct type we call rdrCallWriteBarrierHelper.
We were passing array address instead of element address as the first argument.
This resulted in bad codegen when compiling Roslyn.

Change the return type of genArrayElemAddress from Value \* to IRNode \* and
eliminate a few casts.

Remove some unnecessary semicolons and fix a comment typo.
