### PR TITLE
Fix a number of warnings from clang.

### DIFF
--- a/include/Pal/LLILCPal.h
+++ b/include/Pal/LLILCPal.h
@@ -157,8 +157,10 @@ extern "C" {
 
 #define UNALIGNED
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(BIT64)
 #define __cdecl __attribute__((cdecl))
+#else
+#define __cdecl
 #endif
 
 #define PALIMPORT EXTERN_C

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -232,7 +232,7 @@ struct RuntimeFilterParams {
 /// actually has GC pointers, so \p NumGCPtrs should be nonzero.
 struct GCLayout {
   uint32_t NumGCPointers; ///< Total number of gc pointers to report
-  uint8_t GCPointers[0];  ///< Array indicating location of the gc pointers
+  uint8_t GCPointers[1];  ///< Array indicating location of the gc pointers
 };
 
 /// \brief Structure that encapsulates type information for the values passed to

--- a/include/clr/ntimage.h
+++ b/include/clr/ntimage.h
@@ -1367,7 +1367,7 @@ typedef struct _IMAGE_RESOURCE_DIRECTORY_ENTRY {
         struct {
             ULONG NameOffset:31;
             ULONG NameIsString:1;
-        };
+        } NameInfo;
         ULONG   Name;
         USHORT  Id;
     };
@@ -1376,7 +1376,7 @@ typedef struct _IMAGE_RESOURCE_DIRECTORY_ENTRY {
         struct {
             ULONG   OffsetToDirectory:31;
             ULONG   DataIsDirectory:1;
-        };
+        } DirectoryInfo;
     };
 } IMAGE_RESOURCE_DIRECTORY_ENTRY, *PIMAGE_RESOURCE_DIRECTORY_ENTRY;
 


### PR DESCRIPTION
- Remove unused __cdecl attributes where necessary
- Change a zero-sized array to a one-sized array; 0-sized arrays are not
  standard C++
- Give names to two anonymous structs in ntimage.h