### PR TITLE
Support indirect unmanaged calls.

### DIFF
--- a/include/Reader/abisignature.h
+++ b/include/Reader/abisignature.h
@@ -57,13 +57,33 @@ class ABICallSignature : public ABISignature {
 private:
   const ReaderCallSignature &Signature; ///< The target function signature.
 
+  /// \brief Emits a call to an unmanaged function.
+  ///
+  /// This method is called by \p emitCall when emitting a call that targets an
+  /// unmanaged function. It is responsible for emitting the IR required to
+  /// perform any necessary bookkeeping for the GC as well as the call itself.
+  /// The arguments must already have been arranged as per the calling
+  /// convention and target ABI.
+  ///
+  /// \param Reader        The \p GenIR instance that will be used to emit IR.
+  /// \param Target        The call target.
+  /// \oaram MayThrow      True iff the callee may raise an exception.
+  /// \param Args          The arguments to the call, arranged as per the
+  ///                      calling convention and target ABI.
+  /// \param Result [out]  The result of the call, if any.
+  ///
+  /// \returns The call site corresponding to the unmanaged call.
+  llvm::CallSite emitUnmanagedCall(GenIR &Reader, llvm::Value *Target,
+                                   bool MayThrow,
+                                   llvm::ArrayRef<llvm::Value *> Args,
+                                   llvm::Value *&Result) const;
+
 public:
   ABICallSignature(const ReaderCallSignature &Signature, GenIR &Reader,
                    const ABIInfo &TheABIInfo);
 
-  /// \brief Emits a call to a function with using the argument and result
-  ///        passing information for the signature provided when this value
-  ///        was created.
+  /// \brief Emits a call to a function using the argument and result passing
+  ///        information for the signature provided when this value was created.
   ///
   /// \param Reader           The \p GenIR instance that will be used to emit
   ///                         IR.
@@ -75,7 +95,7 @@ public:
   /// \param CallNode [out]   The call instruction.
   ///
   /// \returns The result of the call to the target.
-  llvm::Value *emitCall(GenIR &Reader, llvm::Value *Target, bool mayThrow,
+  llvm::Value *emitCall(GenIR &Reader, llvm::Value *Target, bool MayThrow,
                         llvm::ArrayRef<llvm::Value *> Args,
                         llvm::Value *IndirectionCell,
                         llvm::Value **CallNode) const;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -256,7 +256,8 @@ public:
                  llvm::Type *> *ArrayTypeMap,
         std::map<CORINFO_FIELD_HANDLE, uint32_t> *FieldIndexMap)
       : ReaderBase(JitContext->JitInfo, JitContext->MethodInfo,
-                   JitContext->Flags) {
+                   JitContext->Flags),
+        UnmanagedCallFrame(nullptr), ThreadPointer(nullptr) {
     this->JitContext = JitContext;
     this->ClassTypeMap = ClassTypeMap;
     this->ReverseClassTypeMap = ReverseClassTypeMap;
@@ -1280,6 +1281,10 @@ private:
   /// \brief Insert IR to setup the security object
   void insertIRForSecurityObject();
 
+  /// \brief Insert IR to setup the unmanaged call frame (PInvoke frame) and
+  ///        the thread pointer.
+  void insertIRForUnmanagedCallFrame();
+
   /// \brief Create the @gc.safepoint_poll() method
   /// Creates the @gc.safepoint_poll() method and insertes it into the
   /// current module. This helper is required by the LLVM GC-Statepoint
@@ -1314,6 +1319,12 @@ private:
   std::map<CORINFO_FIELD_HANDLE, uint32_t> *FieldIndexMap;
   std::map<llvm::BasicBlock *, FlowGraphNodeInfo> FlowGraphInfoMap;
   std::vector<llvm::Value *> LocalVars;
+  llvm::Value *UnmanagedCallFrame; ///< If the method contains unmanaged calls,
+                                   ///< this is the address of the unmanaged
+                                   ///< call frame.
+  llvm::Value *ThreadPointer;      ///< If the method contains unmanaged calls,
+                                   ///< this is the address of the pointer to
+                                   ///< the runtime thread.
   std::vector<CorInfoType> LocalVarCorTypes;
   std::vector<llvm::Value *> Arguments;
   llvm::Value *IndirectResult;

--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -19,6 +19,7 @@
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
 #include "reader.h"
 #include "readerir.h"
@@ -42,6 +43,21 @@ static CallingConv::ID getLLVMCallingConv(CorInfoCallConv CC) {
   }
 }
 
+static CorInfoCallConv
+getNormalizedCallingConvention(const ReaderCallSignature &Signature) {
+  // NOTE: this is only correct for X86-64
+
+  CorInfoCallConv CC = Signature.getCallingConvention();
+  switch (CC) {
+  case CORINFO_CALLCONV_STDCALL:
+  case CORINFO_CALLCONV_THISCALL:
+  case CORINFO_CALLCONV_FASTCALL:
+    return CORINFO_CALLCONV_C;
+  default:
+    return CC;
+  }
+}
+
 ABISignature::ABISignature(const ReaderCallSignature &Signature, GenIR &Reader,
                            const ABIInfo &TheABIInfo) {
   const CallArgType &ResultType = Signature.getResultType();
@@ -56,7 +72,8 @@ ABISignature::ABISignature(const ReaderCallSignature &Signature, GenIR &Reader,
     LLVMArgTypes[I++] = Reader.getType(Arg.CorType, Arg.Class);
   }
 
-  CallingConv::ID CC = getLLVMCallingConv(Signature.getCallingConvention());
+  CallingConv::ID CC =
+      getLLVMCallingConv(getNormalizedCallingConvention(Signature));
   TheABIInfo.computeSignatureInfo(CC, LLVMResultType, LLVMArgTypes, Result,
                                   Args);
 
@@ -68,6 +85,8 @@ ABISignature::ABISignature(const ReaderCallSignature &Signature, GenIR &Reader,
 }
 
 Value *ABISignature::coerce(GenIR &Reader, Type *TheType, Value *TheValue) {
+  assert(!TheType->isVoidTy());
+
   Type *ValueType = TheValue->getType();
 
   if (TheType == ValueType) {
@@ -86,43 +105,225 @@ ABICallSignature::ABICallSignature(const ReaderCallSignature &TheSignature,
                                    GenIR &Reader, const ABIInfo &TheABIInfo)
     : ABISignature(TheSignature, Reader, TheABIInfo), Signature(TheSignature) {}
 
-Value *ABICallSignature::emitCall(GenIR &Reader, llvm::Value *Target,
-                                  bool MayThrow, llvm::ArrayRef<Value *> Args,
-                                  llvm::Value *IndirectionCell,
-                                  llvm::Value **CallNode) const {
+static Value *getFieldAddress(IRBuilder<> &Builder, Value *Base,
+                              uint32_t Offset, Type *FieldTy) {
+  // The base value should be an i8* or i8[]*.
+  assert(Base->getType()->isPointerTy());
+  assert(Base->getType()->getPointerElementType()->isIntegerTy(8) ||
+         Base->getType()
+             ->getPointerElementType()
+             ->getArrayElementType()
+             ->isIntegerTy(8));
+
+  Type *Int32Ty = Type::getInt32Ty(Builder.getContext());
+  Value *Indices[] = {ConstantInt::get(Int32Ty, 0),
+                      ConstantInt::get(Int32Ty, Offset)};
+  Value *Address = Builder.CreateInBoundsGEP(Base, Indices);
+  PointerType *AddressTy = cast<PointerType>(Address->getType());
+  if (AddressTy->getElementType() != FieldTy) {
+    AddressTy = PointerType::get(FieldTy, AddressTy->getAddressSpace());
+    Address = Builder.CreatePointerCast(Address, AddressTy);
+  }
+  return Address;
+}
+
+CallSite ABICallSignature::emitUnmanagedCall(GenIR &Reader, Value *Target,
+                                             bool MayThrow,
+                                             ArrayRef<Value *> Arguments,
+                                             Value *&Result) const {
+  const LLILCJitContext &JitContext = *Reader.JitContext;
+  const struct CORINFO_EE_INFO::InlinedCallFrameInfo &CallFrameInfo =
+      JitContext.EEInfo.inlinedCallFrameInfo;
+  LLVMContext &LLVMContext = *JitContext.LLVMContext;
+  Type *Int8Ty = Type::getInt8Ty(LLVMContext);
+  Type *Int32Ty = Type::getInt32Ty(LLVMContext);
+  Type *Int8PtrTy = Reader.getUnmanagedPointerType(Int8Ty);
+  IRBuilder<> &Builder = *Reader.LLVMBuilder;
+
+  Reader.insertIRForUnmanagedCallFrame();
+
+  Value *CallFrame = Reader.UnmanagedCallFrame;
+  Value *Thread = Reader.ThreadPointer;
+  assert(CallFrame != nullptr);
+  assert(Thread != nullptr);
+
+  // Set m_pDatum if necessary
+  //
+  // TODO: this needs to be updated for direct unmanaged calls, which require
+  //       the target method handle instead of the stub secret parameter.
+  if (Reader.MethodSignature.hasSecretParameter()) {
+    Value *SecretParameter = Reader.secretParam();
+    Value *CallTargetAddress =
+        getFieldAddress(Builder, CallFrame, CallFrameInfo.offsetOfCallTarget,
+                        SecretParameter->getType());
+    Builder.CreateStore(SecretParameter, CallTargetAddress);
+  }
+
+  // Push the unmanaged call frame
+  Value *FrameVPtr = getFieldAddress(Builder, CallFrame,
+                                     CallFrameInfo.offsetOfFrameVptr, Int8Ty);
+  Value *ThreadBase = Builder.CreateLoad(Thread);
+  Value *ThreadFrameAddress = getFieldAddress(
+      Builder, ThreadBase, JitContext.EEInfo.offsetOfThreadFrame, Int8PtrTy);
+  Builder.CreateStore(FrameVPtr, ThreadFrameAddress);
+
+  // Compute the address of the return address field
+  Value *ReturnAddressAddress = getFieldAddress(
+      Builder, CallFrame, CallFrameInfo.offsetOfReturnAddress, Int8PtrTy);
+
+  // Compute the address of the GC mode field
+  Value *GCStateAddress = getFieldAddress(
+      Builder, ThreadBase, JitContext.EEInfo.offsetOfGCState, Int8Ty);
+
+  // Compute address of the thread trap field
+  Value *ThreadTrapAddress = nullptr;
+  Type *ThreadTrapAddressTy = Reader.getUnmanagedPointerType(Int32Ty);
+  void *IndirectAddrOfCaptureThreadGlobal = nullptr;
+  void *AddrOfCaptureThreadGlobal =
+      (void *)JitContext.JitInfo->getAddrOfCaptureThreadGlobal(
+          &IndirectAddrOfCaptureThreadGlobal);
+  if (AddrOfCaptureThreadGlobal != nullptr) {
+    Value *RawThreadTrapAddress = ConstantInt::get(
+        LLVMContext, APInt(Reader.TargetPointerSizeInBits,
+                           (uint64_t)AddrOfCaptureThreadGlobal));
+    ThreadTrapAddress =
+        Builder.CreateIntToPtr(RawThreadTrapAddress, ThreadTrapAddressTy);
+  } else {
+    Value *IndirectThreadTrapAddress = ConstantInt::get(
+        LLVMContext, APInt(Reader.TargetPointerSizeInBits,
+                           (uint64_t)IndirectAddrOfCaptureThreadGlobal));
+    Type *IndirectAddressTy =
+        Reader.getUnmanagedPointerType(ThreadTrapAddressTy);
+    Value *TypedIndirectAddress =
+        Builder.CreateIntToPtr(IndirectThreadTrapAddress, IndirectAddressTy);
+    ThreadTrapAddress = Builder.CreateLoad(TypedIndirectAddress);
+  }
+
+  // Compute address of GC pause helper
+  Value *PauseHelperAddress =
+      (Value *)Reader.getHelperCallAddress(CORINFO_HELP_STOP_FOR_GC);
+
+  // Construct the call.
+  //
+  // The signature of the intrinsic is:
+  // @llvm.experimental_gc_transition(
+  //   fn_ptr target,
+  //   i32 numCallArgs,
+  //   i32 unused,
+  //   ... call args ...,
+  //   i32 numTransitionArgs,
+  //   ... transition args...,
+  //   i32 numDeoptArgs,
+  //   ... deopt args...)
+  //
+  // In the case of CoreCLR, there are 4 transition args and 0 deopt args.
+  //
+  // The transition args are:
+  // 0) Address of the return address field
+  // 1) Address of the GC mode field
+  // 2) Address of the thread trap global
+  // 3) Address of CORINFO_HELP_STOP_FOR_GC
+  Module *M = Reader.Function->getParent();
+  Type *CallTypeArgs[] = {Target->getType()};
+  Function *CallIntrinsic = Intrinsic::getDeclaration(
+      M, Intrinsic::experimental_gc_transition, CallTypeArgs);
+
+  const uint32_t PrefixArgCount = 3;
+  const uint32_t TransitionArgCount = 4;
+  const uint32_t PostfixArgCount = TransitionArgCount + 2;
+  const uint32_t TargetArgCount = Arguments.size();
+  SmallVector<Value *, 16> IntrinsicArgs(PrefixArgCount + TargetArgCount +
+                                         PostfixArgCount);
+
+  // Call target and target arguments
+  IntrinsicArgs[0] = Target;
+  IntrinsicArgs[1] = ConstantInt::get(Int32Ty, TargetArgCount);
+  IntrinsicArgs[2] = ConstantInt::get(Int32Ty, 0);
+
+  uint32_t I, J;
+  for (I = 0, J = 3; I < TargetArgCount; I++, J++) {
+    IntrinsicArgs[J] = Arguments[I];
+  }
+
+  // GC transition arguments
+  IntrinsicArgs[J] = ConstantInt::get(Int32Ty, TransitionArgCount);
+  IntrinsicArgs[J + 1] = ReturnAddressAddress;
+  IntrinsicArgs[J + 2] = GCStateAddress;
+  IntrinsicArgs[J + 3] = ThreadTrapAddress;
+  IntrinsicArgs[J + 4] = PauseHelperAddress;
+
+  // Deopt arguments
+  IntrinsicArgs[J + 5] = ConstantInt::get(Int32Ty, 0);
+
+  CallSite Call = Reader.makeCall(CallIntrinsic, MayThrow, IntrinsicArgs);
+
+  // Get the call result if necessary
+  if (!FuncResultType->isVoidTy()) {
+    Type *ResultTypeArgs[] = {FuncResultType};
+    Function *ResultIntrinsic = Intrinsic::getDeclaration(
+        M, Intrinsic::experimental_gc_result, ResultTypeArgs);
+    Result = Builder.CreateCall(ResultIntrinsic, Call.getInstruction());
+  }
+
+  // Deactivate the unmanaged call frame
+  Builder.CreateStore(Constant::getNullValue(Int8PtrTy), ReturnAddressAddress);
+
+  // Pop the unmanaged call frame
+  Value *FrameLinkAddress = getFieldAddress(
+      Builder, CallFrame, CallFrameInfo.offsetOfFrameLink, Int8PtrTy);
+  Value *FrameLink = Builder.CreateLoad(FrameLinkAddress);
+  Builder.CreateStore(FrameLink, ThreadFrameAddress);
+
+  return Call;
+}
+
+Value *ABICallSignature::emitCall(GenIR &Reader, Value *Target, bool MayThrow,
+                                  ArrayRef<Value *> Args,
+                                  Value *IndirectionCell,
+                                  Value **CallNode) const {
   assert(Target->getType()->isIntegerTy(Reader.TargetPointerSizeInBits));
 
   // Compute the function type
   bool HasIndirectResult = Result.getKind() == ABIArgInfo::Indirect;
   bool HasIndirectionCell = IndirectionCell != nullptr;
-  uint32_t NumExtraArgs =
-      (HasIndirectResult ? 1 : 0) + (HasIndirectionCell ? 1 : 0);
-  int32_t ResultIndex = -1;
+  bool IsUnmanagedCall =
+      Signature.getCallingConvention() != CORINFO_CALLCONV_DEFAULT;
+  assert(((HasIndirectionCell ? 1 : 0) + (IsUnmanagedCall ? 1 : 0)) <= 1);
+
+  uint32_t NumSpecialArgs = 0;
+  if (HasIndirectionCell) {
+    NumSpecialArgs = 1;
+  }
+
+  uint32_t NumExtraArgs = (HasIndirectResult ? 1 : 0) + NumSpecialArgs;
   Value *ResultNode = nullptr;
   SmallVector<Type *, 16> ArgumentTypes(Args.size() + NumExtraArgs);
   SmallVector<Value *, 16> Arguments(Args.size() + NumExtraArgs);
   IRBuilder<> &Builder = *Reader.LLVMBuilder;
 
-  // Check for VSD calls.
+  // Check for calls with special args.
+  //
+  // Any special arguments are passed immediately preceeding the normal
+  // arguments. The backend will place these arguments in the appropriate
+  // registers according to the calling convention. Each special argument should
+  // be machine-word-sized.
   if (HasIndirectionCell) {
-    // The indirection cell is passed as the first argument. The backend will
-    // place it in the appropriate register. The indirection cell should be
-    // integer-typed.
     assert(IndirectionCell->getType()->isIntegerTy(
         Reader.TargetPointerSizeInBits));
     ArgumentTypes[0] = IndirectionCell->getType();
     Arguments[0] = IndirectionCell;
   }
 
+  int32_t ResultIndex = -1;
   if (HasIndirectResult) {
-    ResultIndex = (HasIndirectionCell ? 1 : 0) + (Signature.hasThis() ? 1 : 0);
+    ResultIndex = (int32_t)NumSpecialArgs + (Signature.hasThis() ? 1 : 0);
     ArgumentTypes[ResultIndex] =
         Reader.getUnmanagedPointerType(Result.getType());
     Arguments[ResultIndex] = ResultNode =
         Reader.createTemporary(Result.getType());
   }
 
-  uint32_t I = HasIndirectionCell ? 1 : 0, J = 0;
+  uint32_t I = NumSpecialArgs, J = 0;
   for (auto Arg : Args) {
     if (ResultIndex >= 0 && I == (uint32_t)ResultIndex) {
       I++;
@@ -150,14 +351,29 @@ Value *ABICallSignature::emitCall(GenIR &Reader, llvm::Value *Target,
   Type *FunctionPtrTy = Reader.getUnmanagedPointerType(FunctionTy);
 
   Target = Builder.CreateIntToPtr(Target, FunctionPtrTy);
-  CallSite Call = Reader.makeCall(Target, MayThrow, Arguments);
+
+  // The most straightforward way to satisfy the constraints imposed by the GC
+  // on threads that are executing unmanaged code is to make the transition to
+  // and from unmanaged code immediately preceeding and following the machine
+  // call instruction, respectively. Unfortunately, there is no way to express
+  // this in "standard" LLVM IR, hence the intrinsic. This intrinsic is also
+  // a special GC statepoint that forces any GC pointers in callee-saved
+  // registers to be spilled to the stack.
+  CallSite Call;
+  Value *UnmanagedCallResult = nullptr;
+  if (IsUnmanagedCall) {
+    Call = emitUnmanagedCall(Reader, Target, MayThrow, Arguments,
+                             UnmanagedCallResult);
+  } else {
+    Call = Reader.makeCall(Target, MayThrow, Arguments);
+  }
 
   CallingConv::ID CC;
   if (HasIndirectionCell) {
     assert(Signature.getCallingConvention() == CORINFO_CALLCONV_DEFAULT);
     CC = CallingConv::CLR_VirtualDispatchStub;
   } else {
-    CC = getLLVMCallingConv(Signature.getCallingConvention());
+    CC = getLLVMCallingConv(getNormalizedCallingConvention(Signature));
   }
   Call.setCallingConv(CC);
 
@@ -165,7 +381,12 @@ Value *ABICallSignature::emitCall(GenIR &Reader, llvm::Value *Target,
     assert(!HasIndirectResult);
     const CallArgType &SigResultType = Signature.getResultType();
     Type *Ty = Reader.getType(SigResultType.CorType, SigResultType.Class);
-    ResultNode = coerce(Reader, Ty, Call.getInstruction());
+    if (!Ty->isVoidTy()) {
+      ResultNode = coerce(Reader, Ty, IsUnmanagedCall ? UnmanagedCallResult
+                                                      : Call.getInstruction());
+    } else {
+      ResultNode = Call.getInstruction();
+    }
   } else {
     ResultNode = Builder.CreateLoad(ResultNode);
   }


### PR DESCRIPTION
Unmanaged calls require some extra machinery to setup the necessary data
structures and inform the runtime that control is entering unmanaged code.

This code is comprised of two pieces:
- Unmanaged call frame setup, which occurs in the method prolog, and
- GC mode transition, which occurs at an unmanaged call site.

Unmanaged call frame setup is relatively simple and can be accomplished
entirely in LLVM IR.

The GC transition, however, is more complicated due to the constraints
that must be satisfied for the GC to operate correctly when unmanaged code
is running. In particular, managed code must not run if the GC has been
informed that unmanaged code is running. The approach taken by other
managed code generators (e.g. RyuJIT) in order to meet this constraint is
to inform the GC of the transitions to and from unmanaged code immediately
before and after the machine call instruction, respectively. The same approach
is taken here through the use of the @llvm.experimental.gc_transition intrinic,
which informs the backend to surround the call with the appropriate transition
code. Any code that is not part of the transition itself is represented
directly in IR.