### PR TITLE
Implement reader support for catch handlers and may-throw calls

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1019,20 +1019,6 @@ EHRegion *getFinallyRegion(EHRegion *TryRegion);
 ///
 ///@{
 
-/// \brief Obtain a list of the successor edges of a FlowGraphNode
-///
-/// \param FgNode   The FlowGraphNode of interest.
-/// \returns        A list of the successor edges, or nullptr if there are no
-///                 successors.
-FlowGraphEdgeList *fgNodeGetSuccessorList(FlowGraphNode *FgNode);
-
-/// \brief Obtain a list of the predecessor edges of a FlowGraphNode
-///
-/// \param FgNode   The FlowGraphNode of interest.
-/// \returns        A list of the predecessor edges, or nullptr if there are no
-///                 predecessors.
-FlowGraphEdgeList *fgNodeGetPredecessorList(FlowGraphNode *FgNode);
-
 /// \brief Get the IRNode that is the label for a flow graph node.
 ///
 /// \param  FgNode  The FlowGraphNode of interest.
@@ -1120,22 +1106,6 @@ FlowGraphEdgeList *fgEdgeListGetNextSuccessorActual(FlowGraphEdgeList *FgEdge);
 ///                  if there are no more predecessor edges.
 FlowGraphEdgeList *
 fgEdgeListGetNextPredecessorActual(FlowGraphEdgeList *FgEdge);
-
-/// \brief Obtain a list of the actual (non-exceptional) successor edges of a
-/// FlowGraphNode
-///
-/// \param FgNode   The FlowGraphNode of interest.
-/// \returns        A list of the actual successor edges, or nullptr if there
-///                 are no such successors.
-FlowGraphEdgeList *fgNodeGetSuccessorListActual(FlowGraphNode *Fg);
-
-/// \brief Obtain a list of the actual (non-exceptional) predecessor edges of a
-/// FlowGraphNode
-///
-/// \param FgNode   The FlowGraphNode of interest.
-/// \returns        A list of the actual predecessor edges, or nullptr if there
-///                 are no such predecessors.
-FlowGraphEdgeList *fgNodeGetPredecessorListActual(FlowGraphNode *Fg);
 
 ///@}
 
@@ -2689,6 +2659,37 @@ public:
                      IRNode *Arg2, ReaderAlignType Alignment, bool IsVolatile);
   virtual void dup(IRNode *Opr, IRNode **Result1, IRNode **Result2) = 0;
   virtual void endFilter(IRNode *Arg1) = 0;
+
+  /// \brief Obtain a list of the successor edges of a FlowGraphNode
+  ///
+  /// \param FgNode   The FlowGraphNode of interest.
+  /// \returns        A list of the successor edges, or nullptr if there are no
+  ///                 successors.
+  virtual FlowGraphEdgeList *fgNodeGetSuccessorList(FlowGraphNode *FgNode) = 0;
+
+  /// \brief Obtain a list of the predecessor edges of a FlowGraphNode
+  ///
+  /// \param FgNode   The FlowGraphNode of interest.
+  /// \returns        A list of the predecessor edges, or nullptr if there are
+  ///                 no predecessors.
+  virtual FlowGraphEdgeList *
+  fgNodeGetPredecessorList(FlowGraphNode *FgNode) = 0;
+
+  /// \brief Obtain a list of the actual (non-exceptional) successor edges of a
+  /// FlowGraphNode
+  ///
+  /// \param FgNode   The FlowGraphNode of interest.
+  /// \returns        A list of the actual successor edges, or nullptr if there
+  ///                 are no such successors.
+  FlowGraphEdgeList *fgNodeGetSuccessorListActual(FlowGraphNode *Fg);
+
+  /// \brief Obtain a list of the actual (non-exceptional) predecessor edges of
+  /// a FlowGraphNode
+  ///
+  /// \param FgNode   The FlowGraphNode of interest.
+  /// \returns        A list of the actual predecessor edges, or nullptr if
+  ///                 there are no such predecessors.
+  FlowGraphEdgeList *fgNodeGetPredecessorListActual(FlowGraphNode *Fg);
 
   virtual FlowGraphNode *fgNodeGetNext(FlowGraphNode *FgNode) = 0;
   virtual uint32_t fgNodeGetStartMSILOffset(FlowGraphNode *Fg) = 0;

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1661,14 +1661,12 @@ protected:
   ///          that includes \p Offset, if such a region exists; else nullptr.
   EHRegion *getInnerEnclosingRegion(EHRegion *OuterRegion, uint32_t Offset);
 
-private:
-  /// \brief Perform special processing for blocks that start EH regions.
+  /// Process first entry to a region during 1st-pass flow-graph construction
   ///
-  /// Uses the \p CurrentFgNode to determine which block to process. Ensures
-  /// the operand stack and debugger info is in the proper state for blocks
-  /// that start EH regions.
-  void setupBlockForEH();
+  /// \param Region   \p EHRegion being entered
+  virtual void fgEnterRegion(EHRegion *Region) = 0;
 
