### PR TITLE
Update test environment to make sure we're jitting everything.

### DIFF
--- a/test/LLILCTestEnv.cmd
+++ b/test/LLILCTestEnv.cmd
@@ -7,3 +7,4 @@ REM -------------------------------------------------------------------------
 set COMPLUS_AltJit=*
 set COMPLUS_AltJitName=LLILCJit.dll
 set COMPLUS_GCCONSERVATIVE=1
+set COMPLUS_ZapDisable=1

--- a/test/llilc_runtest.py
+++ b/test/llilc_runtest.py
@@ -175,6 +175,7 @@ def main(argv):
             test_env.write('set COMPlus_AltJit=*\n')
             test_env.write('set COMPlus_AltJitName=' + time_stamped_jit_name + '\n')
             test_env.write('set COMPlus_GCConservative=1\n')
+            test_env.write('set COMPlus_ZapDisable=1\n')
             test_env.write('chcp 65001\n')
             if args.dump_level is not None:
                 test_env.write('set COMPlus_DumpLLVMIR=' + args.dump_level + '\n')


### PR DESCRIPTION
This is needed because recent builds of the core CLR provide an ngen image for mscorlib.

Closes #490.