### PR TITLE
Remove addressOfLeaf.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -3100,9 +3100,7 @@ public:
   // //////////////////////////////////////////////////////////////////////////
 
   // Asks GenIR to make operand value accessible by address, and return a node
-  // that references
-  // the incoming operand by address.
-  virtual IRNode *addressOfLeaf(IRNode *Leaf) = 0;
+  // that references the incoming operand by address.
   virtual IRNode *addressOfValue(IRNode *Leaf) = 0;
 
   /// \brief Delegate to GenIR to generate code to instantiate a new MDArray.

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -703,7 +703,6 @@ public:
 
   // Asks GenIR to make operand value accessible by address, and return a node
   // that references the incoming operand by address.
-  IRNode *addressOfLeaf(IRNode *Leaf) override;
   IRNode *addressOfValue(IRNode *Leaf) override;
 
   IRNode *genNewMDArrayCall(ReaderCallTargetData *CallTargetData,

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -4051,7 +4051,7 @@ void ReaderBase::rdrCallFieldHelper(
       // What this means, is that the helper will *not* return the
       // value that we are interested in.  Instead, it will pass a
       // pointer to the return value as the first param.
-      Arg1 = addressOfLeaf(Dst);
+      Arg1 = addressOfValue(Dst);
 
       // Arg 2
       Arg2 = Obj;
@@ -5001,7 +5001,7 @@ ReaderBase::rdrCall(ReaderCallTargetData *Data, ReaderBaseNS::CallOpcode Opcode,
 #ifdef _WIN64
         case CORINFO_INTRINSIC_StubHelpers_GetStubContextAddr:
           IntrinsicRet = secretParam();
-          IntrinsicRet = addressOfLeaf(IntrinsicRet);
+          IntrinsicRet = addressOfValue(IntrinsicRet);
           if (IntrinsicRet) {
             return IntrinsicRet;
           }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2993,7 +2993,7 @@ IRNode *GenIR::loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Obj,
   Type *AddressTy = Obj->getType();
 
   if (AddressTy->isStructTy() || AddressTy->isFloatingPointTy()) {
-    Obj = addressOfLeaf(Obj);
+    Obj = addressOfValue(Obj);
   }
 
   if (CorInfoType == CORINFO_TYPE_VALUECLASS ||
@@ -3316,10 +3316,6 @@ IRNode *GenIR::makeBoxDstOperand(CORINFO_CLASS_HANDLE Class) {
   Type *Ty = getBoxedType(Class);
   Value *Ptr = llvm::Constant::getNullValue(getManagedPointerType(Ty));
   return (IRNode *)Ptr;
-}
-
-IRNode *GenIR::addressOfLeaf(IRNode *Leaf) {
-  throw NotYetImplementedException("AddressOfLeaf");
 }
 
 IRNode *GenIR::loadElem(ReaderBaseNS::LdElemOpcode Opcode,


### PR DESCRIPTION
All uses of addressOfLeaf can instead be replaced with uses of
addressOfValue.

With these changes, LLILC is able to compile all methods
necessary for the Hello World sample at https://github.com/dotnet/corefxlab/tree/master/demos/CoreClrConsoleApplications/HelloWorld.