### PR TITLE
Allow explicit offset argument to createPointBlock

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -935,13 +935,30 @@ private:
   ///
   /// Use this method to create a block when expanding a single MSIL
   /// instruction into an instruction sequence with control flow. Give the
+  /// block the given MSIL offset at both begin and end since it represents
+  /// code at a single point in the IL stream. Mark the block as not
+  /// contributing an operand stack to any subsequent join.
+  ///
+  /// \param PointOffset       MSIL offset the block starts and ends at.
+  /// \param BlockName         Optional name for the new block.
+  /// \returns                 Newly allocated block.
+  llvm::BasicBlock *createPointBlock(uint32_t PointOffset,
+                                     const llvm::Twine &BlockName = "");
+
+  /// \brief Create a basic block for use when expanding a single MSIL
+  /// instruction.
+  ///
+  /// Use this method to create a block when expanding a single MSIL
+  /// instruction into an instruction sequence with control flow. Give the
   /// block the current MSIL offset at both begin and end since it represents
   /// code at a single point in the IL stream. Mark the block as not
   /// contributing an operand stack to any subsequent join.
   ///
   /// \param BlockName         Optional name for the new block.
   /// \returns                 Newly allocated block.
-  llvm::BasicBlock *createPointBlock(const llvm::Twine &BlockName = "");
+  llvm::BasicBlock *createPointBlock(const llvm::Twine &BlockName = "") {
+    return createPointBlock(CurrInstrOffset, BlockName);
+  }
 
   /// \brief Insert a conditional branch to a point block.
   ///

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -4738,16 +4738,16 @@ BasicBlock *GenIR::createPointBlock(const Twine &BlockName) {
   BasicBlock *Block =
       BasicBlock::Create(*JitContext->LLVMContext, BlockName, Function);
 
-  // Give the call block equal start and end offsets so subsequent processing
+  // Give the point block equal start and end offsets so subsequent processing
   // won't try to translate MSIL into it.
-  FlowGraphNode *CallFlowGraphNode = (FlowGraphNode *)Block;
-  fgNodeSetStartMSILOffset(CallFlowGraphNode, CurrInstrOffset);
-  fgNodeSetEndMSILOffset(CallFlowGraphNode, CurrInstrOffset);
+  FlowGraphNode *PointFlowGraphNode = (FlowGraphNode *)Block;
+  fgNodeSetStartMSILOffset(PointFlowGraphNode, CurrInstrOffset);
+  fgNodeSetEndMSILOffset(PointFlowGraphNode, CurrInstrOffset);
 
   // Point blocks don't need an operand stack: they don't have any MSIL and
   // any successor block will get the stack propagated from the other
   // predecessor.
-  fgNodeSetPropagatesOperandStack(CallFlowGraphNode, false);
+  fgNodeSetPropagatesOperandStack(PointFlowGraphNode, false);
 
   return Block;
 }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -4734,15 +4734,16 @@ IRNode *GenIR::derefAddress(IRNode *Address, bool DstIsGCPtr, bool IsConst,
 // Create an empty block to hold IR for some conditional instructions at a
 // particular point in the MSIL (conditional LLVM instructions that are part
 // of the expansion of a single MSIL instruction)
-BasicBlock *GenIR::createPointBlock(const Twine &BlockName) {
+BasicBlock *GenIR::createPointBlock(uint32_t PointOffset,
+                                    const Twine &BlockName) {
   BasicBlock *Block =
       BasicBlock::Create(*JitContext->LLVMContext, BlockName, Function);
 
   // Give the point block equal start and end offsets so subsequent processing
   // won't try to translate MSIL into it.
   FlowGraphNode *PointFlowGraphNode = (FlowGraphNode *)Block;
-  fgNodeSetStartMSILOffset(PointFlowGraphNode, CurrInstrOffset);
-  fgNodeSetEndMSILOffset(PointFlowGraphNode, CurrInstrOffset);
+  fgNodeSetStartMSILOffset(PointFlowGraphNode, PointOffset);
+  fgNodeSetEndMSILOffset(PointFlowGraphNode, PointOffset);
 
   // Point blocks don't need an operand stack: they don't have any MSIL and
   // any successor block will get the stack propagated from the other


### PR DESCRIPTION
This allows creating point blocks for points other than CurrInstrOffset.