### PR TITLE
Call JIT_GCPoll() runtime helper from gc.safepoint_poll()

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -230,13 +230,6 @@ private:
   /// \returns \p true if GC info was successfully reported.
   bool outputGCInfo(LLILCJitContext *JitContext);
 
-  /// Create the @gc.safepoint_poll() method
-  /// Creates the @gc.safepoint_poll() method and insertes it into the
-  /// current module. This helper is required by the LLVM GC-Statepoint
-  /// insertion phase.
-  /// \param Context JitContext Context record for the current jit request.
-  void createSafepointPoll(LLILCJitContext *Context);
-
 public:
   /// A pointer to the singleton jit instance.
   static LLILCJit *TheJit;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1187,6 +1187,12 @@ private:
   /// \brief Insert IR to setup the security object
   void insertIRForSecurityObject();
 
+  /// \brief Create the @gc.safepoint_poll() method
+  /// Creates the @gc.safepoint_poll() method and insertes it into the
+  /// current module. This helper is required by the LLVM GC-Statepoint
+  /// insertion phase.
+  void createSafepointPoll();
+
 private:
   LLILCJitContext *JitContext;
 


### PR DESCRIPTION
gc.safepoint_poll() helper required by Safepoint placement pass was an
empty function. This change fixes this to call the correct runtime helper
to perform the CLR GC Poll.

The current strategy is to use an unconditional call to the GCPoll helper.
Inlining the GCPoll helper is future work.

The gc.safepoint_poll() generator is moved to GenIR class, given that it generates new IR and 
can use some of GenIR's helper methods.

Testing: All previously passing test programs still pass.

Issue #32
