### PR TITLE
Support for synchronized methods.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2839,7 +2839,7 @@ public:
   virtual IRNode *refAnyType(IRNode *Arg1) = 0;
   virtual IRNode *refAnyVal(IRNode *Val, CORINFO_RESOLVED_TOKEN *ResolvedToken);
   virtual void rethrow() = 0;
-  virtual void returnOpcode(IRNode *Opr, bool IsSynchronousMethod) = 0;
+  virtual void returnOpcode(IRNode *Opr, bool IsSynchronizedMethod) = 0;
   virtual IRNode *shift(ReaderBaseNS::ShiftOpcode Opcode, IRNode *ShiftAmount,
                         IRNode *ShiftOperand) = 0;
   virtual IRNode *sizeofOpcode(CORINFO_RESOLVED_TOKEN *ResolvedToken) = 0;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -436,7 +436,7 @@ public:
   };
 
   void rethrow() override { throw NotYetImplementedException("rethrow"); };
-  void returnOpcode(IRNode *Opr, bool SynchronousMethod) override;
+  void returnOpcode(IRNode *Opr, bool IsSynchronizedMethod) override;
   IRNode *shift(ReaderBaseNS::ShiftOpcode Opcode, IRNode *ShiftAmount,
                 IRNode *ShiftOperand) override;
   IRNode *sizeofOpcode(CORINFO_RESOLVED_TOKEN *ResolvedToken) override;
@@ -754,6 +754,13 @@ public:
   /// PHI of NullCheckArg and the generated call instruction.
   IRNode *callRuntimeHandleHelper(CorInfoHelpFunc Helper, IRNode *Arg1,
                                   IRNode *Arg2, IRNode *NullCheckArg);
+
+  /// Generate a helper call to enter or exit a monitor used by synchronized
+  /// methods.
+  ///
+  /// \param IsEnter true if the monitor should be entered; false if the monitor
+  /// should be exited.
+  void callMonitorHelper(bool IsEnter);
 
   IRNode *convertToBoxHelperArgumentType(IRNode *Opr,
                                          CorInfoType CorType) override;
@@ -1274,6 +1281,13 @@ private:
   bool NeedsSecurityObject;
   llvm::BasicBlock *EntryBlock;
   llvm::Instruction *TempInsertionPoint;
+  IRNode *MethodSyncHandle; ///< If the method is synchronized, this is
+                            ///< the handle used for entering and exiting
+                            ///< the monitor.
+  llvm::Value *SyncFlag;    ///< For synchronized methods this flag
+                            ///< indicates whether the monitor has been
+                            ///< entered. It is set and checked by monitor
+                            ///< helpers.
   uint32_t TargetPointerSizeInBits;
   const uint32_t UnmanagedAddressSpace = 0;
   const uint32_t ManagedAddressSpace = 1;


### PR DESCRIPTION
Add calls to MONITOR_ENTER on entry to the method and MONITOR_EXIT on returns.

We can't catch exceptions yet; when we can we will need to add a try/fault for the entire method
so that we can call MONITOR_EXIT on unhandled exceptions.

We have a synchronized method in HelloWorld (System.IO.TextWriter+SyncTextWriter.WriteLine).
I verified that the generated IR looks correct. I also tested with a simple two-thread race that the
behavior of synchronized instance and static methods is as expected.