### PR TITLE
Add GetManagedThreadId to the list of intrinsics handled as normal calls...

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -4141,6 +4141,10 @@ IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo, bool MayThrow,
       // For now just treat as a normal call.
       break;
     }
+    case CORINFO_INTRINSIC_GetManagedThreadId: {
+      // For now just treat as a normal call.
+      break;
+    }
     default:
       throw NotYetImplementedException("Call intrinsic");
     }


### PR DESCRIPTION
....

As with the other similar cases the jit can simply decline to optimize, and that's what we do here for GetManagedThreadId.