### PR TITLE
Remove two vestigial IRNode property setters

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1180,12 +1180,6 @@ uint32_t irNodeGetMSILOffset(IRNode *Node);
 /// \param Offset    The MSIL offset to use
 void irNodeLabelSetMSILOffset(IRNode *Node, uint32_t Offset);
 
-/// Set the MSIL offset for this branch IR node
-///
-/// \param BranchNode      The node in question
-/// \param Offset          The MSIL offset to use
-void irNodeBranchSetMSILOffset(IRNode *BranchNode, uint32_t Offset);
-
 /// Set the MSIL offset for this exception branch IR node.
 ///
 /// \param BranchNode      The node in question
@@ -1203,12 +1197,6 @@ void irNodeInsertBefore(IRNode *InsertionPoint, IRNode *NewNode);
 /// \param InsertionPoint    Existing IR to use as insertion point
 /// \param NewNode           New IR to insert after \p InsertionPoint
 void irNodeInsertAfter(IRNode *InsertionPoint, IRNode *NewNode);
-
-/// Set the EH region for an IR node
-///
-/// \param Node        The IR node of interest
-/// \param Region      The EH region to associate with the \p Node
-void irNodeSetRegion(IRNode *Node, EHRegion *Region);
 
 /// Get the EH region for an IR node
 ///

--- a/lib/Reader/GenIRStubs.cpp
+++ b/lib/Reader/GenIRStubs.cpp
@@ -74,9 +74,6 @@ void irNodeLabelSetMSILOffset(IRNode *Node, uint32_t LabelMSILOffset) {
   throw NotYetImplementedException("irNodeLabelSetMSILOffset");
 }
 
-// TODO: figure out how we're going to communicate this information.
-void irNodeBranchSetMSILOffset(IRNode *BranchNode, uint32_t Offset) { return; }
-
 void irNodeExceptSetMSILOffset(IRNode *BranchNode, uint32_t Offset) {
   throw NotYetImplementedException("irNodeExceptSetMSILOffset");
 }
@@ -88,9 +85,6 @@ void irNodeInsertBefore(IRNode *InsertionPointTuple, IRNode *NewNode) {
 void irNodeInsertAfter(IRNode *InsertionPointTuple, IRNode *NewNode) {
   throw NotYetImplementedException("irNodeInsertAfter");
 }
-
-// TODO: figure out how we're going to communicate this information.
-void irNodeSetRegion(IRNode *Node, EHRegion *Region) { return; }
 
 EHRegion *irNodeGetRegion(IRNode *Node) {
   throw NotYetImplementedException("irNodeGetRegion");

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -2485,7 +2485,6 @@ void ReaderBase::fgInsertTryEnd(EHRegion *Region) {
   irNodeExceptSetMSILOffset(TryEndNode,
                             irNodeGetMSILOffset(rgnGetLast(Region)));
   irNodeInsertAfter(rgnGetLast(Region), TryEndNode);
-  irNodeSetRegion(TryEndNode, rgnGetParent(Region));
   rgnSetLast(Region, TryEndNode);
 
   EndOfClausesNode = findTryRegionEndOfClauses(Region);
@@ -2533,14 +2532,12 @@ void ReaderBase::fgInsertEHAnnotations(EHRegion *Region) {
     // Add the region starting marker
     RegionStartNode = makeRegionStartNode(RegionType);
     rgnSetHead(Region, RegionStartNode);
-    irNodeSetRegion(RegionStartNode, Region);
 
     fgInsertBeginRegionExceptionNode(OffsetStart, RegionStartNode);
 
     // Add the region ending marker.
     RegionEndNode = makeRegionEndNode(rgnGetRegionType(Region));
     rgnSetLast(Region, RegionEndNode);
-    irNodeSetRegion(RegionEndNode, Region);
     fgInsertEndRegionExceptionNode(OffsetEnd, RegionEndNode);
 
     // Patch the REGION_TRYBODY_END field and REGION_LAST field
@@ -2659,7 +2656,6 @@ IRNode *ReaderBase::fgMakeBranchHelper(IRNode *LabelNode, IRNode *BlockNode,
 
   BranchNode = fgMakeBranch(LabelNode, BlockNode, CurrentOffset, IsConditional,
                             IsNominal);
-  irNodeSetRegion(BranchNode, fgGetRegionFromMSILOffset(CurrentOffset));
   fgAddLabelToBranchList(LabelNode, BranchNode);
   return BranchNode;
 }
@@ -2970,8 +2966,6 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
 
       // Make the switch node.
       BranchNode = fgMakeSwitch((IRNode *)GraphNode, BlockNode);
-      irNodeBranchSetMSILOffset(BranchNode, CurrentOffset);
-      irNodeSetRegion(BranchNode, fgNodeGetRegion(Block));
 
       // Create the block to hold the switch node.
       fgNodeSetEndMSILOffset(Block, NextOffset);
@@ -2999,8 +2993,6 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
       // throw/rethrow splits a block
       BlockNode = fgNodeGetStartIRNode(Block);
       fgMakeThrow(BlockNode);
-      irNodeBranchSetMSILOffset(BranchNode, CurrentOffset);
-      irNodeSetRegion(BranchNode, fgNodeGetRegion(Block));
 
       fgNodeSetEndMSILOffset(Block, NextOffset);
       Block = fgSplitBlock(Block, NextOffset, nullptr);


### PR DESCRIPTION
 - irNodeSetRegion : we won't be mapping individual instructions to their
   regions, the call to do this for endfinally has already been removed
   (4bd6a1e), and the call to set this on `throw` nodes in the first pass
   is broken since we don't generate the throwing `call`/`invoke` until
   the second pass.
 - irNodeBranchSetMSILOffset : we won't be recording offsets on individual
   instructions, and the call for `throw` nodes is broken as for
   `irNodeSetRegion`