### PR TITLE
Verification errors should result in compilation failure

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -329,6 +329,7 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
 
   Function *Func = JitContext->CurrentModule->getFunction(FuncName);
   bool IsOk = !verifyFunction(*Func, &dbgs());
+  assert(IsOk && "verification failed");
 
   if (IsOk) {
     if (DumpLevel >= ::DumpLevel::SUMMARY) {
@@ -336,8 +337,9 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
     }
   } else {
     if (DumpLevel >= ::DumpLevel::SUMMARY) {
-      errs() << "Read " << FuncName << " but failed verification\n";
+      errs() << "Failed to read " << FuncName << "[verification error]\n";
     }
+    return false;
   }
 
   if (DumpLevel == ::DumpLevel::VERBOSE) {


### PR DESCRIPTION
Re-apply the change that was accidentally removed in 93b82adac634fe93c7b798f6d2a855b601ee9310. Verification errors
result in assert or compilation failure.

Closes #335.