### PR TITLE
Stub out getValueFromRuntimeHandle.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -384,9 +384,8 @@ public:
 
   IRNode *getTypeFromHandle(IRNode *HandleNode) override;
 
-  IRNode *getValueFromRuntimeHandle(IRNode *Arg1) override {
-    throw NotYetImplementedException("getValueFromRuntimeHandle");
-  };
+  IRNode *getValueFromRuntimeHandle(IRNode *Arg1) override;
+
   IRNode *arrayGetDimLength(IRNode *Arg1, IRNode *Arg2,
                             CORINFO_CALL_INFO *CallInfo) override {
     throw NotYetImplementedException("arrayGetDimLength");

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3882,6 +3882,18 @@ IRNode *GenIR::getTypeFromHandle(IRNode *Arg1) {
   return (IRNode *)LLVMBuilder->CreateLoad(FieldAddress, IsVolatile);
 }
 
+IRNode *GenIR::getValueFromRuntimeHandle(IRNode *Arg1) {
+  // TODO: other JITs either
+  // a) do not optimize this path, or
+  // b) only optimize here if the incoming argument is the result of lowering
+  //    a ldtoken instruction.
+  //
+  // We don't yet have the ability do detect (b) yet; stick with (a) in the
+  // meantime.
+
+  return nullptr;
+}
+
 CORINFO_CLASS_HANDLE GenIR::inferThisClass(IRNode *ThisArgument) {
   Type *Ty = ((Value *)ThisArgument)->getType();
   assert(Ty->isPointerTy());


### PR DESCRIPTION
Other JITs either
a) do not optimize this path, or
b) only optimize here if the incoming argument is the result of lowering
   a ldtoken instruction.

We don't yet have the ability do detect (b); stick with (a) in the meantime.