### PR TITLE
Implement EndFault stub support

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1661,12 +1661,12 @@ protected:
   FlowGraphNodeOffsetList *fgAddNodeMSILOffset(FlowGraphNode **Node,
                                                uint32_t TargetOffset);
 
-  /// Get the innermost finally region enclosing the given \p Offset.
+  /// Get the innermost fault or finally region enclosing the given \p Offset.
   ///
   /// \param Offset  MSIL offset of interest.
-  /// \returns The innermost finally region enclosing \p Offset if one exists;
-  ///          nullptr otherwise.
-  EHRegion *getInnermostFinallyRegion(uint32_t Offset);
+  /// \returns The innermost fault or finally region enclosing \p Offset if one
+  ///          exists; nullptr otherwise.
+  EHRegion *getInnermostFaultOrFinallyRegion(uint32_t Offset);
 
   /// Find the next-innermost region enclosing the given \p Offset.
   ///
@@ -1852,18 +1852,6 @@ private:
   IRNode *fgMakeBranchHelper(IRNode *LabelNode, IRNode *BlockNode,
                              uint32_t Offset, bool IsConditional,
                              bool IsNominal);
-
-  /// \brief Create IR for an endfinally instruction.
-  ///
-  /// Have the client create IR for an endfinally instruction. Note
-  /// there can be more than one of these in a finally region.
-  ///
-  /// \param BlockNode     the block that is the end of the finally.
-  /// \param FinallyRegion the finally region being ended.
-  /// \param Offset        msil offset for the endfinally instruction.
-  /// \returns the branch generated to terminate the block for this endfinally.
-  IRNode *fgMakeEndFinallyHelper(IRNode *BlockNode, EHRegion *FinallyRegion,
-                                 uint32_t Offset);
 
   /// \brief Remove all unreachable blocks.
   ///
@@ -3038,8 +3026,28 @@ public:
   virtual IRNode *fgMakeBranch(IRNode *LabelNode, IRNode *BlockNode,
                                uint32_t CurrentOffset, bool IsConditional,
                                bool IsNominal) = 0;
+  /// \brief Create IR for an endfinally instruction.
+  ///
+  /// Have the client create IR for an endfinally instruction. Note
+  /// there can be more than one of these in a finally region.
+  ///
+  /// \param BlockNode     the block that is the end of the finally.
+  /// \param FinallyRegion the finally region being ended.
+  /// \param Offset        msil offset for the endfinally instruction.
+  /// \returns the branch generated to terminate the block for this endfinally.
   virtual IRNode *fgMakeEndFinally(IRNode *BlockNode, EHRegion *FinallyRegion,
                                    uint32_t CurrentOffset) = 0;
+  /// \brief Create IR for an endfault instruction.
+  ///
+  /// Have the client create IR for an endfault instruction. Note
+  /// there can be more than one of these in a fault region.
+  ///
+  /// \param BlockNode     the block that is the end of the fault.
+  /// \param FaultRegion   the fault region being ended.
+  /// \param Offset        msil offset for the endfault instruction.
+  /// \returns the branch generated to terminate the block for this endfault.
+  virtual IRNode *fgMakeEndFault(IRNode *BlockNode, EHRegion *FaultRegion,
+                                 uint32_t CurrentOffset) = 0;
 
   // turns an unconditional branch to the entry label into a fall-through
   // or a branch to the exit label, depending on whether it was a recursive

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -619,6 +619,8 @@ public:
                        bool IsNominal) override;
   IRNode *fgMakeEndFinally(IRNode *InsertNode, EHRegion *FinallyRegion,
                            uint32_t CurrentOffset) override;
+  IRNode *fgMakeEndFault(IRNode *InsertNode, EHRegion *FaultRegion,
+                         uint32_t CurrentOffset) override;
 
   // turns an unconditional branch to the entry label into a fall-through
   // or a branch to the exit label, depending on whether it was a recursive

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2188,9 +2188,7 @@ IRNode *GenIR::fgMakeThrow(IRNode *Insert) {
 
 IRNode *GenIR::fgMakeEndFinally(IRNode *InsertNode, EHRegion *FinallyRegion,
                                 uint32_t CurrentOffset) {
-  if (FinallyRegion == nullptr) {
-    throw NotYetImplementedException("endfinally null region");
-  }
+  assert(FinallyRegion != nullptr);
 
   BasicBlock *Block = (BasicBlock *)InsertNode;
   SwitchInst *Switch = FinallyRegion->EndFinallySwitch;
@@ -2216,6 +2214,19 @@ IRNode *GenIR::fgMakeEndFinally(IRNode *InsertNode, EHRegion *FinallyRegion,
   // Generate and return branch to the block that holds the switch
   LLVMBuilder->SetInsertPoint(Block);
   return (IRNode *)LLVMBuilder->CreateBr(TargetBlock);
+}
+
+IRNode *GenIR::fgMakeEndFault(IRNode *InsertNode, EHRegion *FaultRegion,
+                              uint32_t CurrentOffset) {
+  // Fault handlers can only be reached by exceptions, and we don't
+  // yet support handling exceptions, so this can't be reached.
+  // Generate an UnreachableInst to keep the IR well-formed.
+  // When we do support handlers, this will become a branch to the
+  // next outer handler.
+
+  BasicBlock *Block = (BasicBlock *)InsertNode;
+  LLVMBuilder->SetInsertPoint(Block);
+  return (IRNode *)LLVMBuilder->CreateUnreachable();
 }
 
 void GenIR::beginFlowGraphNode(FlowGraphNode *Fg, uint32_t CurrOffset,


### PR DESCRIPTION
`endfinally` and `endfault` are the same MSIL instruction (distinguished by
whether the enclosing region's type is `fault` or `finally`).  Accomodate
both by changing the `getInnermostFinallyRegion` helper to also find
`fault`s (and rename it to `getInnermostFaultOrFinallyRegion`), adding
`fgMakeEndFault` parallel to `fgMakeEndFinally`, and invoking one or the
other according to the discovered region type.  Also get rid of the
superfluous `fgMakeEndFinallyHelper` routine.

`fgMakeEndFault` just generates an UnreachableInst for now (since handlers
are stubbed out).

Closes #393