### PR TITLE
Add Issue ItemMetaData to ItemGroup ExcludeList in exclusion.targets 

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -1,65 +1,185 @@
 <Project DefaultTargets = "GetListOfTestCmds"
     xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
-        <ExcludeList Include="$(XunitTestBinBase)\Interop\ICastable\Castable.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\div2.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\localloc.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Or_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Or_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_And_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_No_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Or_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Xor_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_And_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_And_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Xor_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_And_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Or_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Xor_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Xor_Op.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\eh1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\funclet.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\fgtest1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfpseh5_1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfpseh6_1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\regress\vswhidbey\339415.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\regress\vswhidbey\143837.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\fieldExprUnchecked1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeArray.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeArray1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\hugeexpr1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeField1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeField2.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\hugeSimpleExpr1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExprUnchecked1.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\Inline_Handler.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\Inline_Vars.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\InlineThrow.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_class_instance01.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_class_static01.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_struct_instance01.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_struct_static01.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_instance01.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_instance02.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_static01.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_static02.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_instance01.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_instance02.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_static01.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_static02.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\bool.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\byte.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\char.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\decimal.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\double.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\float.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\int.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\long.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\sbyte.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\short.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\uint.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ulong.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ushort.cmd"/>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\fgtest2.cmd"/>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\ICastable\Castable.cmd" >
+             <Issue>547</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\div2.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\localloc.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList> 
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Or_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Or_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_And_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_No_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Or_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Xor_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_And_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_And_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Xor_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_And_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Or_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Xor_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Xor_Op.cmd" >
+             <Issue>480</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\eh1.cmd" >
+             <Issue>420</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\funclet.cmd" >
+             <Issue>420</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\fgtest1.cmd" >
+             <Issue>420</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\fgtest2.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfpseh5_1.cmd" >
+             <Issue>420</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfpseh6_1.cmd" >
+             <Issue>420</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\regress\vswhidbey\339415.cmd" >
+             <Issue>420</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\regress\vswhidbey\143837.cmd" >
+             <Issue>420</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\fieldExprUnchecked1.cmd" >
+             <Issue>462</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeArray.cmd" >
+             <Issue>462</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeArray1.cmd" >
+             <Issue>462</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\hugeexpr1.cmd" >
+             <Issue>462</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeField1.cmd" >
+             <Issue>462</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeField2.cmd" >
+             <Issue>462</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\hugeSimpleExpr1.cmd" >
+             <Issue>462</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExprUnchecked1.cmd" >
+             <Issue>462</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\Inline_Handler.cmd" >
+             <Issue>487</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\Inline_Vars.cmd" >
+             <Issue>487</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\InlineThrow.cmd" >
+             <Issue>487</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_class_instance01.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_class_static01.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_struct_instance01.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_struct_static01.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_instance01.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_instance02.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_static01.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_static02.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_instance01.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_instance02.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_static01.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_static02.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\bool.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\byte.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\char.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\decimal.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\double.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\float.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\int.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\long.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\sbyte.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\short.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\uint.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ulong.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ushort.cmd" >
+             <Issue>516</Issue>
+        </ExcludeList>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Add Issue ItemMetaData to ItemGroup ExcludeList in excusion.targets
for each test case so that when a known issue is fixed we know which
tests to re-enable. Some of the issue numbers are relatively general
and more like a placeholder. As investigation goes on and we become
clearer about the causes, more specific issue number will replace the
placeholder.