### PR TITLE
Exclude JIT CSE test cases that has issue with LLILC

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -859,6 +859,25 @@ function Global:ExcludeTest([string]$Arch="x64", [string]$Build="Release")
   del 339415*
   del 143837*
   popd
+
+  # Excluding JIT\jit64\opt\cse\arrayexpr2*, fieldexpr2*,
+  # fieldExprUnchecked1*, HugeArray*, HugeArray1*
+  # hugeexpr1*, HugeField1*, HugeField2*, hugeSimpleExpr1*
+  # mixedexpr1*, simpleexpr4*, staticFieldExprUnchecked1*
+  pushd $CoreCLRTest\JIT\jit64\opt\cse
+  del arrayexpr2*
+  del fieldexpr2*
+  del fieldExprUnchecked1*
+  del HugeArray*
+  del HugeArray1*
+  del hugeexpr1*
+  del HugeField1*
+  del HugeField2*
+  del hugeSimpleExpr1*
+  del mixedexpr1*
+  del simpleexpr4*
+  del staticFieldExprUnchecked1*
+  popd 
 }
 
 # -------------------------------------------------------------------------

--- a/test/exclusion
+++ b/test/exclusion
@@ -17,3 +17,15 @@ JIT\jit64\gc\misc\structret6_2
 JIT\jit64\gc\misc\structret6_3
 JIT\jit64\gc\regress\vswhidbey\339415
 JIT\jit64\gc\regress\vswhidbey\143837
+JIT\jit64\opt\cse\arrayexpr2
+JIT\jit64\opt\cse\fieldexpr2
+JIT\jit64\opt\cse\fieldExprUnchecked1
+JIT\jit64\opt\cse\HugeArray
+JIT\jit64\opt\cse\HugeArray1
+JIT\jit64\opt\cse\hugeexpr1
+JIT\jit64\opt\cse\HugeField1
+JIT\jit64\opt\cse\HugeField2
+JIT\jit64\opt\cse\hugeSimpleExpr1
+JIT\jit64\opt\cse\mixedexpr1
+JIT\jit64\opt\cse\simpleexpr4
+JIT\jit64\opt\cse\staticFieldExprUnchecked1


### PR DESCRIPTION
25 JIT CSE test cases were added in CoreCLR repo in https://github.com/dotnet/coreclr/pull/738.
12 of them have issues if run with LLILC. Exclude them
in both powershell and python scripts. Issue https://github.com/dotnet/llilc/issues/462
is created for investigation of the causes.