### PR TITLE
Implement multidimensional array access intrinsics.

### DIFF
--- a/Documentation/llilc-reader.md
+++ b/Documentation/llilc-reader.md
@@ -140,7 +140,7 @@ LLVM Types.
     single LLVM Type: ClassTypeMap and ArrayTypeMap.  ClassTypeMap is
     indexed by CORINFO\_CLASS\_HANDLE and is used for non-array types.
     ArrayTypeMap is indexed by `<element type, element handle, array
-    rank>` tuple.  The reason for that is that two different
+    rank, is vector>` tuple.  The reason for that is that two different
     CORINFO\_CLASS\_HANDLEs can identify the same array: the actual
     array handle and the handle for its MethodTable.
 

--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -143,8 +143,9 @@ public:
   /// them.
   ///
   /// \note Arrays can't be looked up via the \p ClassTypeMap. Instead they
-  /// are looked up via element type, element handle, and array rank.
-  std::map<std::tuple<CorInfoType, CORINFO_CLASS_HANDLE, uint32_t>,
+  /// are looked up via element type, element handle, array rank, and whether
+  /// this array is a vector (single-dimensional array with zero lower bound).
+  std::map<std::tuple<CorInfoType, CORINFO_CLASS_HANDLE, uint32_t, bool>,
            llvm::Type *> ArrayTypeMap;
 
   /// \brief Map from a field handle to the index of that field in the overall

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1551,6 +1551,9 @@ public:
                               IRNode *Node);
 
 #if !defined(NDEBUG)
+  /// \brief Debug-only reader function to print MSIL of the current method.
+  void printMSIL();
+
   /// \brief Debug-only reader function to print range of MSIL.
   ///
   /// Print the MSIL in the buffer for the given range. Output emitted via

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -381,6 +381,10 @@ const char *OpcodeName[] = {
 #endif
 
 #if !defined(NDEBUG)
+void ReaderBase::printMSIL() {
+  printMSIL(MethodInfo->ILCode, 0, MethodInfo->ILCodeSize);
+}
+
 void ReaderBase::printMSIL(uint8_t *Buf, uint32_t StartOffset,
                            uint32_t EndOffset) {
   uint8_t *Operand;


### PR DESCRIPTION
Implement arrayGet, arraySet, and arrayAddress to expand 2D and 3D
array accesses inline; allow runtime helper to do the expansions
for arrays of other dimensions.

Fix getTypedAddress to deal with ldind.ref with a nativeint arg.
(This was a new test failure after unblocking methods with md array
accesses).

Remove NYI for intrinsics in GenIR::genCall since only a fixed set
of intrinsics is expected to be expanded there; the rest should be
turned into runtime helper calls. Note that ReaderBase::rdrCall also
looks at intrinsics.

Add printMSIL() to dump msil for the current method.

Closes #530.
Closes #540.
Closes #560.