### PR TITLE
Allow blocks to have zero stack-propagating preds

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2714,6 +2714,13 @@ public:
   /// propagate operand stack.
   bool fgNodeHasMultiplePredsPropagatingStack(FlowGraphNode *Node);
 
+  /// Check whether this node has any predecessors that propagate operand stack.
+  ///
+  /// \param Node Flow graph node.
+  /// \returns true iff this flow graph node has any predecessors that propagate
+  /// operand stack.
+  bool fgNodeHasNoPredsPropagatingStack(FlowGraphNode *Node);
+
   virtual IRNode *
   getStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken) = 0;
   virtual void initBlk(IRNode *NumBytes, IRNode *ValuePerByte,

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -8010,7 +8010,8 @@ void ReaderBase::msilToIR(void) {
         // Check that CurrentNode is the only predecessor of Successor that
         // propagates stack.
         ASSERTNR(!fgNodeHasMultiplePredsPropagatingStack(Successor));
-        ASSERTNR(fgNodePropagatesOperandStack(CurrentNode));
+        ASSERTNR(fgNodePropagatesOperandStack(CurrentNode) ||
+                 fgNodeHasNoPredsPropagatingStack(Successor));
 
         // The two checks above ensure that it's safe to insert Successor after
         // CurrentNode even if that breaks MSIL offset order.
@@ -8083,6 +8084,20 @@ bool ReaderBase::fgNodeHasMultiplePredsPropagatingStack(FlowGraphNode *Node) {
     }
   }
   return false;
+}
+
+bool ReaderBase::fgNodeHasNoPredsPropagatingStack(FlowGraphNode *Node) {
+  for (FlowGraphEdgeList *NodePredecessorList =
+           fgNodeGetPredecessorListActual(Node);
+       NodePredecessorList != nullptr;
+       NodePredecessorList =
+           fgEdgeListGetNextPredecessorActual(NodePredecessorList)) {
+    FlowGraphNode *PredecessorNode = fgEdgeListGetSource(NodePredecessorList);
+    if (fgNodePropagatesOperandStack(PredecessorNode)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 // Checks to see if a given offset is the start of an instruction. If

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -5397,15 +5397,20 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
     FlowGraphNode *SuccessorBlock = fgEdgeListGetSink(SuccessorList);
 
     if (!fgNodeHasMultiplePredsPropagatingStack(SuccessorBlock)) {
-      // The current node is the only relevant predecessor of this Successor.
-      ASSERTNR(fgNodePropagatesOperandStack(CurrentBlock));
       // We need to create a stack for the Successor and copy the items from the
       // current stack.
       if (!fgNodePropagatesOperandStack(SuccessorBlock)) {
         // This successor block doesn't need a stack. This is a common case for
         // implicit exception throw blocks or conditional helper calls.
       } else {
-        fgNodeSetOperandStack(SuccessorBlock, ReaderOperandStack->copy());
+        // The current node is the only relevant predecessor of this Successor.
+        if (fgNodePropagatesOperandStack(CurrentBlock)) {
+          fgNodeSetOperandStack(SuccessorBlock, ReaderOperandStack->copy());
+        } else {
+          // The successor block starts with empty stack.
+          assert(fgNodeHasNoPredsPropagatingStack(SuccessorBlock));
+          fgNodeSetOperandStack(SuccessorBlock, createStack());
+        }
       }
     } else {
       ReaderStack *SuccessorStack = fgNodeGetOperandStack(SuccessorBlock);


### PR DESCRIPTION
Update `maintainOperandStacks` and new block processing in `msilToIR` to
accomodate this.  Some EH-related blocks will have only exception dispatch
point blocks as predecessors.