### PR TITLE
Fix for GenIR::cmp

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -5394,7 +5394,7 @@ IRNode *GenIR::cmp(ReaderBaseNS::CmpOpcode Opcode, IRNode *Arg1, IRNode *Arg2) {
     Cmp = LLVMBuilder->CreateICmp(IntCmpMap[Opcode], Arg1, Arg2);
   }
 
-  IRNode *Result = convertToStackType((IRNode *)Cmp, CORINFO_TYPE_INT);
+  IRNode *Result = convertToStackType((IRNode *)Cmp, CORINFO_TYPE_UINT);
 
   return Result;
 }


### PR DESCRIPTION
Zero-extend the result of ICmp and FCmp from i1 to i32 instead of sign-extending it.

Now the result of ICmp and FCmp is 0 or 1 instead of 0 or -1.
This was causing bad codegen for a couple of Roslyn methods.

Closes #517.