### PR TITLE
Precise GC: Bail early on managed aggregates

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1090,7 +1090,9 @@ private:
 
   llvm::PointerType *getUnmanagedPointerType(llvm::Type *ElementType);
 
-  bool isManagedPointerType(llvm::PointerType *PointerType);
+  bool isManagedType(llvm::Type *Type);
+  bool isManagedPointerType(llvm::Type *Type);
+  bool isManagedAggregateType(llvm::Type *Type);
 
   llvm::StoreInst *makeStore(llvm::Value *ValueToStore, llvm::Value *Address,
                              bool IsVolatile, bool AddressMayBeNull = true);


### PR DESCRIPTION
Precise GC using statepoints cannot handle aggregates that contain
managed pointers yet. (Issue #33)

So, this change adds a check to the reader-postpass, which scans the
generated IR if it contains values of managed-aggregate type.
If so, the compilation fails gracefully by throwing a NYI exception.

This check in ReaderIr.cpp is based on the assertion checks in
[RewriteStatepointsForGC.cpp](https://github.com/Microsoft/llvm/blob/master/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp).

[Issue #32]
