### PR TITLE
Update test case exclusion after adding GC test cases in CoreCLR

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -826,16 +826,38 @@ function Global:ApplyFilter([string]$File)
 
 function Global:ExcludeTest([string]$Arch="x64", [string]$Build="Release")
 {
-  # Excluding Interop\ICastable\Castable*"
+  # Excluding Interop\ICastable\Castable*
   # remove ICastable until it can be debugged
   pushd $CoreCLRTest\Interop\ICastable
   del Castable*
   popd
 
-  # Excluding JIT\CodeGenBringUpTests\div2*,localloc*"
+  # Excluding JIT\CodeGenBringUpTests\div2*,localloc*
   pushd $CoreCLRTest\JIT\CodeGenBringUpTests
   del div2*
   del localloc*
+  popd
+
+  # Excluding JIT\jit64\gc\misc\eh1*,funclet*,fgtest1*,
+  # struct6_5*,struct7_1*,structfpseh5_1*,structfpseh6_1*,
+  # structret6_1*,structret6_2*,structret6_3*
+  pushd $CoreCLRTest\JIT\jit64\gc\misc
+  del eh1*
+  del funclet*
+  del fgtest1*
+  del struct6_5*
+  del struct7_1*
+  del structfpseh5_1*
+  del structfpseh6_1*
+  del structret6_1*
+  del structret6_2*
+  del structret6_3*
+  popd
+
+  # Excluding JIT\jit64\gc\regress\vswhidbey\339415*,143837*
+  pushd $CoreCLRTest\JIT\jit64\gc\regress\vswhidbey
+  del 339415*
+  del 143837*
   popd
 }
 

--- a/test/exclusion
+++ b/test/exclusion
@@ -5,3 +5,15 @@ Common;Exceptions;GC;Loader;managed;packages;Regressions;runtime;Tests;TestWrapp
 Interop\ICastable\Castable
 JIT\CodeGenBringUpTests\div2
 JIT\CodeGenBringUpTests\localloc
+JIT\jit64\gc\misc\eh1
+JIT\jit64\gc\misc\funclet
+JIT\jit64\gc\misc\fgtest1
+JIT\jit64\gc\misc\struct6_5
+JIT\jit64\gc\misc\struct7_1
+JIT\jit64\gc\misc\structfpseh5_1
+JIT\jit64\gc\misc\structfpseh6_1
+JIT\jit64\gc\misc\structret6_1
+JIT\jit64\gc\misc\structret6_2
+JIT\jit64\gc\misc\structret6_3
+JIT\jit64\gc\regress\vswhidbey\339415
+JIT\jit64\gc\regress\vswhidbey\143837


### PR DESCRIPTION
83 GC related test cases were just added to CoreCLR repository.
12 of them cannot run with LLILC at this point. Exclude them for now.
Exclusion is added in both powershell script and python script.
Passed verification with llilc_test.

Also added newline at the end of exclusion file.