+private:
   /// \brief Check if this offset is the start of an MSIL instruction.
   ///
   /// Helper used to check whether branch targets and similar are referring
@@ -1949,7 +1947,8 @@ private:
 
   /// \brief Process a region transition during 1st-pass flow-graph construction
   ///
-  /// Computes the new current region and the MSIL offset where the next region
+  /// Does any processing necessary for entering the new region and computes
+  /// the new current region and the MSIL offset where the next region
   /// transition will occur (in a forward lexical walk).
   ///
   /// \param OldRegion   The region that was current before reaching \p Offset

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1420,6 +1420,14 @@ protected:
   // could look like with divide-by-zero checks folded onto divides.
   static const bool UseExplicitZeroDivideChecks = true;
 
+  /// \brief Suppresses generation of code to handle exceptions
+  ///
+  /// This flag can be used when bringing up a new runtime target that doesn't
+  /// yet have exception handling support implemented.  If this flag is set,
+  /// no EH clauses will be reported to the runtime, but any code that doesn't
+  /// dynamically throw exceptions will be handled correctly.
+  static const bool SuppressExceptionHandlers = false;
+
   // Verification Info
 public:
   bool VerificationNeeded;

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -967,6 +967,15 @@ bool rgnGetIsLive(EHRegion *EhRegion);
 void rgnSetIsLive(EHRegion *EhRegion, bool Live);
 void rgnSetParent(EHRegion *EhRegion, EHRegion *Parent);
 EHRegion *rgnGetParent(EHRegion *EhRegion);
+/// \brief Determine if this region is lexically outside its parent in the tree
+///
+/// Handler regions are children of the \p try regions they protect in the
+/// region tree, but lexically they come after (not inside) the protected
+/// region.  This routine identifies them.
+///
+/// \param Region   The child region to check against its parent
+/// \returns True iff this region is lexically outside its parent
+bool rgnIsOutsideParent(EHRegion *Region);
 void rgnSetChildList(EHRegion *EhRegion, EHRegionList *Children);
 EHRegionList *rgnGetChildList(EHRegion *EhRegion);
 bool rgnGetHasNonLocalFlow(EHRegion *EhRegion);
@@ -1009,23 +1018,6 @@ EHRegion *getFinallyRegion(EHRegion *TryRegion);
 /// \name Client Flow Graph interface
 ///
 ///@{
-
-/// \brief Determine the EH region for this flow graph node
-///
-/// One the EH regions have been created, each flow graph node should have an
-/// innermost containing EH region. This method returns that region.
-///
-/// \param FgNode   The FlowGraphNode of interest.
-/// \returns        Associated EH region.
-EHRegion *fgNodeGetRegion(FlowGraphNode *FgNode);
-
-/// \brief Establish the EH region for this flow graph node
-///
-/// Sets up the association between a FlowGraphNode and and EH Region.
-///
-/// \param FgNode   The FlowGraphNode of interest.
-/// \param EhRegion The EH region to associate.
-void fgNodeSetRegion(FlowGraphNode *FgNode, EHRegion *EhRegion);
 
 /// \brief Obtain a list of the successor edges of a FlowGraphNode
 ///
@@ -1355,6 +1347,7 @@ public:
   // The reader's operand stack. Public because of inlining and debug prints
   ReaderStack *ReaderOperandStack;
 
+  // Used in both first and second pass
   // Public for debug printing
   EHRegion *CurrentRegion;
 
@@ -1983,6 +1976,19 @@ private:
 
   void rgnCreateRegionTree(void);
   void rgnPushRegionChild(EHRegion *Parent, EHRegion *Child);
+
+  /// \brief Process a region transition during 1st-pass flow-graph construction
+  ///
+  /// Computes the new current region and the MSIL offset where the next region
+  /// transition will occur (in a forward lexical walk).
+  ///
+  /// \param OldRegion   The region that was current before reaching \p Offset
+  /// \param Offset      The new MSIL offset reached in the lexical walk
+  /// \param NextOffset [out] The MSIL offset where the next region transition
+  ///                         after this one will occur (in the lexical walk)
+  /// \returns The innermost \p EHRegion enclosing \p Offset
+  EHRegion *fgSwitchRegion(EHRegion *OldRegion, uint32_t Offset,
+                           uint32_t *NextOffset);
 
 public:
   EHRegion *rgnMakeRegion(ReaderBaseNS::RegionKind Type, EHRegion *Parent,
@@ -2690,6 +2696,10 @@ public:
   virtual uint32_t fgNodeGetEndMSILOffset(FlowGraphNode *Fg) = 0;
   virtual void fgNodeSetEndMSILOffset(FlowGraphNode *FgNode,
                                       uint32_t Offset) = 0;
+  virtual EHRegion *fgNodeGetRegion(FlowGraphNode *FgNode) = 0;
+  virtual void fgNodeSetRegion(FlowGraphNode *FgNode, EHRegion *EhRegion) = 0;
+  virtual void fgNodeChangeRegion(FlowGraphNode *FgNode,
+                                  EHRegion *EhRegion) = 0;
 
   /// \brief Checks whether this node has been visited by an algorithm
   /// traversing the flow graph.
@@ -3068,11 +3078,9 @@ public:
   /// \param PreviousNode  The new node will follow \p PreviousNode in the
   ///                      node list if specified (may be nullptr, in which case
   ///                      the new node will simply be appended)
-  /// \param Region        EHRegion to apply to the new node
   /// \returns The new FlowGraphNode
   virtual FlowGraphNode *makeFlowGraphNode(uint32_t TargetOffset,
-                                           FlowGraphNode *PreviousNode,
-                                           EHRegion *Region) = 0;
+                                           FlowGraphNode *PreviousNode) = 0;
   virtual void markAsEHLabel(IRNode *LabelNode) = 0;
   virtual IRNode *makeTryEndNode(void) = 0;
   virtual IRNode *makeRegionStartNode(ReaderBaseNS::RegionKind RegionType) = 0;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -167,29 +167,22 @@ public:
   /// \pre \p Fg != nullptr.
   /// \post **this** is a successor edge list representing the successors
   /// of \p Fg.
