### PR TITLE
Annotate root region as covering entire method

### DIFF
--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -1679,6 +1679,7 @@ void ReaderBase::rgnCreateRegionTree(void) {
 
   RegionTreeRoot = rgnMakeRegion(ReaderBaseNS::RGN_Root, nullptr,
                                  RegionTreeRoot, &AllRegionList);
+  rgnSetEndMSILOffset(RegionTreeRoot, MethodInfo->ILCodeSize);
   RegionTree = RegionTreeRoot;
 
   // Map the clause information into try regions for later processing


### PR DESCRIPTION
Without this, we were leaving its start and end offsets both set to zero,
which makes it appear not to contain its children and confuses things.