### PR TITLE
Exclude Inline optimization test cases that have issue with LLILC

### DIFF
--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -898,6 +898,14 @@ function Global:ExcludeTest([string]$Arch="x64", [string]$Build="Release")
   del Int_Xor_Op*
   del Double_Xor_Op*
   popd
+
+  # Excluding JIT\opt\Inline\Inline_Handler*, Inline_Vars*, InlineThrow*
+  pushd $CoreCLRTest\JIT\opt\Inline
+  del Inline_Handler*
+  del Inline_Vars*
+  del InlineThrow*
+  popd
+
 }
 
 # -------------------------------------------------------------------------

--- a/test/exclusion
+++ b/test/exclusion
@@ -42,3 +42,6 @@ JIT\jit64\opt\cse\hugeSimpleExpr1
 JIT\jit64\opt\cse\mixedexpr1
 JIT\jit64\opt\cse\simpleexpr4
 JIT\jit64\opt\cse\staticFieldExprUnchecked1
+JIT\opt\Inline\Inline_Handler
+JIT\opt\Inline\Inline_Vars
+JIT\opt\Inline\InlineThrow


### PR DESCRIPTION
39 inlining optimization test cases were added in CoreCLR repo in dotnet/coreclr#776.
3 of them have issue if run with LLILC, Inline_Handler, Inline_Vars, InlineThrow.
Exclude them in both powershell and python scripts. Issue dotnet#487
is created for investigation of the causes.