-  FlowGraphSuccessorEdgeList(FlowGraphNode *Fg)
-      : FlowGraphEdgeList(), SuccIterator(Fg->getTerminator()),
-        SuccIteratorEnd(Fg->getTerminator(), true) {}
+  FlowGraphSuccessorEdgeList(FlowGraphNode *Fg);
 
   /// Move the current location in the flow graph edge list to the next edge.
   /// \pre The current edge has not reached the end of the edge list.
   /// \post The current edge has been advanced to the next, or has possibly
   /// reached the end iterator (meaning no more successors).
-  void moveNext() override { SuccIterator++; }
+  void moveNext() override;
 
   /// \return The sink of the current edge which will be one of the successors
   /// of the \p Fg node, unless the list has been exhausted in which case
   /// return nullptr.
-  FlowGraphNode *getSink() override {
-    return (SuccIterator == SuccIteratorEnd) ? nullptr
-                                             : (FlowGraphNode *)*SuccIterator;
-  }
+  FlowGraphNode *getSink() override;
 
   /// \return The source of the current edge which will be \p Fg node.
   /// \pre The current edge has not reached the end of the edge list.
-  FlowGraphNode *getSource() override {
-    return (FlowGraphNode *)SuccIterator.getSource();
-  }
+  FlowGraphNode *getSource() override;
 
 private:
   llvm::succ_iterator SuccIterator;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -47,8 +47,8 @@ public:
     StartMSILOffset = 0;
     EndMSILOffset = 0;
     Region = nullptr;
-    IsVisited = false;
     TheReaderStack = nullptr;
+    IsVisited = false;
     PropagatesOperandStack = true;
   };
 
@@ -63,12 +63,12 @@ public:
   /// Region containing this block
   EHRegion *Region;
 
+  /// Used to track what is on the operand stack on entry to the basic block.
+  ReaderStack *TheReaderStack;
+
   /// In algorithms traversing the flow graph, used to track which basic blocks
   /// have been visited.
   bool IsVisited;
-
-  /// Used to track what is on the operand stack on entry to the basic block.
-  ReaderStack *TheReaderStack;
 
   /// true iff this basic block uses an operand stack and propagates it to the
   /// block's successors when it's not empty on exit.

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -322,6 +322,8 @@ public:
     throw NotYetImplementedException("endFilter");
   };
 
+  FlowGraphEdgeList *fgNodeGetSuccessorList(FlowGraphNode *FgNode) override;
+  FlowGraphEdgeList *fgNodeGetPredecessorList(FlowGraphNode *FgNode) override;
   FlowGraphNode *fgNodeGetNext(FlowGraphNode *FgNode) override;
   uint32_t fgNodeGetStartMSILOffset(FlowGraphNode *Fg) override;
   void fgNodeSetStartMSILOffset(FlowGraphNode *Fg, uint32_t Offset) override;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -46,6 +46,7 @@ public:
   FlowGraphNodeInfo() {
     StartMSILOffset = 0;
     EndMSILOffset = 0;
+    Region = nullptr;
     IsVisited = false;
     TheReaderStack = nullptr;
     PropagatesOperandStack = true;
@@ -58,6 +59,9 @@ public:
   /// Byte offset that is just past the last MSIL instruction of the Basic
   /// Block.
   uint32_t EndMSILOffset;
+
+  /// Region containing this block
+  EHRegion *Region;
 
   /// In algorithms traversing the flow graph, used to track which basic blocks
   /// have been visited.
@@ -330,6 +334,9 @@ public:
   void fgNodeSetStartMSILOffset(FlowGraphNode *Fg, uint32_t Offset) override;
   uint32_t fgNodeGetEndMSILOffset(FlowGraphNode *Fg) override;
   void fgNodeSetEndMSILOffset(FlowGraphNode *FgNode, uint32_t Offset) override;
+  EHRegion *fgNodeGetRegion(FlowGraphNode *FgNode) override;
+  void fgNodeSetRegion(FlowGraphNode *FgNode, EHRegion *EhRegion) override;
+  void fgNodeChangeRegion(FlowGraphNode *FgNode, EHRegion *EhRegion) override;
 
   bool fgNodeIsVisited(FlowGraphNode *FgNode) override;
   void fgNodeSetVisited(FlowGraphNode *FgNode, bool Visited) override;
@@ -636,8 +643,7 @@ public:
     throw NotYetImplementedException("insertEHAnnotationNode");
   };
   FlowGraphNode *makeFlowGraphNode(uint32_t TargetOffset,
-                                   FlowGraphNode *PreviousNode,
-                                   EHRegion *Region) override;
+                                   FlowGraphNode *PreviousNode) override;
   void markAsEHLabel(IRNode *LabelNode) override {
     throw NotYetImplementedException("markAsEHLabel");
   };

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -361,6 +361,17 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
 
   JitContext->MethodName = FuncName;
 
