### PR TITLE
Add makeCall wrapper

### DIFF
--- a/include/Reader/abisignature.h
+++ b/include/Reader/abisignature.h
@@ -68,13 +68,14 @@ public:
   /// \param Reader           The \p GenIR instance that will be used to emit
   ///                         IR.
   /// \param Target           The call target.
+  /// \param MayThrow         True iff the callee may raise an exception
   /// \param Args             The arguments to the call.
   /// \param IndirectionCell  The indirection cell argument for the call, if
   ///                         any.
   /// \param CallNode [out]   The call instruction.
   ///
   /// \returns The result of the call to the target.
-  llvm::Value *emitCall(GenIR &Reader, llvm::Value *Target,
+  llvm::Value *emitCall(GenIR &Reader, llvm::Value *Target, bool mayThrow,
                         llvm::ArrayRef<llvm::Value *> Args,
                         llvm::Value *IndirectionCell,
                         llvm::Value **CallNode) const;

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -3134,15 +3134,16 @@ public:
                                       IRNode *ThisArg) = 0;
 
   // Helper callback used by rdrCall to emit call code.
-  virtual IRNode *genCall(ReaderCallTargetData *CallTargetData,
+  virtual IRNode *genCall(ReaderCallTargetData *CallTargetData, bool MayThrow,
                           std::vector<IRNode *> Args, IRNode **CallNode) = 0;
 
   virtual bool canMakeDirectCall(ReaderCallTargetData *CallTargetData) = 0;
 
   // Generate call to helper
-  virtual IRNode *callHelper(CorInfoHelpFunc HelperID, IRNode *Dst,
-                             IRNode *Arg1 = nullptr, IRNode *Arg2 = nullptr,
-                             IRNode *Arg3 = nullptr, IRNode *Arg4 = nullptr,
+  virtual IRNode *callHelper(CorInfoHelpFunc HelperID, bool MayThrow,
+                             IRNode *Dst, IRNode *Arg1 = nullptr,
+                             IRNode *Arg2 = nullptr, IRNode *Arg3 = nullptr,
+                             IRNode *Arg4 = nullptr,
                              ReaderAlignType Alignment = Reader_AlignUnknown,
                              bool IsVolatile = false, bool NoCtor = false,
                              bool CanMoveUp = false) = 0;

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -410,10 +410,11 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
       Value *Condition = LLVMBuilder->CreateIsNotNull(JustMyCodeFlag, "JMC");
       IRNode *Zero = loadConstantI4(0);
       Type *Void = Type::getVoidTy(*JitContext->LLVMContext);
+      const bool MayThrow = false;
       const bool CallReturns = true;
       genConditionalHelperCall(
-          Condition, CorInfoHelpFunc::CORINFO_HELP_DBG_IS_JUST_MY_CODE, Void,
-          JustMyCodeFlag, Zero, CallReturns, "JustMyCodeHook");
+          Condition, CorInfoHelpFunc::CORINFO_HELP_DBG_IS_JUST_MY_CODE,
+          MayThrow, Void, JustMyCodeFlag, Zero, CallReturns, "JustMyCodeHook");
     }
   }
 
