### PR TITLE
Disable symbol searching.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -216,6 +216,8 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
     return CORJIT_INTERNALERROR;
   }
 
+  // Don't allow the EE to search for external symbols.
+  NewEngine->DisableSymbolSearching();
   Context.EE = NewEngine;
 
   // Now jit the method.


### PR DESCRIPTION
We don't want the LLVM dynamic loader to try and resolve external symbols by name. As things stand today, if jitted code contains external symbol references we have a bug in the jit.

This anticipates a change I'm about to make in LLVM where I enable the ability to resolve externals by name for x64 COFF RtDyld, since other LLVM clients need this.

Once both changes are in we'll get a somewhat clearer error message when Jitted code has an unsat, e.g.

`LLVM ERROR: Program used external function '__chkstk' which could not be resolved!`