+  if (IsOk) {
+    for (BasicBlock &BB : *Func) {
+      if (BB.getLandingPadInst() != nullptr) {
+        // Don't try to push the EH code downstream (we'll currently fail on
+        // the first method with EH if we do that, which prevents being able
+        // to see IR for later methods)
+        return false;
+      }
+    }
+  }
+
   return IsOk;
 }
 

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -259,7 +259,7 @@ fgEdgeListGetNextPredecessorActual(FlowGraphEdgeList *FgEdge) {
   return FgEdge;
 }
 
-FlowGraphEdgeList *fgNodeGetSuccessorListActual(FlowGraphNode *Fg) {
+FlowGraphEdgeList *ReaderBase::fgNodeGetSuccessorListActual(FlowGraphNode *Fg) {
   FlowGraphEdgeList *FgEdge;
 
   FgEdge = fgNodeGetSuccessorList(Fg);
@@ -269,7 +269,8 @@ FlowGraphEdgeList *fgNodeGetSuccessorListActual(FlowGraphNode *Fg) {
   return FgEdge;
 }
 
-FlowGraphEdgeList *fgNodeGetPredecessorListActual(FlowGraphNode *Fg) {
+FlowGraphEdgeList *
+ReaderBase::fgNodeGetPredecessorListActual(FlowGraphNode *Fg) {
   FlowGraphEdgeList *FgEdge;
 
   FgEdge = fgNodeGetPredecessorList(Fg);

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -104,8 +104,11 @@ public:
   EHRegionList *Children;
   uint32_t StartMsilOffset;
   uint32_t EndMsilOffset;
+  union {
+    llvm::SwitchInst *EndFinallySwitch; // Only used for Finally regions
+    mdToken CatchClassToken;            // Only used for Catch regions
+  };
   ReaderBaseNS::RegionKind Kind;
-  llvm::SwitchInst *EndFinallySwitch;
 };
 
 struct EHRegionList {
@@ -242,8 +245,12 @@ EHRegion *rgnGetCatchTryRegion(EHRegion *CatchRegion) { return nullptr; }
 void rgnSetCatchTryRegion(EHRegion *CatchRegion, EHRegion *TryRegion) {
   return;
 }
-mdToken rgnGetCatchClassToken(EHRegion *CatchRegion) { return 0; }
-void rgnSetCatchClassToken(EHRegion *CatchRegion, mdToken Token) { return; }
+mdToken rgnGetCatchClassToken(EHRegion *CatchRegion) {
+  return CatchRegion->CatchClassToken;
+}
+void rgnSetCatchClassToken(EHRegion *CatchRegion, mdToken Token) {
+  CatchRegion->CatchClassToken = Token;
+}
 
 #pragma endregion
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2220,6 +2220,21 @@ FlowGraphNode *fgEdgeListGetSource(FlowGraphEdgeList *FgEdge) {
   return FgEdge->getSource();
 }
 
+FlowGraphSuccessorEdgeList::FlowGraphSuccessorEdgeList(FlowGraphNode *Fg)
+    : FlowGraphEdgeList(), SuccIterator(Fg->getTerminator()),
+      SuccIteratorEnd(Fg->getTerminator(), true) {}
+
+void FlowGraphSuccessorEdgeList::moveNext() { SuccIterator++; }
+
+FlowGraphNode *FlowGraphSuccessorEdgeList::getSink() {
+  return (SuccIterator == SuccIteratorEnd) ? nullptr
+                                           : (FlowGraphNode *)*SuccIterator;
+}
+
+FlowGraphNode *FlowGraphSuccessorEdgeList::getSource() {
+  return (FlowGraphNode *)SuccIterator.getSource();
+}
+
 void GenIR::fgNodeSetOperandStack(FlowGraphNode *Fg, ReaderStack *Stack) {
   FlowGraphInfoMap[Fg].TheReaderStack = Stack;
 }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2180,7 +2180,7 @@ FlowGraphNode *GenIR::fgNodeGetIDom(FlowGraphNode *FgNode) {
   return Idom;
 }
 
-FlowGraphEdgeList *fgNodeGetSuccessorList(FlowGraphNode *FgNode) {
+FlowGraphEdgeList *GenIR::fgNodeGetSuccessorList(FlowGraphNode *FgNode) {
   FlowGraphEdgeList *FgEdge = new FlowGraphSuccessorEdgeList(FgNode);
   if (fgEdgeListGetSink(FgEdge) == nullptr) {
     return nullptr;
@@ -2196,7 +2196,7 @@ FlowGraphEdgeList *fgEdgeListGetNextSuccessor(FlowGraphEdgeList *FgEdge) {
   return FgEdge;
 }
 
-FlowGraphEdgeList *fgNodeGetPredecessorList(FlowGraphNode *Fg) {
+FlowGraphEdgeList *GenIR::fgNodeGetPredecessorList(FlowGraphNode *Fg) {
   FlowGraphEdgeList *FgEdge = new FlowGraphPredecessorEdgeList(Fg);
   if (fgEdgeListGetSource(FgEdge) == nullptr) {
     return nullptr;

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -104,6 +104,7 @@ public:
   EHRegionList *Children;
   uint32_t StartMsilOffset;
   uint32_t EndMsilOffset;
+  llvm::LandingPadInst *HandlerLandingPad;
   union {
     llvm::SwitchInst *EndFinallySwitch; // Only used for Finally regions
     mdToken CatchClassToken;            // Only used for Catch regions
@@ -341,6 +342,8 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   NeedsSecurityObject = false;
   DoneBuildingFlowGraph = false;
   UnreachableContinuationBlock = nullptr;
+  // Personality function is created on-demand.
+  PersonalityFunction = nullptr;
 
   initParamsAndAutos(MethodSignature);
 
@@ -2099,6 +2102,214 @@ void GenIR::beginFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrOffset,
   }
 }
 
+// Allow filtering which try regions we support (during EH bring-up)
+static bool hasNYIClause(EHRegion *TryRegion) {
+  for (EHRegionList *ChildNode = rgnGetChildList(TryRegion); ChildNode;
+       ChildNode = rgnListGetNext(ChildNode)) {
+    EHRegion *Child = rgnListGetRgn(ChildNode);
+    switch (Child->Kind) {
+    case ReaderBaseNS::RegionKind::RGN_Try:
+      // This is a nested region, not an attached handler.  It doesn't require
+      // any code in the landing pad.
+      break;
+    case ReaderBaseNS::RegionKind::RGN_MCatch:
+      // This handler type is implemented.
+      break;
+    case ReaderBaseNS::RegionKind::RGN_MExcept:
+    case ReaderBaseNS::RegionKind::RGN_Finally:
+    case ReaderBaseNS::RegionKind::RGN_Fault:
+      // These are not yet implemented.
+      return true;
+    default:
+      llvm_unreachable("Unexpected region kind");
+    }
+  }
+  // No NYI clause found.
+  return false;
+}
+
+void GenIR::fgEnterRegion(EHRegion *Region) {
+  // Find the outer region handler first.
+  EHRegion *Parent = rgnGetParent(Region);
+
+  if (rgnIsOutsideParent(Region)) {
+    // Get the nearest enclosing ancestor, not the immediate parent
+    Parent = rgnGetParent(Parent);
+  }
+
+  LandingPadInst *LandingPad = Parent->HandlerLandingPad;
+
+  if (Region->Kind == ReaderBaseNS::RegionKind::RGN_Try &&
+      !SuppressExceptionHandlers && !hasNYIClause(Region)) {
+    // Create a new inner landing pad
+    LandingPad = createLandingPad(Region, LandingPad);
+  }
+
+  // Record the handler so we can hook up exception edges later.
+  Region->HandlerLandingPad = LandingPad;
+}
+
+LandingPadInst *GenIR::createLandingPad(EHRegion *TryRegion,
+                                        LandingPadInst *OuterLandingPad) {
+  LLVMContext &LLVMContext = *JitContext->LLVMContext;
+  BasicBlock *LandingBlock =
+      createPointBlock(TryRegion->EndMsilOffset, "ExceptionDispatch");
+  IRBuilder<>::InsertPoint SavedInsertPoint = LLVMBuilder->saveIP();
+  LLVMBuilder->SetInsertPoint(LandingBlock);
+
+  // The landingpad expects a pointer to the personality routine.
+  if (PersonalityFunction == nullptr) {
+    // The EE provides a CorInfoHelpFunc handle for the actual personality
+    // routine (CORINFO_HELP_EE_PERSONALITY_ROUTINE), but
+    // A) the handle is opqaue, and we need an llvm::Function, and
+    // B) LLVM's EH lowering expects the personality routine to have one of a
+    //    few known names.
+    // Eventually, we want to be able to create llvm::Functions for
+    // CorInfoHelpFunc handles, and either get rid of the name matching in the
+    // EH lowering or teach it about the CLR's personality routine
+    // (ProcessCLRException).  For now, just pretend to be Windows MSVCRT C++
+    // since it triggers the most appropriate paths in WinEHPrepare.
+    // Use a dummy function type.
+    FunctionType *PersonalityTy =
+        FunctionType::get(Type::getVoidTy(LLVMContext), false);
+    PersonalityFunction =
+        Function::Create(PersonalityTy, Function::ExternalLinkage,
+                         "__CxxFrameHandler3", JitContext->CurrentModule);
+  }
+  // Landingpad defines an i8* (in addrspace 0) which is intended to be a
+  // pointer to the exception object.  An actual pointer to a CLR exception
+  // object would need to be a GC pointer, but since the pointer here isn't
+  // used for actual codegen (but rather is just used to connect the dataflow
+  // between the LandingPad and the begincatch intrinsic call), use i8* to
+  // match LLVM's expectations.
+  Type *FauxExceptionType = Type::getInt8PtrTy(LLVMContext);
+  // Use i32 as selector type to match Clang.
+  IntegerType *SelectorType = IntegerType::getInt32Ty(LLVMContext);
+  // The LandingPad instruction itself defines an (exception, selector) pair
+  StructType *PairType =
+      llvm::StructType::get(FauxExceptionType, SelectorType, nullptr);
+  LandingPadInst *LandingPad = LLVMBuilder->CreateLandingPad(
+      PairType, PersonalityFunction, 1, "ExnData");
+  // Extract the exception and selector.  Clang spills these to locals, but
+  // that seems unnecessary for us (WinEHPrepare explicitly promotes them
+  // to registers if it sees them spilled).
+  Value *FauxException =
+      LLVMBuilder->CreateExtractValue(LandingPad, 0, "ExceptionToken");
+  Value *Selector =
+      LLVMBuilder->CreateExtractValue(LandingPad, 1, "SelectorToken");
+
+  // Walk the list of attached handlers, adding clauses as appropriate.
+  for (EHRegionList *ChildNode = rgnGetChildList(TryRegion); ChildNode;
+       ChildNode = rgnListGetNext(ChildNode)) {
+    EHRegion *Child = rgnListGetRgn(ChildNode);
+    switch (Child->Kind) {
+    case ReaderBaseNS::RegionKind::RGN_Try:
+      // This is a nested region, not an attached handler.  It doesn't require
+      // any code in the landing pad.
+      break;
+    case ReaderBaseNS::RegionKind::RGN_MCatch:
+      genCatchDispatch(Child, LandingPad, FauxException, Selector);
+      break;
+    case ReaderBaseNS::RegionKind::RGN_MExcept:
+    case ReaderBaseNS::RegionKind::RGN_Finally:
+    case ReaderBaseNS::RegionKind::RGN_Fault:
+      // These are not yet implemented.  Omit the dispatch code for them, so
+      // they will be discarded as unreachable and we can still compile these
+      // functions cleanly (though they will not run correctly if an exception
+      // is thrown that needed to be processed by one of these handlers).
+      // Mark the landing pad as a cleanup to indicate that it ought to process
+      // exceptions for which we're not adding clauses.
+      LandingPad->setCleanup(true);
+      break;
+    default:
+      llvm_unreachable("Unexpected region kind");
+    }
+  }
+
+  // If we didn't break out to a handler, continue propagating the exception.
+  LLVMBuilder->CreateResume(FauxException);
+
+  // Return the insertion point to where the caller had it.
+  LLVMBuilder->restoreIP(SavedInsertPoint);
+
+  return LandingPad;
+}
+
+void GenIR::genCatchDispatch(EHRegion *CatchRegion, LandingPadInst *LandingPad,
+                             Value *FauxException, Value *Selector) {
+  LLVMContext &LLVMContext = *JitContext->LLVMContext;
+  // Get the token representing the type that the catch handles.
+  mdToken ClassToken = rgnGetCatchClassToken(CatchRegion);
+  CORINFO_RESOLVED_TOKEN ResolvedToken;
+  resolveToken(ClassToken, CORINFO_TOKENKIND_Class, &ResolvedToken);
+  Type *CaughtType = getType(CORINFO_TYPE_CLASS, ResolvedToken.hClass);
+  // Generate a global variable that represents the caught exception type
+  // handle.
+  // TODO: This will need to be a value that can be mapped back to the class
+  // token.  Creating a dummy placeholder GlobalVariable for now.  Use i8 for
+  // tye type because we need to cast the address to i8* to form a well-typed
+  // LandingPad anyway.
+  Type *Int8Ty = Type::getInt8Ty(LLVMContext);
+  StructType *ExnClassType =
+      cast<StructType>(cast<PointerType>(CaughtType)->getElementType());
+  const bool IsConstant = true;
+  GlobalVariable *TokenValue = new GlobalVariable(
+      *JitContext->CurrentModule, Int8Ty, IsConstant,
+      GlobalVariable::ExternalLinkage, nullptr, ExnClassType->getName());
+  // Register this clause with the LandingPad instruction.
+  LandingPad->addClause(TokenValue);
+  // In LLVM, the landing pad clause entry (which for us is the class
+  // token) is not identical to dispatch selector (which is an i32); the
+  // @llvm.eh.typeid.for intrinsic is used to convert from the clause
+  // entry to the selector value.  Emit the call to get the selector value
+  // that will identify this catch type.
+  Value *IntrinsicCallee = Intrinsic::getDeclaration(JitContext->CurrentModule,
+                                                     Intrinsic::eh_typeid_for);
+  Value *ClassSelector =
+      LLVMBuilder->CreateCall(IntrinsicCallee, TokenValue, "ClassSelector");
+
+  // Generate the test to see if the dynamically-provided selector matches
+  // the selector for this clause.
+  Value *Match = LLVMBuilder->CreateICmpEQ(Selector, ClassSelector, "DoCatch");
+  // Create the successor blocks for the true/false cases of the match.
+  BasicBlock *EnterCatchBlock =
+      createPointBlock(CatchRegion->StartMsilOffset, "EnterCatch");
+  EHRegion *TryRegion = CatchRegion->Parent;
+  BasicBlock *ContinueBlock =
+      createPointBlock(TryRegion->EndMsilOffset, "ContinueDispatch");
+  // Branch to the appropriate successor.
+  LLVMBuilder->CreateCondBr(Match, EnterCatchBlock, ContinueBlock);
+  // Populate the enter-catch block
+  LLVMBuilder->SetInsertPoint(EnterCatchBlock);
+  // SEQUENCE POINTS: ensure sequence point at eh region start
+  if (needSequencePoints()) {
+    setSequencePoint(CatchRegion->StartMsilOffset,
+                     ICorDebugInfo::SOURCE_TYPE_INVALID);
+  }
+  // Generate a local to hold the pointer to the caught exception.
+  Value *ExnPtrAddr = createTemporary(CaughtType, "CaughtException");
+  // The begincatch intrinsic takes the address of the local as i8*
+  Type *Int8PtrTy = Type::getInt8PtrTy(LLVMContext);
+  Value *CastExnPtrAddr = LLVMBuilder->CreateBitCast(ExnPtrAddr, Int8PtrTy);
+  Value *BeginCatchCallee = Intrinsic::getDeclaration(JitContext->CurrentModule,
+                                                      Intrinsic::eh_begincatch);
+  Value *BeginCatch =
+      LLVMBuilder->CreateCall2(BeginCatchCallee, FauxException, CastExnPtrAddr);
+  // The catch handler code itself expects the exception pointer to be on
+  // the evaluation stack.
+  IRNode *ExnPtr = (IRNode *)LLVMBuilder->CreateLoad(ExnPtrAddr);
+  ReaderStack *EnterBlockStack = createStack();
+  EnterBlockStack->push(ExnPtr);
+  fgNodeSetOperandStack((FlowGraphNode *)EnterCatchBlock, EnterBlockStack);
+  fgNodeSetPropagatesOperandStack((FlowGraphNode *)EnterCatchBlock, true);
+  // Branch to the handler code.
+  FlowGraphNode *HandlerNode = nullptr;
+  fgAddNodeMSILOffset(&HandlerNode, CatchRegion->StartMsilOffset);
+  LLVMBuilder->CreateBr((BasicBlock *)HandlerNode);
+  // Reset the insert point to continue exception dispatch.
+  LLVMBuilder->SetInsertPoint(ContinueBlock);
+}
+
 void GenIR::endFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrOffset) { return; }
 
 IRNode *GenIR::findBlockSplitPointAfterNode(IRNode *Node) {
@@ -2143,8 +2354,8 @@ void GenIR::replaceFlowGraphNodeUses(FlowGraphNode *OldNode,
 }
 
 bool fgEdgeListIsNominal(FlowGraphEdgeList *FgEdge) {
-  // This is supposed to return true for exception edges.
-  return false;
+  BasicBlock *Successor = (BasicBlock *)fgEdgeListGetSink(FgEdge);
+  return Successor->isLandingPad();
 }
 
 // Hook called from reader fg builder to identify potential inline candidates.
@@ -2181,7 +2392,8 @@ FlowGraphNode *GenIR::fgNodeGetIDom(FlowGraphNode *FgNode) {
 }
 
 FlowGraphEdgeList *GenIR::fgNodeGetSuccessorList(FlowGraphNode *FgNode) {
-  FlowGraphEdgeList *FgEdge = new FlowGraphSuccessorEdgeList(FgNode);
+  EHRegion *Region = fgNodeGetRegion(FgNode);
+  FlowGraphEdgeList *FgEdge = new FlowGraphSuccessorEdgeList(FgNode, Region);
   if (fgEdgeListGetSink(FgEdge) == nullptr) {
     return nullptr;
   }
@@ -2220,13 +2432,30 @@ FlowGraphNode *fgEdgeListGetSource(FlowGraphEdgeList *FgEdge) {
   return FgEdge->getSource();
 }
 
-FlowGraphSuccessorEdgeList::FlowGraphSuccessorEdgeList(FlowGraphNode *Fg)
+FlowGraphSuccessorEdgeList::FlowGraphSuccessorEdgeList(FlowGraphNode *Fg,
+                                                       EHRegion *Region)
     : FlowGraphEdgeList(), SuccIterator(Fg->getTerminator()),
-      SuccIteratorEnd(Fg->getTerminator(), true) {}
+      SuccIteratorEnd(Fg->getTerminator(), true), NominalSucc(nullptr) {
+  if (Region != nullptr) {
+    LandingPadInst *LandingPad = Region->HandlerLandingPad;
+    if (LandingPad != nullptr) {
+      NominalSucc = LandingPad->getParent();
+    }
+  }
+}
 
-void FlowGraphSuccessorEdgeList::moveNext() { SuccIterator++; }
+void FlowGraphSuccessorEdgeList::moveNext() {
+  if (NominalSucc == nullptr) {
+    SuccIterator++;
+  } else {
+    NominalSucc = nullptr;
+  }
+}
 
 FlowGraphNode *FlowGraphSuccessorEdgeList::getSink() {
+  if (NominalSucc != nullptr) {
+    return (FlowGraphNode *)NominalSucc;
+  }
   return (SuccIterator == SuccIteratorEnd) ? nullptr
                                            : (FlowGraphNode *)*SuccIterator;
 }
@@ -4764,10 +4993,50 @@ uint32_t GenIR::updateLeaveOffset(EHRegion *Region, uint32_t LeaveOffset,
   return InnermostTargetOffset;
 }
 
+static EHRegion *getCommonAncestor(EHRegion *Region1, EHRegion *Region2) {
+  if ((Region1 == nullptr) || (Region2 == nullptr)) {
+    return nullptr;
+  }
+  int Depth1 = 0;
+  for (EHRegion *Ancestor1 = Region1->Parent; Ancestor1 != nullptr;
+       Ancestor1 = Ancestor1->Parent) {
+    ++Depth1;
+  }
+  int Depth2 = 0;
+  for (EHRegion *Ancestor2 = Region2->Parent; Ancestor2 != nullptr;
+       Ancestor2 = Ancestor2->Parent) {
+    ++Depth2;
+  }
+  while (Depth1 > Depth2) {
+    Region1 = Region1->Parent;
+    --Depth1;
+  }
+  while (Depth2 > Depth1) {
+    Region2 = Region2->Parent;
+    --Depth2;
+  }
+  while (Region1 != Region2) {
+    Region1 = Region1->Parent;
+    Region2 = Region2->Parent;
+  }
+  return Region1;
+}
+
 void GenIR::leave(uint32_t TargetOffset, bool IsNonLocal,
                   bool EndsWithNonLocalGoto) {
-  // TODO: handle leaves from handler regions
-  return;
+  // Check if this leave exits any catch regions
+  BasicBlock *CurrentBlock = LLVMBuilder->GetInsertBlock();
+  BasicBlock *TargetBlock = CurrentBlock->getUniqueSuccessor();
+  EHRegion *TargetRegion = fgNodeGetRegion((FlowGraphNode *)TargetBlock);
+  EHRegion *ExitToRegion = getCommonAncestor(CurrentRegion, TargetRegion);
+  for (EHRegion *Leaving = CurrentRegion; Leaving != ExitToRegion;
+       Leaving = Leaving->Parent) {
+    if (Leaving->Kind == ReaderBaseNS::RegionKind::RGN_MCatch) {
+      Value *ExitCatchIntrinsic = Intrinsic::getDeclaration(
+          JitContext->CurrentModule, Intrinsic::eh_endcatch);
+      LLVMBuilder->CreateCall(ExitCatchIntrinsic);
+    }
+  }
 }
 
 IRNode *GenIR::loadStr(mdToken Token) {


### PR DESCRIPTION
Map each `BasicBlock` to its containing `EHRegion`.
Generate code for catch handlers, and landing pads with appropriate exception dispatch for catch-protected try regions.
Generate `invoke` with appropriate unwind label rather than `call` for calls that may throw.
Other handler types are still discarded; the plan is to push catch regions through the full phase list before moving on to other handler types (to get an earlier handle on unknowns).
When a function is compiled that contains a catch handler, it goes through reading, verification, and dumping (if enabled), but then is discarded (since otherwise the downstream processing would crash on the first method with a catch handler).

This PR is for a merge into the EH branch; doing a PR now to get the work-in-progress reviewed, but keeping it into the branch to avoid regressing our ability to compile methods that contain catch handlers (but don't dynamically catch exceptions at run-time during test execution).