### PR TITLE
Preemptively add predecessor operands for PHI nodes and implement LLVM's dead block removal

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1870,8 +1870,11 @@ private:
   /// Walk the flow graph and remove any block that cannot be reached from the
   /// head block. Blocks are removed by calling \p fgDeleteBlockAndNodes.
   ///
+  /// Clients can override this if they have their own global dead block
+  /// removal.
+  ///
   /// \param FgHead     the head block of the flow graph.
-  void fgRemoveUnusedBlocks(FlowGraphNode *FgHead);
+  virtual void fgRemoveUnusedBlocks(FlowGraphNode *FgHead);
 
   /// Find the canonical landing point for leaves from an EH region.
   ///

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -580,6 +580,7 @@ public:
   };
   bool fgBlockHasFallThrough(FlowGraphNode *Block) override;
 
+  void fgRemoveUnusedBlocks(FlowGraphNode *FgHead) override;
   void fgDeleteBlock(FlowGraphNode *Block) override;
   void fgDeleteEdge(FlowGraphEdgeList *Arc) override {
     throw NotYetImplementedException("fgDeleteEdge");

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -1983,9 +1983,6 @@ void ReaderBase::fgRemoveUnusedBlocks(FlowGraphNode *FgHead) {
       // TODO - possibly more cleanup checking is warranted.
       // Also need to issue warning when nontrivial code is removed.
       fgDeleteBlockAndNodes(Block);
-    } else {
-      ASSERTNR(fgNodeIsVisited(Block));
-      fgNodeSetVisited(Block, false);
     }
     Block = NextBlock;
   }
@@ -8043,6 +8040,18 @@ void ReaderBase::msilToIR(void) {
 
   // Remove blocks that weren't marked as visited.
   fgRemoveUnusedBlocks(FgHead);
+
+  // Verify that all blocks that remain were, in fact, visited.
+  // Also, unset the visited bit on these blocks.
+  for (FlowGraphNode *Block = FgHead; Block != nullptr;) {
+    FlowGraphNode *NextBlock;
+    NextBlock = fgNodeGetNext(Block);
+#if !defined(NDEBUG)
+    ASSERTNR(fgNodeIsVisited(Block));
+#endif
+    fgNodeSetVisited(Block, false);
+    Block = NextBlock;
+  }
 
   // Report result of verification to the VM
   if ((Flags & CORJIT_FLG_SKIP_VERIFICATION) == 0) {

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -18,9 +18,10 @@
 #include "newvstate.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/IR/Intrinsics.h"
-#include "llvm/Support/Debug.h"       // for dbgs()
-#include "llvm/Support/raw_ostream.h" // for errs()
-#include "llvm/Support/ConvertUTF.h"  // for ConvertUTF16toUTF8
+#include "llvm/Support/Debug.h"          // for dbgs()
+#include "llvm/Support/raw_ostream.h"    // for errs()
+#include "llvm/Support/ConvertUTF.h"     // for ConvertUTF16toUTF8
+#include "llvm/Transforms/Utils/Local.h" // for removeUnreachableBlocks
 #include <cstdlib>
 #include <new>
 
@@ -2133,6 +2134,10 @@ FlowGraphNode *GenIR::fgSplitBlock(FlowGraphNode *Block, IRNode *Node) {
   }
   fgNodeSetPropagatesOperandStack((FlowGraphNode *)NewBlock, PropagatesStack);
   return (FlowGraphNode *)NewBlock;
+}
+
+void GenIR::fgRemoveUnusedBlocks(FlowGraphNode *FgHead) {
+  removeUnreachableBlocks(*this->Function);
 }
 
 void GenIR::fgDeleteBlock(FlowGraphNode *Node) {
@@ -5841,7 +5846,20 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
         if (CreatePHIs) {
           // The Successor has at least 2 predecessors so we use 2 as the
           // hint for the number of PHI sources.
+          // TODO: Could be nice to have actual pred. count here instead, but
+          // there's no simple way of fetching that, AFAICT.
           PHI = createPHINode(SuccessorBlock, CurrentValue->getType(), 2, "");
+
+          // Preemptively add all predecessors to the PHI node to ensure
+          // that we don't forget any once we're done.
+          FlowGraphEdgeList *PredecessorList =
+              fgNodeGetPredecessorListActual(SuccessorBlock);
+          while (PredecessorList != nullptr) {
+            PHI->addIncoming(UndefValue::get(CurrentValue->getType()),
+                             fgEdgeListGetSource(PredecessorList));
+            PredecessorList =
+                fgEdgeListGetNextPredecessorActual(PredecessorList);
+          }
         } else {
           // PHI instructions should have been inserted already
           PHI = cast<PHINode>(CurrentInst);
@@ -5877,9 +5895,11 @@ void GenIR::AddPHIOperand(PHINode *PHI, Value *NewOperand,
       PHI->mutateType(NewPHITy);
       for (int i = 0; i < PHI->getNumOperands(); ++i) {
         Value *Operand = PHI->getIncomingValue(i);
-        BasicBlock *OperandBlock = PHI->getIncomingBlock(i);
-        Operand = ChangePHIOperandType(Operand, OperandBlock, NewPHITy);
-        PHI->setIncomingValue(i, Operand);
+        if (!isa<UndefValue>(Operand)) {
+          BasicBlock *OperandBlock = PHI->getIncomingBlock(i);
+          Operand = ChangePHIOperandType(Operand, OperandBlock, NewPHITy);
+          PHI->setIncomingValue(i, Operand);
+        }
       }
     }
     if (NewPHITy != NewOperandTy) {
@@ -5889,7 +5909,11 @@ void GenIR::AddPHIOperand(PHINode *PHI, Value *NewOperand,
     LLVMBuilder->restoreIP(SavedInsertPoint);
   }
 
-  PHI->addIncoming(NewOperand, NewBlock);
+  int BlockIndex = PHI->getBasicBlockIndex(NewBlock);
+  if (BlockIndex >= 0)
+    PHI->setIncomingValue(BlockIndex, NewOperand);
+  else
+    PHI->addIncoming(NewOperand, NewBlock);
 }
 
 Value *GenIR::ChangePHIOperandType(Value *Operand, BasicBlock *OperandBlock,

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -69,5 +69,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\uint.cmd"/>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ulong.cmd"/>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ushort.cmd"/>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\fgtest2.cmd"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This fixes #489 and #529.

The test `fgtest2` mentioned in #489 still fails, but that's because it throws an exception in the test itself.