### PR TITLE
Add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ build/
 *.log
 *.scc
 
+# Python cache
+__pycache__
+
 # Visual C++ cache files
 ipch/
 *.aps


### PR DESCRIPTION
Python creates test/__pycache__ as a side-effect of running
test/llilc_runtests.py.