### PR TITLE
Implement loadAndBox

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -392,9 +392,8 @@ public:
   };
 
   IRNode *loadAndBox(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Addr,
-                     ReaderAlignType AlignmentPrefix) override {
-    throw NotYetImplementedException("loadAndBox");
-  };
+                     ReaderAlignType AlignmentPrefix) override;
+
   IRNode *convertHandle(IRNode *RuntimeTokenNode, CorInfoHelpFunc HelperID,
                         CORINFO_CLASS_HANDLE ClassHandle) override;
   void


### PR DESCRIPTION
This is a simple-minded implementation of `loadAndBox` that loads the value and then passes it off to the box handler.

Closes #300.

For primitives and value types the box handler will immediately turn around and store the value so it can pass the value's address to the box helper, which then loads the value and stores it into the box payload. I've left optimizing this path as a TODO and will open a linked issue.