### PR TITLE
Enable ReaderBase::printMSIL in debug builds.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1550,7 +1550,7 @@ public:
   FlowGraphNode *fgSplitBlock(FlowGraphNode *Block, uint32_t Offset,
                               IRNode *Node);
 
-#if defined(_DEBUG)
+#if !defined(NDEBUG)
   /// \brief Debug-only reader function to print range of MSIL.
   ///
   /// Print the MSIL in the buffer for the given range. Output emitted via

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -370,7 +370,7 @@ underflow:
   return ILSize;
 }
 
-#if !defined(NODEBUG) || defined(CC_PEVERIFY)
+#if !defined(NDEBUG) || defined(CC_PEVERIFY)
 
 const char *OpcodeName[] = {
 #define OPDEF_HELPER OPDEF_OPCODENAME
@@ -380,7 +380,7 @@ const char *OpcodeName[] = {
 
 #endif
 
-#ifndef NODEBUG
+#if !defined(NDEBUG)
 void ReaderBase::printMSIL(uint8_t *Buf, uint32_t StartOffset,
                            uint32_t EndOffset) {
   uint8_t *Operand;


### PR DESCRIPTION
The #ifdefs controlling the inclusion of printMSIL were using incorrect
preprocessor symbols. This method can be used from a debugger to dump
the IL for a method being compiled.