### PR TITLE
Use llvm_unreachable instead of assert(false)

### DIFF
--- a/lib/Reader/abi.cpp
+++ b/lib/Reader/abi.cpp
@@ -156,7 +156,7 @@ ABIInfo *ABIInfo::get(Module &M) {
     return new X86_64ABIInfo(TargetTriple, M.getDataLayout());
 
   default:
-    assert(false && "Unsupported architecture");
+    llvm_unreachable("Unsupported architecture");
   }
 }
 


### PR DESCRIPTION
This avoids

>  warning C4715: 'ABIInfo::get' : not all control paths return a value
