### PR TITLE
Preserve stack-propagating-ness in fgSplitBlock

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1888,6 +1888,7 @@ void GenIR::fgNodeSetEndMSILOffset(FlowGraphNode *Fg, uint32_t Offset) {
 FlowGraphNode *GenIR::fgSplitBlock(FlowGraphNode *Block, IRNode *Node) {
   Instruction *Inst = (Instruction *)Node;
   BasicBlock *TheBasicBlock = (BasicBlock *)Block;
+  bool PropagatesStack = fgNodePropagatesOperandStack(Block);
   BasicBlock *NewBlock;
   if (Inst == nullptr) {
     NewBlock = BasicBlock::Create(*JitContext->LLVMContext, "", Function,
@@ -1923,6 +1924,7 @@ FlowGraphNode *GenIR::fgSplitBlock(FlowGraphNode *Block, IRNode *Node) {
       BranchInst::Create(NewBlock, TheBasicBlock);
     }
   }
+  fgNodeSetPropagatesOperandStack((FlowGraphNode *)NewBlock, PropagatesStack);
   return (FlowGraphNode *)NewBlock;
 }
 


### PR DESCRIPTION
If we're splitting a block that we've already marked as not propagating
stack (i.e. a point block), preserve that annotation on the newly-created
tail block (since it represents the same flow point as exit from the
original block).  The bit is left set on the original block (which becomes
the head); it's up to the caller to know why it's splitting the block here
and whether stack is propagated at this split point.