### PR TITLE
Infer the type of 'this' in indirect calls.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -3209,6 +3209,13 @@ public:
 
   virtual IRNode *makeDirectCallTargetNode(void *CodeAddress) = 0;
 
+  /// \brief Infer the type of the 'this' argument to an indirect call from
+  ///        the given IR node.
+  ///
+  /// \param ThisArgument  The IR node that represents the 'this' argument.
+  /// \returns The class handle that corresponds to the type of the node.
+  virtual CORINFO_CLASS_HANDLE inferThisClass(IRNode *ThisArgument) = 0;
+
   // Called once region tree has been built.
   virtual void setEHInfo(EHRegion *EhRegionTree,
                          EHRegionList *EhRegionList) = 0;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -796,6 +796,8 @@ public:
 
   IRNode *makeDirectCallTargetNode(void *CodeAddr) override;
 
+  CORINFO_CLASS_HANDLE inferThisClass(IRNode *ThisArgument) override;
+
   // Called once region tree has been built.
   void setEHInfo(EHRegion *EhRegionTree, EHRegionList *EhRegionList) override;
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3763,6 +3763,26 @@ IRNode *GenIR::getTypeFromHandle(IRNode *Arg1) {
   return (IRNode *)LLVMBuilder->CreateLoad(FieldAddress, IsVolatile);
 }
 
+CORINFO_CLASS_HANDLE GenIR::inferThisClass(IRNode *ThisArgument) {
+  Type *Ty = ((Value *)ThisArgument)->getType();
+  assert(Ty->isPointerTy());
+
+  // Check for a ref class first.
+  auto MapElem = ReverseClassTypeMap->find(Ty);
+  if (MapElem != ReverseClassTypeMap->end()) {
+    return MapElem->second;
+  }
+
+  // No hit, check for a value class.
+  Ty = Ty->getPointerElementType();
+  MapElem = ReverseClassTypeMap->find(Ty);
+  if (MapElem != ReverseClassTypeMap->end()) {
+    return MapElem->second;
+  }
+
+  return nullptr;
+}
+
 bool GenIR::canMakeDirectCall(ReaderCallTargetData *CallTargetData) {
   return !CallTargetData->isJmp();
 }


### PR DESCRIPTION
Indirect call signatures may not specify the type of the 'this' parameter
of the target method. To handle this case, infer the type of the 'this'
parameter from the type of the 'this' argument. This is consistent with
the behavior prescribed by ECMA-335, which states that the type of the
'this' argument should be assumed to be correct in this case (see section
III.3.20).