### PR TITLE
Process the flow graph in the order of MSIL offsets.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -246,9 +246,6 @@ struct CallArgType {
   CORINFO_CLASS_HANDLE Class;
 };
 
-/// \brief Enum describing state of a flow graph node.
-enum FlowGraphNodeState { Undiscovered = 0, Discovered = 1, Visited = 2 };
-
 /// Structure representing a linked list of flow graph nodes
 struct FlowGraphNodeList {
   FlowGraphNode *Block;    ///< Head node in the list
@@ -1683,19 +1680,19 @@ private:
   IRNode *fgAddCaseToCaseListHelper(IRNode *SwitchNode, IRNode *LabelNode,
                                     uint32_t Element);
 
-  /// \brief Add the undiscovered successors of this block to the worklist.
+  /// \brief Add the unvisited successors of this block to the worklist.
   ///
   /// This method scans all the successor blocks of \p CurrBlock, and
-  /// if there are any undiscovered ones , creates new work list nodes for these
-  /// successors, marks them as discovered, and prepends them, returning a new
+  /// if there are any unvisited ones, creates new work list nodes for these
+  /// successors, marks them as visited, and prepends them, returning a new
   /// worklist head node.
   ///
   /// \param Worklist       The current worklist of blocks.
-  /// \param CurrBlock      The block to examine for undiscovered successors.
+  /// \param CurrBlock      The block to examine for unvisited successors.
   /// \returns              Updated worklist of blocks.
   FlowGraphNodeWorkList *
-  fgPrependUndiscoveredSuccToWorklist(FlowGraphNodeWorkList *Worklist,
-                                      FlowGraphNode *CurrBlock);
+  fgPrependUnvisitedSuccToWorklist(FlowGraphNodeWorkList *Worklist,
+                                   FlowGraphNode *CurrBlock);
 
   /// \brief Remove this flow graph node and associated client IRNodes.
   ///
@@ -1798,13 +1795,11 @@ private:
 
   /// \brief Remove all unreachable blocks.
   ///
-  /// Walk the flow graph and remove any block (except the tail block)
-  /// that cannot be reached from the head block. Blocks are removed by
-  /// calling \p fgDeleteBlockAndNodes.
+  /// Walk the flow graph and remove any block that cannot be reached from the
+  /// head block. Blocks are removed by calling \p fgDeleteBlockAndNodes.
   ///
   /// \param FgHead     the head block of the flow graph.
-  /// \param FgTail     the tail block of the flow graph.
-  void fgRemoveUnusedBlocks(FlowGraphNode *FgHead, FlowGraphNode *FgTail);
+  void fgRemoveUnusedBlocks(FlowGraphNode *FgHead);
 
   /// Find the canonical landing point for leaves from an EH region.
   ///
@@ -2600,13 +2595,6 @@ public:
   virtual void fgNodeSetEndMSILOffset(FlowGraphNode *FgNode,
                                       uint32_t Offset) = 0;
 
-  /// \brief Checks whether this node has been discovered by an algorithm
-  /// traversing the flow graph.
-  ///
-  /// \param FgNode Flow graph node to check.
-  /// \returns true iff this node has been discovered.
-  virtual bool fgNodeIsDiscovered(FlowGraphNode *FgNode) = 0;
-
   /// \brief Checks whether this node has been visited by an algorithm
   /// traversing the flow graph.
   ///
@@ -2614,12 +2602,13 @@ public:
   /// \returns true iff this node has been visited.
   virtual bool fgNodeIsVisited(FlowGraphNode *FgNode) = 0;
 
-  /// \brief Sets the traversing state of this node.
+  /// \brief Sets whether this node has been visited by an algorithm
+  /// traversing the flow graph.
   ///
   /// \param FgNode Flow graph node to set the state.
-  /// \param State The new state.
-  virtual void fgNodeSetState(FlowGraphNode *FgNode,
-                              FlowGraphNodeState State) = 0;
+  /// \param Visited true iff this node has been visited,
+  virtual void fgNodeSetVisited(FlowGraphNode *FgNode, bool Visited) = 0;
+
   virtual void fgNodeSetOperandStack(FlowGraphNode *Fg, ReaderStack *Stack) = 0;
   virtual ReaderStack *fgNodeGetOperandStack(FlowGraphNode *Fg) = 0;
 

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -39,7 +39,7 @@ public:
   FlowGraphNodeInfo() {
     StartMSILOffset = 0;
     EndMSILOffset = 0;
-    State = Undiscovered;
+    IsVisited = false;
     TheReaderStack = nullptr;
     PropagatesOperandStack = true;
   };
@@ -53,8 +53,8 @@ public:
   uint32_t EndMSILOffset;
 
   /// In algorithms traversing the flow graph, used to track which basic blocks
-  /// have been discovered or visited.
-  FlowGraphNodeState State;
+  /// have been visited.
+  bool IsVisited;
 
   /// Used to track what is on the operand stack on entry to the basic block.
   ReaderStack *TheReaderStack;
@@ -321,9 +321,8 @@ public:
   uint32_t fgNodeGetEndMSILOffset(FlowGraphNode *Fg) override;
   void fgNodeSetEndMSILOffset(FlowGraphNode *FgNode, uint32_t Offset) override;
 
-  bool fgNodeIsDiscovered(FlowGraphNode *FgNode) override;
   bool fgNodeIsVisited(FlowGraphNode *FgNode) override;
-  void fgNodeSetState(FlowGraphNode *FgNode, FlowGraphNodeState State) override;
+  void fgNodeSetVisited(FlowGraphNode *FgNode, bool Visited) override;
   void fgNodeSetOperandStack(FlowGraphNode *Fg, ReaderStack *Stack) override;
   ReaderStack *fgNodeGetOperandStack(FlowGraphNode *Fg) override;
 

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -2002,15 +2002,14 @@ void ReaderBase::fgDeleteBlockAndNodes(FlowGraphNode *Block) {
 }
 
 // removeUnusedBlocks
-// - Iterate from fgHead to fgTail using FgNodeGetNext
-// - fgHead and fgTail must have been visited
+// - Iterate from fgHead to the end of the list of nodes using FgNodeGetNext
+// - fgHead must have been visited
 // - clear visited bit on remaining blocks
-void ReaderBase::fgRemoveUnusedBlocks(FlowGraphNode *FgHead,
-                                      FlowGraphNode *FgTail) {
+void ReaderBase::fgRemoveUnusedBlocks(FlowGraphNode *FgHead) {
   FlowGraphNode *Block;
 
   // Remove Unused Blocks
-  for (Block = FgHead; Block != FgTail;) {
+  for (Block = FgHead; Block != nullptr;) {
     FlowGraphNode *NextBlock;
     NextBlock = fgNodeGetNext(Block);
 
@@ -2020,17 +2019,10 @@ void ReaderBase::fgRemoveUnusedBlocks(FlowGraphNode *FgHead,
       fgDeleteBlockAndNodes(Block);
     } else {
       ASSERTNR(fgNodeIsVisited(Block));
-      fgNodeSetState(Block, Undiscovered);
+      fgNodeSetVisited(Block, false);
     }
     Block = NextBlock;
   }
-
-  // Do some verification on the exit block
-  ASSERTNR(Block == FgTail);
-  // if ( !fgNodeIsVisited((FlowGraphNode*)Block)) {
-  // TODO: make common
-  // ASSERTNR( FgCanRemoveLabel(exitLabel(GenIR)));
-  //}
 }
 
 // This code returns the MSIL offset of the "canonical" landing point
@@ -7852,8 +7844,8 @@ void ReaderBase::readBytesForFlowGraphNode(FlowGraphNode *Fg,
 }
 
 FlowGraphNodeWorkList *
-ReaderBase::fgPrependUndiscoveredSuccToWorklist(FlowGraphNodeWorkList *Worklist,
-                                                FlowGraphNode *CurrBlock) {
+ReaderBase::fgPrependUnvisitedSuccToWorklist(FlowGraphNodeWorkList *Worklist,
+                                             FlowGraphNode *CurrBlock) {
   FlowGraphNode *Successor;
 
   for (FlowGraphEdgeList *FgEdge = fgNodeGetSuccessorList(CurrBlock);
@@ -7861,7 +7853,7 @@ ReaderBase::fgPrependUndiscoveredSuccToWorklist(FlowGraphNodeWorkList *Worklist,
 
     Successor = fgEdgeListGetSink(FgEdge);
 
-    if (!fgNodeIsDiscovered(Successor)) {
+    if (!fgNodeIsVisited(Successor)) {
 #ifndef NODEBUG
       // Ensure that no block is on the worklist twice.
       FlowGraphNodeWorkList *DbTemp;
@@ -7878,8 +7870,8 @@ ReaderBase::fgPrependUndiscoveredSuccToWorklist(FlowGraphNodeWorkList *Worklist,
       FlowGraphNodeWorkList *NewBlockList =
           (FlowGraphNodeWorkList *)getTempMemory(sizeof(FlowGraphNodeWorkList));
 
-      // Mark the block as discovered
-      fgNodeSetState(Successor, Discovered);
+      // Mark the block as added to the list
+      fgNodeSetVisited(Successor, true);
 
       // Add the new blockList element to the head of the list.
       NewBlockList->Block = Successor;
@@ -7947,13 +7939,14 @@ void ReaderBase::msilToIR(void) {
   // Notify GenIR we've finsihed building the flow graph
   readerMiddlePass();
 
-  // Iterate over flow graph in reverse postorder.
+  // Iterate over flow graph in depth-first preorder to discover reachable
+  // blocks.
   Worklist =
       (FlowGraphNodeWorkList *)getTempMemory(sizeof(FlowGraphNodeWorkList));
   Worklist->Block = FgHead;
   Worklist->Next = nullptr;
   Worklist->Parent = nullptr;
-  fgNodeSetState(FgHead, Discovered);
+  fgNodeSetVisited(FgHead, true);
 
 // fake up edges to unreachable code for peverify
 // (so we can report errors in unreachable code)
@@ -7989,33 +7982,49 @@ void ReaderBase::msilToIR(void) {
 
   bool IsImportOnly = (Flags & CORJIT_FLG_IMPORT_ONLY) != 0;
 
-  // First compute reverse postorder of the flow graph. Walk the graph in
-  // depth-first order and prepend the node to FlowGraphRPO after all of its
-  // children have been processed.
-  std::list<FlowGraphNode *> FlowGraphRPO;
-
+  // Walk the graph in depth-first order to discover reachable nodes but don't
+  // process them yet. All reachable nodes are marked as visited.
   while (Worklist != nullptr) {
     FlowGraphNode *Block, *Parent;
 
+    // Pop top block
     Block = Worklist->Block;
-    if (fgNodeIsVisited(Block)) {
-      // Push Block to the RPO list and pop it from the worklist.
-      FlowGraphRPO.push_front(Block);
-      Worklist = Worklist->Next;
-      continue;
-    }
+    Worklist = Worklist->Next;
 
-    // Append undiscovered successors to worklist
-    Worklist = fgPrependUndiscoveredSuccToWorklist(Worklist, Block);
-    // Mark the block as visited. It will be prepended to FlowGraphRPO when
-    // it's again on top of the worklist.
-    fgNodeSetState(Block, Visited);
+    // Prepend unvisited successors to worklist
+    Worklist = fgPrependUnvisitedSuccToWorklist(Worklist, Block);
   }
 
-  // Process the nodes in reverse postorder.
-  std::list<FlowGraphNode *>::iterator it = FlowGraphRPO.begin();
+  // Process the blocks in the MSIL offset order. ECMA spec guarantees
+  // that no back edge (in MSIL offset sense) will have a non-empty operand
+  // stack.
 
-  while (it != FlowGraphRPO.end()) {
+  // Compute the MSIL offset order. We are using a list because processing
+  // a block may result in more created blocks that need to be inserted in the
+  // middle of the container.
+  std::list<FlowGraphNode *> FlowGraphMSILOffsetOrder;
+  uint32_t LastInsertedInOrderBlockEndOffset = 0;
+  for (FlowGraphNode *Block = FgHead; Block != nullptr;
+       Block = fgNodeGetNext(Block)) {
+    uint32_t StartOffset = fgNodeGetStartMSILOffset(Block);
+    uint32_t EndOffset = fgNodeGetEndMSILOffset(Block);
+    if (fgNodeIsVisited(Block)) {
+      if (LastInsertedInOrderBlockEndOffset <= StartOffset) {
+        LastInsertedInOrderBlockEndOffset = EndOffset;
+      } else {
+        // This is a block that's not in MSIL offset order.
+        // Assert that this block doesn't propagate operand stack and
+        // doesn't have any msil and, therefore, can be processed out-of-order.
+        ASSERTNR(!fgNodePropagatesOperandStack(Block));
+        ASSERTNR(StartOffset == EndOffset);
+      }
+      FlowGraphMSILOffsetOrder.push_back(Block);
+    }
+  }
+
+  // Process the nodes in MSIL offset order.
+  std::list<FlowGraphNode *>::iterator it = FlowGraphMSILOffsetOrder.begin();
+  while (it != FlowGraphMSILOffsetOrder.end()) {
     FlowGraphNode *CurrentNode = *it;
     readBytesForFlowGraphNode(CurrentNode, IsImportOnly);
 
@@ -8037,15 +8046,17 @@ void ReaderBase::msilToIR(void) {
       if (!fgNodeIsVisited(Successor)) {
         // Check that CurrentNode is the only predecessor of Successor that
         // propagates stack.
-        ASSERT(!fgNodeHasMultiplePredsPropagatingStack(Successor));
+        ASSERTNR(!fgNodeHasMultiplePredsPropagatingStack(Successor));
         ASSERTNR(fgNodePropagatesOperandStack(CurrentNode));
-        // Insert Successor to the RPO list after CurrentNode.
+
+        // The two checks above ensure that it's safe to insert Successor after
+        // CurrentNode even if that breaks MSIL offset order.
         ++it;
-        FlowGraphRPO.insert(it, Successor);
+        FlowGraphMSILOffsetOrder.insert(it, Successor);
         // Point the iterator back to CurrentNode.
         --it;
         --it;
-        fgNodeSetState(Successor, Visited);
+        fgNodeSetVisited(Successor, true);
       }
     }
     ++it;
@@ -8072,7 +8083,7 @@ void ReaderBase::msilToIR(void) {
   }
 
   // Remove blocks that weren't marked as visited.
-  fgRemoveUnusedBlocks(FgHead, FgTail);
+  fgRemoveUnusedBlocks(FgHead);
 
   // Report result of verification to the VM
   if ((Flags & CORJIT_FLG_SKIP_VERIFICATION) == 0) {

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1912,6 +1912,7 @@ IRNode *GenIR::fgMakeEndFinally(IRNode *InsertNode, EHRegion *FinallyRegion,
     uint32_t EndOffset = FinallyRegion->EndMsilOffset;
     fgNodeSetStartMSILOffset(TargetNode, EndOffset);
     fgNodeSetEndMSILOffset(TargetNode, EndOffset);
+    fgNodeSetPropagatesOperandStack(TargetNode, false);
   }
 
   // Generate and return branch to the block that holds the switch
@@ -2043,16 +2044,12 @@ ReaderStack *GenIR::fgNodeGetOperandStack(FlowGraphNode *Fg) {
   return FlowGraphInfoMap[Fg].TheReaderStack;
 }
 
-bool GenIR::fgNodeIsDiscovered(FlowGraphNode *Fg) {
-  return FlowGraphInfoMap[Fg].State != Undiscovered;
-}
-
 bool GenIR::fgNodeIsVisited(FlowGraphNode *Fg) {
-  return FlowGraphInfoMap[Fg].State == Visited;
+  return FlowGraphInfoMap[Fg].IsVisited;
 }
 
-void GenIR::fgNodeSetState(FlowGraphNode *Fg, FlowGraphNodeState State) {
-  FlowGraphInfoMap[Fg].State = State;
+void GenIR::fgNodeSetVisited(FlowGraphNode *Fg, bool Visited) {
+  FlowGraphInfoMap[Fg].IsVisited = Visited;
 }
 
 // Check whether this node propagates operand stack.
@@ -4479,6 +4476,8 @@ uint32_t GenIR::updateLeaveOffset(EHRegion *Region, uint32_t LeaveOffset,
         UnreachableContinuationBlock =
             BasicBlock::Create(Context, "NullDefault", Function);
         new UnreachableInst(Context, UnreachableContinuationBlock);
+        fgNodeSetPropagatesOperandStack(
+            (FlowGraphNode *)UnreachableContinuationBlock, false);
       }
 
       LoadInst *Load = new LoadInst(SelectorAddr);


### PR DESCRIPTION
This is necessary to compute PHI types before processing their blocks.
ECMA-335 guarantees empty operand stacks on MSIL offset back edges.

Update the reader document.
