### PR TITLE
Fix for using namespace llvm inside header file

### DIFF
--- a/include/Jit/utility.h
+++ b/include/Jit/utility.h
@@ -23,8 +23,6 @@
 #include "llvm/Support/Atomic.h"
 #include "llvm/Config/llvm-config.h"
 
-using namespace llvm;
-
 /// \brief MethodName struct representing a particular method on a type.
 ///
 /// MethodNames are the elements of MethodSet and are used to do filtering of
@@ -87,8 +85,8 @@ public:
 
     // This write should be atomic, delete if we're not the first.
 
-    sys::cas_flag Value =
-        sys::CompareAndSwap((sys::cas_flag *)&(this->Initialized), 0x1, 0x0);
+    llvm::sys::cas_flag Value = llvm::sys::CompareAndSwap(
+        (llvm::sys::cas_flag *)&(this->Initialized), 0x1, 0x0);
 
     if (Value != 0x0) {
       delete ML;

--- a/lib/Jit/utility.cpp
+++ b/lib/Jit/utility.cpp
@@ -18,6 +18,8 @@
 #include "utility.h"
 #include "llvm/Support/ConvertUTF.h"
 
+using namespace llvm;
+
 // Checks given parsed representation to see if method is in the set.
 
 bool MethodSet::contains(const char *Name, const char *ClassName,
@@ -51,7 +53,7 @@ std::unique_ptr<std::string> Convert::utf16ToUtf8(const char16_t *WideStr) {
 
   ArrayRef<char> SrcBytes((const char *)WideStr, 2 * SrcLen);
   std::unique_ptr<std::string> OutString(new std::string);
-  llvm::convertUTF16ToUTF8String(SrcBytes, *OutString);
+  convertUTF16ToUTF8String(SrcBytes, *OutString);
 
   return OutString;
 }


### PR DESCRIPTION
When including the header file for other purpose, this caused ambiguous name conflicts for other types.
By convention, I moved it to cpp file where it is used.