### PR TITLE
Fix some wide string issues in JIT options.

### DIFF
--- a/include/Jit/utility.h
+++ b/include/Jit/utility.h
@@ -107,10 +107,11 @@ private:
   std::list<MethodName> *MethodList = nullptr;
 };
 
-/// \brief Class implementing a platform independent wchar_t to utf8.
+/// \brief Class implementing miscellaneous conversion functions.
 class Convert {
 public:
-  static std::unique_ptr<std::string> wideToUtf8(const wchar_t *wideStr);
+  /// Convert a UTF-16 string to a UTF-8 string.
+  static std::unique_ptr<std::string> utf16ToUtf8(const char16_t *wideStr);
 };
 
 #endif // UTILITY_H

--- a/lib/Jit/utility.cpp
+++ b/lib/Jit/utility.cpp
@@ -43,8 +43,13 @@ bool MethodSet::contains(const char *Name, const char *ClassName,
   return false;
 }
 
-std::unique_ptr<std::string> Convert::wideToUtf8(const wchar_t *WideStr) {
-  ArrayRef<char> SrcBytes((const char *)WideStr, (2 * wcslen(WideStr)));
+std::unique_ptr<std::string> Convert::utf16ToUtf8(const char16_t *WideStr) {
+  // Get the length of the input
+  size_t SrcLen = 0;
+  for (; WideStr[SrcLen] != (char16_t)0; SrcLen++)
+    ;
+
+  ArrayRef<char> SrcBytes((const char *)WideStr, 2 * SrcLen);
   std::unique_ptr<std::string> OutString(new std::string);
   llvm::convertUTF16ToUTF8String(SrcBytes, *OutString);
 


### PR DESCRIPTION
On *Nix platforms, a `wchar_t` is actually a UTF-32 codepoint; on Windows,
it is a UTF-16 codepoint. Thus, when the CLR headers say `wchar_t`, what
they actually mean is `char16_t`. Fix the JIT options code to deal in
UTF-16 strings on all platforms.