### PR TITLE
Support for storing value type to static field

### DIFF
--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -4222,9 +4222,7 @@ void ReaderBase::rdrCallWriteBarrierHelper(
     } else {
       // If the class doesn't have a gc layout then use a memcopy
       IRNode *Size = loadConstantI4(getClassSize(Class));
-      const bool MayThrow = true;
-      callHelper(CORINFO_HELP_MEMCPY, MayThrow, nullptr, Dst, Src, Size,
-                 nullptr, Alignment, IsVolatile);
+      cpBlk(Size, Src, Dst, Alignment, IsVolatile);
     }
   }
 }


### PR DESCRIPTION
This is the case where we don't need writer barrier which was already filtered out.
I use cpBlk which falls back to memcpy helper call to implement this.
I've verified this with a unit test which will commit to our test asset in separate.