### PR TITLE
Implement support for union types.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1322,6 +1322,11 @@ private:
   /// \returns    LLVM type that models the built-in string type.
   llvm::Type *getBuiltInStringType();
 
+  /// Get the LLVM type for the built-in object type.
+  ///
+  /// \returns    LLVM type that models the built-in object type.
+  llvm::Type *getBuiltInObjectType();
+
   /// Get the LLVM type for an array of references.
   ///
   /// Used when we know that some type must be an array but our local
@@ -1345,6 +1350,32 @@ private:
   uint32_t addArrayFields(std::vector<llvm::Type *> &Fields,
                           CorInfoType ElementCorType,
                           CORINFO_CLASS_HANDLE ElementClassHandle);
+
+  /// Add fields of a type to the field vector, expanding structures
+  /// (recursively) to the types they contain.
+  ///
+  /// \param Fields    vector of offset, type info for overlapping fields.
+  /// \param Offset    offset of the new type to add.
+  /// \param Ty        the new type to add.
+  void
+  addFieldsRecursively(std::vector<std::pair<uint32_t, llvm::Type *>> &Fields,
+                       uint32_t Offset, llvm::Type *Ty);
+
+  /// Given a set of overlapping primitive typed fields, determine the set of
+  /// representative fields to used to describe these in an LLVM type and add
+  /// them to the field collection for that type. Ensure that any GC
+  /// references are properly described. Non-GC fields will be represented by
+  /// suitably sized byte arrays.
+  ///
+  /// \param OverlapFields [in, out]  On input, vector of offset, type info for
+  ///                                 overlapping fields. Empty on on exit.
+  /// \param Fields [in, out]         On input, vector of field types found so
+  ///                                 far for the ultimate type being
+  ///                                 constructed. On exit, extended with
+  ///                                 representative fields for the overlap set.
+  void createOverlapFields(
+      std::vector<std::pair<uint32_t, llvm::Type *>> &OverlapFields,
+      std::vector<llvm::Type *> &Fields);
 
 private:
   LLILCJitContext *JitContext;


### PR DESCRIPTION
Closes #275.

Types with explicit layout may have fields that overlap one another (aka union types). Before this change we'd fail to compile any method that referenced one of these union types. We now model them as best we can using LLVM types.

LLVM doesn't provide a strong way to describe unions. Instead we generally provide a byte array that covers the extent of the union as a representative placeholder. That means for some fields there is no exact LLMV type counterpart. Downstream consumers cope with this as follows: for any field within the extent of a set of overlapping fields, we omit that field handle from the `FieldIndexMap`, so that when a ldfld or similar goes to find out what LLVM type index to use, it comes up empty-handed. We already had a fall-back path here to simply use the EE provided field offset when this happens, and so now that path kicks in for accesses to overlapping fields, and subsequent pointer casts then fix up the types properly.

However things are not quite that simple. We also want the LLVM type to fully describe the location of any GC references within the type, and it is valid for GC references to appear in one of these overlap sets. GC references must fully overlap one another and can't be safely overlapped with non-GC data (see Ecma-355, II.10.7). This means the extents of the GC references in an union partition the union into ranges of either non-GC data or GC references. We report the former using the byte arrays, and the latter as object references. Thus for instance a type `C` like
```
[StructLayout(LayoutKind.Explicit)]
public struct A
{
    [FieldOffset(0)]public string Name;
    [FieldOffset(8)]public int Size;
}

[StructLayout(LayoutKind.Explicit)]
public struct C
{
    [FieldOffset(0)]public A X;
    [FieldOffset(0)]public string Name;
    [FieldOffset(8)]public int Size;
}

```
would on x64 be described as
```
type <{ %System.Object addrspace(1)*, [8 x i8] }>
```
This special handling for GC references is strictly only necessary for value types (since GC reference locations for value types on the stack must be reported at GC safe points) but for uniformity we do it for all types. We also continue to double-check value type GC locations against the GC pointer info provided by the EE.