### PR TITLE
Separate options for ConservativeGC and Inserting Safepoints

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -241,7 +241,7 @@ public:
 
   /// \name CoreCLR GC information
   //@{
-  bool ShouldUseConservativeGC; ///< Whether the GC is conservative/precise
+  bool ShouldInsertStatepoints; ///< Whether to insert gc.statepoint intrinsics
   //@}
 
 private:

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -71,6 +71,12 @@ bool shouldUseConservativeGC() {
   return (LevelCStr != nullptr) && (strcmp(LevelCStr, "1") == 0);
 }
 
+// Determine if GC statepoints should be inserted.
+bool shouldInsertStatepoints() {
+  const char *LevelCStr = getenv("COMPLUS_INSERTSTATEPOINTS");
+  return (LevelCStr != nullptr) && (strcmp(LevelCStr, "1") == 0);
+}
+
 // The one and only Jit Object.
 LLILCJit *LLILCJit::TheJit = nullptr;
 
@@ -102,7 +108,9 @@ LLILCJit::LLILCJit() {
   InitializeNativeTargetAsmParser();
   llvm::linkStatepointExampleGC();
 
-  ShouldUseConservativeGC = shouldUseConservativeGC();
+  ShouldInsertStatepoints = shouldInsertStatepoints();
+  assert(ShouldInsertStatepoints ||
+         shouldUseConservativeGC() && "Statepoints required for precise-GC");
 }
 
 #ifdef LLVM_ON_WIN32
@@ -227,7 +235,7 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
 
   if (HasMethod) {
 
-    if (!ShouldUseConservativeGC) {
+    if (ShouldInsertStatepoints) {
       // If using Precise GC, run the GC-Safepoint insertion
       // and lowering passes before generating code.
       legacy::PassManager Passes;

--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -238,7 +238,7 @@ Function *ABIMethodSignature::createFunction(GenIR &Reader, Module &M) {
   }
   F->setCallingConv(CC);
 
-  if (!LLILCJit::TheJit->ShouldUseConservativeGC) {
+  if (LLILCJit::TheJit->ShouldInsertStatepoints) {
     F->setGC("statepoint-example");
   }
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -277,7 +277,7 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
     ASSERTNR(UNREACHED);
   }
 
-  if (!LLILCJit::TheJit->ShouldUseConservativeGC) {
+  if (LLILCJit::TheJit->ShouldInsertStatepoints) {
     createSafepointPoll();
   }
 
@@ -429,7 +429,7 @@ void GenIR::readerPostPass(bool IsImportOnly) {
     insertIRForSecurityObject();
   }
 
-  if (!LLILCJit::TheJit->ShouldUseConservativeGC) {
+  if (LLILCJit::TheJit->ShouldInsertStatepoints) {
 
     // Precise GC using statepoints cannot handle aggregates that contain
     // managed pointers yet. So, check if this function deals with such values


### PR DESCRIPTION
CoreCLR's COMPLUS_GCCONSERVATIVE flag tells the runtime to use
conservative when set. LLILC also used this flag to determine whether
the insertion and lowering of statepoint intrinsics are done.

With this change, steatpoints are inserted if the COMPLUS_INSERTSTATEPOINTS
switch is set, regardless of the COMPLUS_GCCONSERVATIVE flag.
This allows testing of LLILC Jit with statepoints inserted. That is, to
check that the code itself is still correct, regardless of the GC information.

Issue #32 