### PR TITLE
Move initial capacity calculation into createStack

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2845,7 +2845,7 @@ public:
   methodNeedsToKeepAliveGenericsContext(bool KeepGenericsCtxtAlive) = 0;
 
   // Called to instantiate an empty reader stack.
-  virtual ReaderStack *createStack(uint32_t MaxStack, ReaderBase *Reader) = 0;
+  virtual ReaderStack *createStack() = 0;
 
   // Called when reader begins processing method.
   virtual void readerPrePass(uint8_t *Buffer, uint32_t NumBytes) = 0;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -505,7 +505,7 @@ public:
   methodNeedsToKeepAliveGenericsContext(bool KeepGenericsCtxtAlive) override;
 
   // Called to instantiate an empty reader stack.
-  ReaderStack *createStack(uint32_t MaxStack, ReaderBase *Reader) override;
+  ReaderStack *createStack() override;
 
   // Called when reader begins processing method.
   void readerPrePass(uint8_t *Buf, uint32_t NumBytes) override;

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -7939,9 +7939,7 @@ void ReaderBase::msilToIR(void) {
 #endif
 
   // Set up the initial stack
-  ReaderOperandStack = createStack(
-      std::min(MethodInfo->maxStack, std::min(100u, MethodInfo->ILCodeSize)),
-      this);
+  ReaderOperandStack = createStack();
   ASSERTNR(ReaderOperandStack);
   fgNodeSetOperandStack(FgHead, ReaderOperandStack);
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -80,10 +80,12 @@ ReaderStack *GenStack::copy() {
   return Copy;
 }
 
-ReaderStack *GenIR::createStack(uint32_t MaxStack, ReaderBase *Reader) {
-  void *Buffer = Reader->getTempMemory(sizeof(GenStack));
+ReaderStack *GenIR::createStack() {
+  uint32_t MaxStack =
+      std::min(MethodInfo->maxStack, std::min(100U, MethodInfo->ILCodeSize));
+  void *Buffer = getTempMemory(sizeof(GenStack));
   // extra 16 should reduce frequency of reallocation when inlining / jmp
-  return new (Buffer) GenStack(MaxStack + 16, Reader);
+  return new (Buffer) GenStack(MaxStack + 16, this);
 }
 
 #pragma endregion
@@ -5412,10 +5414,7 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
         // We need to create a new stack for the Successor and populate it
         // with PHI instructions corresponding to the values on the current
         // stack.
-        SuccessorStack =
-            createStack(std::min(MethodInfo->maxStack,
-                                 std::min(100U, MethodInfo->ILCodeSize)),
-                        this);
+        SuccessorStack = createStack();
         fgNodeSetOperandStack(SuccessorBlock, SuccessorStack);
         CreatePHIs = true;
       }


### PR DESCRIPTION
We were using the same calculation at all callsites, so just remove the
parameter and do the calculation in the method itself; this simplifies
adding new callsites.

Also remove the ReaderBase parameter, since it's always the same as the
instance pointer.