@@ -510,7 +511,8 @@ void GenIR::insertIRToKeepGenericContextAlive() {
   Value *FrameEscape = Intrinsic::getDeclaration(JitContext->CurrentModule,
                                                  Intrinsic::frameescape);
   Value *Args[] = {ContextLocalAddress};
-  LLVMBuilder->CreateCall(FrameEscape, Args);
+  const bool MayThrow = false;
+  makeCall(FrameEscape, MayThrow, Args);
   // Don't move TempInsertionPoint up since what we added was not an alloca
   LLVMBuilder->restoreIP(SavedInsertPoint);
 
@@ -545,7 +547,8 @@ void GenIR::insertIRForSecurityObject() {
                                       IsIndirect, IsRelocatable, IsCallTarget);
   CorInfoHelpFunc SecurityHelper =
       JitContext->JitInfo->getSecurityPrologHelper(MethodHandle);
-  callHelper(SecurityHelper, nullptr, MethodNode,
+  const bool MayThrow = true;
+  callHelper(SecurityHelper, MayThrow, nullptr, MethodNode,
              (IRNode *)SecurityObjectAddress);
 
   LLVMBuilder->restoreIP(SavedInsertPoint);
@@ -566,7 +569,8 @@ void GenIR::callMonitorHelper(bool IsEnter) {
   } else {
     HelperId = IsEnter ? CORINFO_HELP_MON_ENTER : CORINFO_HELP_MON_EXIT;
   }
-  callHelperImpl(HelperId, Type::getVoidTy(*JitContext->LLVMContext),
+  const bool MayThrow = false;
+  callHelperImpl(HelperId, MayThrow, Type::getVoidTy(*JitContext->LLVMContext),
                  MethodSyncHandle, (IRNode *)SyncFlag);
 }
 
@@ -2499,13 +2503,17 @@ IRNode *GenIR::binaryOp(ReaderBaseNS::BinaryOpcode Opcode, IRNode *Arg1,
       llvm_unreachable("Bad floating point type!");
     }
 
-    Result = callHelperImpl(Helper, ResultType, Arg1, Arg2);
+    const bool MayThrow = false;
+    Result = (IRNode *)callHelperImpl(Helper, MayThrow, ResultType, Arg1, Arg2)
+                 .getInstruction();
   } else if (IsOverflow) {
     // Call the appropriate intrinsic.  Its result is a pair of the arithmetic
     // result and a bool indicating whether the operation overflows.
     Value *Intrinsic = Intrinsic::getDeclaration(
         JitContext->CurrentModule, Triple[Opcode].Op.Intrinsic, ResultType);
-    Value *Pair = LLVMBuilder->CreateCall2(Intrinsic, Arg1, Arg2);
+    Value *Args[] = {Arg1, Arg2};
+    const bool MayThrow = false;
+    Value *Pair = makeCall(Intrinsic, MayThrow, Args).getInstruction();
 
     // Extract the bool and raise an overflow exception if set.
     Value *OvfBool = LLVMBuilder->CreateExtractValue(Pair, 1, "Ovf");
@@ -3067,6 +3075,13 @@ LoadInst *GenIR::makeLoad(Value *Address, bool IsVolatile,
   return LLVMBuilder->CreateLoad(Address, IsVolatile);
 }
 
+CallSite GenIR::makeCall(Value *Callee, bool MayThrow, ArrayRef<Value *> Args) {
+  if (MayThrow) {
+    // TODO: Generate an invoke with an appropriate unwind label.
+  }
+  return LLVMBuilder->CreateCall(Callee, Args);
+}
+
 void GenIR::storeStaticField(CORINFO_RESOLVED_TOKEN *FieldToken,
                              IRNode *ValueToStore, bool IsVolatile) {
   // Gather information about the field
@@ -3233,8 +3248,10 @@ IRNode *GenIR::loadElemA(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Index,
   if (!IsReadOnly && ((ClassAttribs & CORINFO_FLG_VALUECLASS) == 0)) {
     IRNode *HandleNode = genericTokenToNode(ResolvedToken);
     PointerType *ElementAddressTy = getManagedPointerType(ElementTy);
-    return callHelperImpl(CORINFO_HELP_LDELEMA_REF, ElementAddressTy, Array,
-                          Index, HandleNode);
+    const bool MayThrow = true;
+    return (IRNode *)callHelperImpl(CORINFO_HELP_LDELEMA_REF, MayThrow,
+                                    ElementAddressTy, Array, Index,
+                                    HandleNode).getInstruction();
   }
 
   return genArrayElemAddress(Array, Index, ElementTy);
@@ -3402,21 +3419,23 @@ bool isNonVolatileWriteHelperCall(CorInfoHelpFunc HelperId) {
 }
 
 // Generate call to helper
-IRNode *GenIR::callHelper(CorInfoHelpFunc HelperID, IRNode *Dst, IRNode *Arg1,
-                          IRNode *Arg2, IRNode *Arg3, IRNode *Arg4,
-                          ReaderAlignType Alignment, bool IsVolatile,
-                          bool NoCtor, bool CanMoveUp) {
+IRNode *GenIR::callHelper(CorInfoHelpFunc HelperID, bool MayThrow, IRNode *Dst,
+                          IRNode *Arg1, IRNode *Arg2, IRNode *Arg3,
+                          IRNode *Arg4, ReaderAlignType Alignment,
+                          bool IsVolatile, bool NoCtor, bool CanMoveUp) {
   LLVMContext &LLVMContext = *this->JitContext->LLVMContext;
   Type *ReturnType =
       (Dst == nullptr) ? Type::getVoidTy(LLVMContext) : Dst->getType();
-  return callHelperImpl(HelperID, ReturnType, Arg1, Arg2, Arg3, Arg4, Alignment,
-                        IsVolatile, NoCtor, CanMoveUp);
+  return (IRNode *)callHelperImpl(HelperID, MayThrow, ReturnType, Arg1, Arg2,
+                                  Arg3, Arg4, Alignment, IsVolatile, NoCtor,
+                                  CanMoveUp).getInstruction();
 }
 
-IRNode *GenIR::callHelperImpl(CorInfoHelpFunc HelperID, Type *ReturnType,
-                              IRNode *Arg1, IRNode *Arg2, IRNode *Arg3,
-                              IRNode *Arg4, ReaderAlignType Alignment,
-                              bool IsVolatile, bool NoCtor, bool CanMoveUp) {
+CallSite GenIR::callHelperImpl(CorInfoHelpFunc HelperID, bool MayThrow,
+                               Type *ReturnType, IRNode *Arg1, IRNode *Arg2,
+                               IRNode *Arg3, IRNode *Arg4,
+                               ReaderAlignType Alignment, bool IsVolatile,
+                               bool NoCtor, bool CanMoveUp) {
   ASSERT(HelperID != CORINFO_HELP_UNDEF);
 
   // TODO: We can turn some of these helper calls into intrinsics.
@@ -3463,7 +3482,7 @@ IRNode *GenIR::callHelperImpl(CorInfoHelpFunc HelperID, Type *ReturnType,
 
   // This is an intermediate result. Callers must handle
   // transitioning to a valid stack type, if appropriate.
-  IRNode *Call = (IRNode *)LLVMBuilder->CreateCall(Target, Arguments);
+  CallSite Call = makeCall(Target, MayThrow, Arguments);
 
   if (IsVolatile && isNonVolatileWriteHelperCall(HelperID)) {
     // TODO: this is only needed where CLRConfig::INTERNAL_JitLockWrite is set
@@ -3500,7 +3519,9 @@ IRNode *GenIR::callRuntimeHandleHelper(CorInfoHelpFunc Helper, IRNode *Arg1,
 
   // Call the helper unconditionally if NullCheckArg is null.
   if ((NullCheckArg == nullptr) || isConstantNull(NullCheckArg)) {
-    return callHelperImpl(Helper, ReturnType, Arg1, Arg2);
+    const bool MayThrow = true;
+    return (IRNode *)callHelperImpl(Helper, MayThrow, ReturnType, Arg1, Arg2)
+        .getInstruction();
   }
 
   BasicBlock *SaveBlock = LLVMBuilder->GetInsertBlock();
@@ -3509,10 +3530,11 @@ IRNode *GenIR::callRuntimeHandleHelper(CorInfoHelpFunc Helper, IRNode *Arg1,
   Value *Compare = LLVMBuilder->CreateIsNull(NullCheckArg, "NullCheck");
 
   // Generate conditional helper call.
-  bool CallReturns = true;
-  CallInst *HelperCall =
-      genConditionalHelperCall(Compare, Helper, ReturnType, Arg1, Arg2,
-                               CallReturns, "RuntimeHandleHelperCall");
+  const bool MayThrow = true;
+  const bool CallReturns = true;
+  CallSite HelperCall =
+      genConditionalHelperCall(Compare, Helper, MayThrow, ReturnType, Arg1,
+                               Arg2, CallReturns, "RuntimeHandleHelperCall");
 
   // The result is a PHI of NullCheckArg and the generated call.
   // The generated code is equivalent to
@@ -3523,9 +3545,9 @@ IRNode *GenIR::callRuntimeHandleHelper(CorInfoHelpFunc Helper, IRNode *Arg1,
   // return x;
   BasicBlock *CurrentBlock = LLVMBuilder->GetInsertBlock();
   BasicBlock *CallBlock = HelperCall->getParent();
-  PHINode *PHI =
-      mergeConditionalResults(CurrentBlock, NullCheckArg, SaveBlock, HelperCall,
-                              CallBlock, "RuntimeHandle");
+  PHINode *PHI = mergeConditionalResults(CurrentBlock, NullCheckArg, SaveBlock,
+                                         HelperCall.getInstruction(), CallBlock,
+                                         "RuntimeHandle");
   return (IRNode *)PHI;
 }
 
@@ -3546,11 +3568,12 @@ IRNode *GenIR::convertHandle(IRNode *GetTokenNumericNode,
   // Get the value that should be assigned to the struct's field, e.g., an
   // instance of RuntimeType.
   Type *HelperResultType = FieldAddress->getType()->getPointerElementType();
-  IRNode *HelperResult =
-      callHelperImpl(HelperID, HelperResultType, GetTokenNumericNode);
+  const bool MayThrow = true;
+  CallSite HelperResult =
+      callHelperImpl(HelperID, MayThrow, HelperResultType, GetTokenNumericNode);
 
   // Assign the field of the result struct.
-  LLVMBuilder->CreateStore(HelperResult, FieldAddress);
+  LLVMBuilder->CreateStore(HelperResult.getInstruction(), FieldAddress);
 
   const bool IsVolatile = false;
   return (IRNode *)LLVMBuilder->CreateLoad(Result, IsVolatile);
@@ -3652,7 +3675,8 @@ IRNode *GenIR::genNewMDArrayCall(ReaderCallTargetData *CallTargetData,
                                        getUnmanagedPointerType(FunctionType));
 
   // Replace the old call instruction with the new one.
-  *CallNode = (IRNode *)LLVMBuilder->CreateCall(Callee, Arguments);
+  const bool MayThrow = true;
+  *CallNode = (IRNode *)makeCall(Callee, MayThrow, Arguments).getInstruction();
   return *CallNode;
 }
 
@@ -3704,8 +3728,10 @@ IRNode *GenIR::genNewObjThisArg(ReaderCallTargetData *CallTargetData,
 
   // Create the address operand for the newobj helper.
   CorInfoHelpFunc HelperId = getNewHelper(CallTargetData->getResolvedToken());
+  const bool MayThrow = true;
   Value *ThisPointer =
-      callHelperImpl(HelperId, ThisType, CallTargetData->getClassHandleNode());
+      callHelperImpl(HelperId, MayThrow, ThisType,
+                     CallTargetData->getClassHandleNode()).getInstruction();
   return (IRNode *)ThisPointer;
 }
 
@@ -3736,7 +3762,7 @@ IRNode *GenIR::genNewObjReturnNode(ReaderCallTargetData *CallTargetData,
   return ThisArg;
 }
 
-IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
+IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo, bool MayThrow,
                        std::vector<IRNode *> Args, IRNode **CallNode) {
   IRNode *Call = nullptr, *ReturnNode = nullptr;
   IRNode *TargetNode = CallTargetInfo->getCallTargetNode();
@@ -3815,7 +3841,7 @@ IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo,
 
   ABICallSignature ABICallSig(Signature, *this, *JitContext->TheABIInfo);
   Value *ResultNode = ABICallSig.emitCall(
-      *this, (Value *)TargetNode, Arguments,
+      *this, (Value *)TargetNode, MayThrow, Arguments,
       (Value *)CallTargetInfo->getIndirectionCellNode(), (Value **)&Call);
 
   // Add VarArgs cookie to outgoing param list
@@ -3907,7 +3933,9 @@ Value *GenIR::genConvertOverflowCheck(Value *Source, IntegerType *TargetTy,
     }
 
     // Call the helper to convert to int.
-    Source = callHelperImpl(Helper, HelperResultTy, (IRNode *)Source);
+    const bool MayThrow = true;
+    Source = callHelperImpl(Helper, MayThrow, HelperResultTy, (IRNode *)Source)
+                 .getInstruction();
     SourceTy = HelperResultTy;
 
     // The result of the helper call already has the requested signedness.
@@ -4372,7 +4400,10 @@ IRNode *GenIR::unbox(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Object,
 
   // Call helper to do the type check and get the address of the unbox payload.
   Type *PtrTy = getType(CorInfoType::CORINFO_TYPE_BYREF, ClassHandle);
-  IRNode *Result = callHelperImpl(HelperId, PtrTy, ClassHandleArgument, Object);
+  const bool MayThrow = true;
+  IRNode *Result =
+      (IRNode *)callHelperImpl(HelperId, MayThrow, PtrTy, ClassHandleArgument,
+                               Object).getInstruction();
 
   // If requested, load the object onto the evaluation stack.
   if (AndLoad) {
@@ -4417,26 +4448,26 @@ void GenIR::switchOpcode(IRNode *Opr) {
 void GenIR::throwOpcode(IRNode *Arg1) {
   // Using a call for now; this will need to be invoke
   // when we get EH flow properly modeled.
-  CallInst *ThrowCall =
-      (CallInst *)callHelper(CORINFO_HELP_THROW, nullptr, Arg1);
+  Type *Void = Type::getVoidTy(*JitContext->LLVMContext);
+  const bool MayThrow = true;
+  CallSite ThrowCall = callHelperImpl(CORINFO_HELP_THROW, MayThrow, Void, Arg1);
 
   // Annotate the helper
-  ThrowCall->setDoesNotReturn();
+  ThrowCall.setDoesNotReturn();
 }
 
-CallInst *GenIR::genConditionalHelperCall(Value *Condition,
-                                          CorInfoHelpFunc HelperId,
-                                          Type *ReturnType, IRNode *Arg1,
-                                          IRNode *Arg2, bool CallReturns,
-                                          const Twine &CallBlockName) {
+CallSite GenIR::genConditionalHelperCall(
+    Value *Condition, CorInfoHelpFunc HelperId, bool MayThrow, Type *ReturnType,
+    IRNode *Arg1, IRNode *Arg2, bool CallReturns, const Twine &CallBlockName) {
   // Create the call block and fill it in.
   BasicBlock *CallBlock = createPointBlock(CallBlockName);
   IRBuilder<>::InsertPoint SavedInsertPoint = LLVMBuilder->saveIP();
   LLVMBuilder->SetInsertPoint(CallBlock);
-  CallInst *HelperCall =
-      (CallInst *)callHelperImpl(HelperId, ReturnType, Arg1, Arg2);
+  CallSite HelperCall =
+      callHelperImpl(HelperId, MayThrow, ReturnType, Arg1, Arg2);
+
   if (!CallReturns) {
-    HelperCall->setDoesNotReturn();
+    HelperCall.setDoesNotReturn();
     LLVMBuilder->CreateUnreachable();
   }
   LLVMBuilder->restoreIP(SavedInsertPoint);
@@ -4453,9 +4484,10 @@ void GenIR::genConditionalThrow(Value *Condition, CorInfoHelpFunc HelperId,
                                 const Twine &ThrowBlockName) {
   IRNode *Arg1 = nullptr, *Arg2 = nullptr;
   Type *ReturnType = Type::getVoidTy(*JitContext->LLVMContext);
-  bool CallReturns = false;
-  genConditionalHelperCall(Condition, HelperId, ReturnType, Arg1, Arg2,
-                           CallReturns, ThrowBlockName);
+  const bool MayThrow = true;
+  const bool CallReturns = false;
+  genConditionalHelperCall(Condition, HelperId, MayThrow, ReturnType, Arg1,
+                           Arg2, CallReturns, ThrowBlockName);
 }
 
 IRNode *GenIR::genNullCheck(IRNode *Node) {
@@ -4943,8 +4975,10 @@ IRNode *GenIR::loadVirtFunc(IRNode *Arg1, CORINFO_RESOLVED_TOKEN *ResolvedToken,
 
   Type *Ty =
       Type::getIntNTy(*this->JitContext->LLVMContext, TargetPointerSizeInBits);
-  IRNode *CodeAddress = callHelperImpl(CORINFO_HELP_VIRTUAL_FUNC_PTR, Ty, Arg1,
-                                       TypeToken, MethodToken);
+  const bool MayThrow = true;
+  IRNode *CodeAddress =
+      (IRNode *)callHelperImpl(CORINFO_HELP_VIRTUAL_FUNC_PTR, MayThrow, Ty,
+                               Arg1, TypeToken, MethodToken).getInstruction();
 
   return CodeAddress;
 }
@@ -5335,8 +5369,9 @@ IRNode *GenIR::newArr(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1) {
       getType(CorInfoType::CORINFO_TYPE_CLASS, ResolvedToken->hClass);
   Value *Destination = Constant::getNullValue(ArrayType);
 
-  return callHelper(getNewArrHelper(ElementType), (IRNode *)Destination, Token,
-                    NumOfElements);
+  const bool MayThrow = true;
+  return callHelper(getNewArrHelper(ElementType), MayThrow,
+                    (IRNode *)Destination, Token, NumOfElements);
 }
 
 // CastOp - Generates code for castclass or isinst.
@@ -5388,9 +5423,11 @@ IRNode *GenIR::castOp(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *ObjRefNode,
   // Generate the helper call or intrinsic
   const bool IsVolatile = false;
   const bool DoesNotInvokeStaticCtor = Optimize;
-  return callHelperImpl(HelperId, ResultType, ClassHandleNode, ObjRefNode,
-                        nullptr, nullptr, Reader_AlignUnknown, IsVolatile,
-                        DoesNotInvokeStaticCtor);
+  const bool MayThrow = true;
+  return (IRNode *)callHelperImpl(HelperId, MayThrow, ResultType,
+                                  ClassHandleNode, ObjRefNode, nullptr, nullptr,
+                                  Reader_AlignUnknown, IsVolatile,
+                                  DoesNotInvokeStaticCtor).getInstruction();
 }
 
 // Override the cast class optimization
@@ -5416,7 +5453,8 @@ bool GenIR::abs(IRNode *Argument, IRNode **Result) {
     Type *Types[] = {Ty};
     Value *FAbs = Intrinsic::getDeclaration(JitContext->CurrentModule,
                                             Intrinsic::fabs, Types);
-    Value *Abs = LLVMBuilder->CreateCall(FAbs, Argument);
+    bool MayThrow = false;
+    Value *Abs = makeCall(FAbs, MayThrow, Argument).getInstruction();
     *Result = (IRNode *)Abs;
     return true;
   }
@@ -5438,9 +5476,10 @@ IRNode *GenIR::localAlloc(IRNode *Arg, bool ZeroInit) {
 
   // Zero the allocated region if so requested.
   if (ZeroInit) {
-    Value *ZeroByte = ConstantInt::get(Context, APInt(8, 0, true));
+    const bool MayThrow = false;
     Type *VoidTy = Type::getVoidTy(Context);
-    callHelperImpl(CORINFO_HELP_MEMSET, VoidTy, (IRNode *)LocAlloc,
+    Value *ZeroByte = ConstantInt::get(Context, APInt(8, 0, true));
+    callHelperImpl(CORINFO_HELP_MEMSET, MayThrow, VoidTy, (IRNode *)LocAlloc,
                    (IRNode *)ZeroByte, Arg);
   }
 


### PR DESCRIPTION
This wraps LLVMBuilder->CreateCall, and will be where the logic goes that
instead creates an invoke with an appropriate exception edge if we're in a
protected region.

I decided to go ahead and split this out from my EH changes and PR it to master since it touches many lines and I expect this aspect of the changes (having a makeCall helper with this signature) to stick.