### PR TITLE
Override deregisterEHFrames.

### DIFF
--- a/include/Jit/EEMemoryManager.h
+++ b/include/Jit/EEMemoryManager.h
@@ -108,12 +108,24 @@ public:
   ///
   /// This is currently invoked once per .xdata section. The EE uses this info
   /// to build and register the appropriate .pdata with the OS.
-  /// \param Addr           The address of the data in the pre-loaded image.
-  /// \param LoadAddr       The address the data will have once loaded.
-  /// \param Size           Size of the unwind data in bytes.
+  ///
+  /// \param Addr      The address of the data in the pre-loaded image.
+  /// \param LoadAddr  The address the data will have once loaded.
+  /// \param Size      Size of the unwind data in bytes.
+  ///
   /// \note Because we're not relocating data during loading, \p Addr and
   /// \p LoadAddr are currently identical.
   void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr, size_t Size) override;
+
+  /// \brief Callback to handle unregistering unwind data.
+  ///
+  /// This is currently a no-op.
+  ///
+  /// \param Addr      The address of the data in the image.
+  /// \param LoadAddr  The address the data has after loading.
+  /// \param Size      Size of the unwind data in bytes.
+  void deregisterEHFrames(uint8_t *Addr, uint64_t LoadAddr,
+                          size_t Size) override;
 
 private:
   LLILCJitContext *Context;         ///< LLVM context for types, etc.

--- a/lib/Jit/EEMemoryManager.cpp
+++ b/lib/Jit/EEMemoryManager.cpp
@@ -98,7 +98,10 @@ void EEMemoryManager::reserveAllocationSpace(uintptr_t CodeSize,
   CorJitAllocMemFlag Flag =
       CorJitAllocMemFlag::CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN;
 
-  assert(DataSizeRW == 0);
+  // We allow the amount of RW data to be nonzero to work around the fact that
+  // MCJIT will not report a size of zero for any section, even if that
+  // section does not, in fact, contain any data. allocateDataSection will
+  // catch any RW sections that are actually allocated.
 
   uint8_t *HotBlock = nullptr;
   uint8_t *ColdBlock = nullptr;
@@ -135,6 +138,9 @@ void EEMemoryManager::registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
       this->HotCodeBlock, nullptr, StartOffset, EndOffset, Size,
       (BYTE *)LoadAddr, CorJitFuncKind::CORJIT_FUNC_ROOT);
 }
+
+void EEMemoryManager::deregisterEHFrames(uint8_t *Addr, uint64_t LoadAddr,
+                                         size_t Size) {}
 
 EEMemoryManager::~EEMemoryManager() {
   // nothing yet.


### PR DESCRIPTION
This is a no-op for now, but is required for correctness given that we
also overload registerEHFrames.