### PR TITLE
Use GcInfo Encoding in LLILC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,13 @@ endif()
 set(WITH_CORECLR  "" CACHE PATH "Path to the directory where CoreCLR was built or installed.")
 set(CORECLR_SEARCH_PATHS "")
 set(CORECLR_INCLUDE "")
+set(CORECLR_GCINFO "")
 
 if( NOT WITH_CORECLR STREQUAL "" )
   get_filename_component(WITH_CORECLR_ABS "${WITH_CORECLR}" ABSOLUTE)
   list(APPEND CORECLR_SEARCH_PATHS "${WITH_CORECLR_ABS}")
   set(CORECLR_INCLUDE "${WITH_CORECLR_ABS}/inc")
+  set(CORECLR_GCINFO "${WITH_CORECLR_ABS}/gcinfo")  
 endif()
 
 # Check for CoreCLR headers
@@ -147,6 +149,21 @@ endif()
 find_path(OPENUM_H "openum.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
 if(OPENUM_H STREQUAL OPENUM_H-NOTFOUND)
   message(FATAL_ERROR "Cannot find openum.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
+endif()
+
+find_path(GCINFOTYPES_H "gcinfotypes.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+if(GCINFOTYPES_H STREQUAL GCINFOENCODER_H-NOTFOUND)
+  message(FATAL_ERROR "Cannot find gcinfotypes.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
+endif()
+
+find_path(GCINFOENCODER_H "gcinfoencoder.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+if(GCINFOENCODER_H STREQUAL GCINFOENCODER_H-NOTFOUND)
+  message(FATAL_ERROR "Cannot find gcinfoencoder.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
+endif()
+
+find_path(GCINFOENCODER_CPP "gcinfoencoder.cpp" PATHS "${CORECLR_GCINFO}" NO_DEFAULT_PATH)
+if(GCINFOENCODER_CPP STREQUAL GCINFOENCODER_CPP-NOTFOUND)
+  message(FATAL_ERROR "Cannot find gcinfoencoder.cpp. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
 endif()
 
 include_directories("${CORECLR_INCLUDE}")

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(clr)
 add_subdirectory(Driver)
+add_subdirectory(GcInfo)
 add_subdirectory(Jit)
 add_subdirectory(Pal)
 add_subdirectory(Reader)

--- a/include/GcInfo/GcInfo.h
+++ b/include/GcInfo/GcInfo.h
@@ -1,0 +1,22 @@
+//===---- include/gcinfo/gcinfo.h -------------------------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Wrapper that includes all GcInfo related headers
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef GCINFO_H
+#define GCINFO_H
+
+#define STANDALONE_BUILD
+#include "gcinfoencoder.h"
+
+#endif // GCINFO_H

--- a/include/GcInfo/GcInfoUtil.h
+++ b/include/GcInfo/GcInfoUtil.h
@@ -1,0 +1,686 @@
+//===---- include/gcinfo/gcinfoutil.h ---------------------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Utility classes used by GCInfoEncoder library
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef GCINFOUTIL_H
+#define GCINFOUTIL_H
+
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <new>
+#include <unordered_map>
+
+#include "global.h"
+#include "LLILCPal.h"
+
+#if defined(_MSC_VER)
+#include <windows.h>
+#else
+#include <cstddef>
+#include <cstdarg>
+#include "ntimage.h"
+#include "misc.h"
+#endif
+
+#include "corjit.h"
+#include "eexcp.h"
+
+//*****************************************************************************
+//  Helper Macros
+//*****************************************************************************
+
+#if !defined(_ASSERTE)
+#define _ASSERTE(expr) assert(expr)
+#endif
+#if !defined(_ASSERT)
+#define _ASSERT(expr) assert(expr)
+#endif
+
+//*****************************************************************************
+//  Logging Support
+//*****************************************************************************
+
+#define LF_GCINFO 1
+
+// LL_INFO##N: can be expected to generate NH logs per small but not trival run
+#define LL_EVERYTHING 10
+#define LL_INFO1000000 9
+#define LL_INFO100000 8
+#define LL_INFO10000 7
+#define LL_INFO1000 6
+#define LL_INFO100 5
+#define LL_INFO10 4
+#define LL_WARNING 3
+#define LL_ERROR 2
+#define LL_FATALERROR 1
+#define LL_ALWAYS 0
+
+#define FMT_STK "sp%s0x%02x "
+#define DBG_STK(off) (off >= 0) ? "+" : "-", (off >= 0) ? off : -off
+
+#ifdef GCINFOEMITTER_LOGGING
+#define LOG(x)                                                                 \
+  do {                                                                         \
+    gcinfo_log x;                                                              \
+  } while (0)
+#else
+#define LOG(x)
+#endif
+
+inline void gcinfo_log(long facility, long level, const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+}
+
+//*****************************************************************************
+//  Utility Functions
+//*****************************************************************************
+
+inline BOOL IS_ALIGNED(size_t val, size_t alignment) {
+  // alignment must be a power of 2 for this implementation to work
+  // (need modulo otherwise)
+  _ASSERTE(0 == (alignment & (alignment - 1)));
+  return 0 == (val & (alignment - 1));
+}
+
+inline BOOL IS_ALIGNED(const void *val, size_t alignment) {
+  return IS_ALIGNED((size_t)val, alignment);
+}
+
+//------------------------------------------------------------------------
+// BitPosition: Return the position of the single bit that is set in 'value'.
+//
+// Return Value:
+//    The position (0 is LSB) of bit that is set in 'value'
+//------------------------------------------------------------------------
+
+unsigned BitPosition(unsigned value);
+
+//*****************************************************************************
+//  Overflow Checking
+//*****************************************************************************
+
+template <class _Ty, _Ty _Val>
+struct integral_constant { // convenient template for integral constant types
+  static const _Ty value = _Val;
+
+  typedef _Ty value_type;
+  typedef integral_constant<_Ty, _Val> type;
+};
+
+typedef integral_constant<bool, true> true_type;
+typedef integral_constant<bool, false> false_type;
+
+template <class _Ty> struct remove_const { // remove top level const qualifier
+  typedef _Ty type;
+};
+
+template <class _Ty>
+struct remove_const<const _Ty> { // remove top level const qualifier
+  typedef _Ty type;
+};
+
+template <class _Ty>
+struct remove_const<const _Ty[]> { // remove top level const qualifier
+  typedef _Ty type[];
+};
+
+template <class _Ty, unsigned int _Nx>
+struct remove_const<const _Ty[_Nx]> { // remove top level const qualifier
+  typedef _Ty type[_Nx];
+};
+
+template <bool _Test, class _Ty1, class _Ty2>
+struct conditional { // type is _Ty2 for assumed !_Test
+  typedef _Ty2 type;
+};
+
+template <class _Ty1, class _Ty2>
+struct conditional<true, _Ty1, _Ty2> { // type is _Ty1 for _Test
+  typedef _Ty1 type;
+};
+
+template <typename T>
+struct is_signed
+    : conditional<static_cast<typename remove_const<T>::type>(-1) < 0,
+                  true_type, false_type>::type {};
+
+template <typename Dst, typename Src> inline bool FitsIn(Src val) {
+  if (is_signed<Src>::value ==
+      is_signed<Dst>::value) {        // Src and Dst are equally signed
+    if (sizeof(Src) <= sizeof(Dst)) { // No truncation is possible
+      return true;
+    } else { // Truncation is possible, requiring runtime check
+      return val == (Src)((Dst)val);
+    }
+  } else if (is_signed<Src>::value) { // Src is signed, Dst is unsigned
+#ifdef __GNUC__
+    // Workaround for GCC warning: "comparison is always
+    // false due to limited range of data type."
+    if (!(val == 0 || val > 0))
+#else
+    if (val < 0)
+#endif
+    { // A negative number cannot be represented by an unsigned type
+      return false;
+    } else {
+      if (sizeof(Src) <= sizeof(Dst)) { // No truncation is possible
+        return true;
+      } else { // Truncation is possible, requiring runtime check
+        return val == (Src)((Dst)val);
+      }
+    }
+  } else { // Src is unsigned, Dst is signed
+    if (sizeof(Src) <
+        sizeof(Dst)) { // No truncation is possible. Note that Src is strictly
+      // smaller than Dst.
+      return true;
+    } else { // Truncation is possible, requiring runtime check
+#ifdef __GNUC__
+      // Workaround for GCC warning: "comparison is always
+      // true due to limited range of data type." If in fact
+      // Dst were unsigned we'd never execute this code
+      // anyway.
+      return ((Dst)val > 0 || (Dst)val == 0) &&
+#else
+      return ((Dst)val >= 0) &&
+#endif
+             (val == (Src)((Dst)val));
+    }
+  }
+}
+
+//*****************************************************************************
+//  A Simple Allocator
+//*****************************************************************************
+
+class IAllocator {
+public:
+  virtual void *Alloc(size_t sz) = 0;
+
+  virtual void Free(void *p) = 0;
+};
+
+class GcInfoAllocator : public IAllocator {
+  static int ZeroLengthAlloc;
+
+public:
+  void *Alloc(size_t sz) {
+    if (sz == 0) {
+      return (void *)(&ZeroLengthAlloc);
+    }
+
+    return ::operator new(sz);
+  }
+
+  virtual void Free(void *p) {
+    if (p != (void *)(&ZeroLengthAlloc)) {
+      ::operator delete(p);
+    }
+  }
+};
+
+//*****************************************************************************
+//  Quick Sort Implementation
+//*****************************************************************************
+
+template <class T> class CQuickSort {
+protected:
+  T *m_pBase; // Base of array to sort.
+private:
+  SSIZE_T m_iCount;    // How many items in array.
+  SSIZE_T m_iElemSize; // Size of one element.
+public:
+  CQuickSort(T *pBase, // Address of first element.
+             SSIZE_T iCount)
+      : // How many there are.
+        m_pBase(pBase),
+        m_iCount(iCount), m_iElemSize(sizeof(T)) {}
+
+  // Call to sort the array.
+  inline void Sort() { SortRange(0, m_iCount - 1); }
+
+protected:
+  // Override this function to do the comparison.
+  __forceinline virtual int Compare( // -1, 0, or 1
+      T *psFirst,                    // First item to compare.
+      T *psSecond)                   // Second item to compare.
+  {
+    return (memcmp(psFirst, psSecond, sizeof(T)));
+  }
+
+  __forceinline virtual void Swap(SSIZE_T iFirst, SSIZE_T iSecond) {
+    if (iFirst == iSecond)
+      return;
+    T sTemp(m_pBase[iFirst]);
+    m_pBase[iFirst] = m_pBase[iSecond];
+    m_pBase[iSecond] = sTemp;
+  }
+
+private:
+  inline void SortRange(SSIZE_T iLeft, SSIZE_T iRight) {
+    SSIZE_T iLast;
+    SSIZE_T i; // loop variable.
+
+    for (;;) {
+      // if less than two elements you're done.
+      if (iLeft >= iRight)
+        return;
+
+      // ASSERT that we now have valid indicies.  This is statically provable
+      // since this private function is only called with valid indicies,
+      // and iLeft and iRight only converge towards eachother.  However,
+      // PreFast can't detect this because it doesn't know about our callers.
+      assert(iLeft >= 0 && iLeft < m_iCount);
+      assert(iRight >= 0 && iRight < m_iCount);
+
+      // The mid-element is the pivot, move it to the left.
+      Swap(iLeft, (iLeft + iRight) / 2);
+      iLast = iLeft;
+
+      // move everything that is smaller than the pivot to the left.
+      for (i = iLeft + 1; i <= iRight; i++) {
+        if (Compare(&m_pBase[i], &m_pBase[iLeft]) < 0) {
+          Swap(i, ++iLast);
+        }
+      }
+
+      // Put the pivot to the point where it is in between smaller
+      // and larger elements.
+      Swap(iLeft, iLast);
+
+      // Sort each partition.
+      SSIZE_T iLeftLast = iLast - 1;
+      SSIZE_T iRightFirst = iLast + 1;
+      if (iLeftLast - iLeft < iRight - iRightFirst) {
+        // Left partition is smaller, sort it recursively
+        SortRange(iLeft, iLeftLast);
+        // Tail call to sort the right (bigger) partition
+        iLeft = iRightFirst;
+        // iRight = iRight;
+        continue;
+      } else { // Right partition is smaller, sort it recursively
+        SortRange(iRightFirst, iRight);
+        // Tail call to sort the left (bigger) partition
+        // iLeft = iLeft;
+        iRight = iLeftLast;
+        continue;
+      }
+    }
+  }
+};
+
+//*****************************************************************************
+//  SList Implementation
+//*****************************************************************************
+
+//------------------------------------------------------------------
+// struct SLink, to use a singly linked list
+// have a data member m_Link of type SLink in your class
+// and instantiate the template SList class
+//--------------------------------------------------------------------
+
+struct SLink;
+typedef struct SLink *PTR_SLink;
+
+struct SLink {
+  PTR_SLink m_pNext;
+  SLink() { m_pNext = NULL; }
+
+  void InsertAfter(SLink *pLinkToInsert) {
+    _ASSERTE(NULL == pLinkToInsert->m_pNext);
+
+    PTR_SLink pTemp = m_pNext;
+
+    m_pNext = PTR_SLink(pLinkToInsert);
+    pLinkToInsert->m_pNext = pTemp;
+  }
+};
+
+//------------------------------------------------------------------
+// class SList. Intrusive singly linked list.
+//
+// To use SList with the default instantiation, your class should
+// define a data member of type SLink and named 'm_Link'. To use a
+// different field name, you need to provide an explicit LinkPtr
+// template argument. For example:
+//   'SList<MyClass, false, MyClass*, &MyClass::m_FieldName>'
+//--------------------------------------------------------------
+template <class T, typename __PTR = T *, SLink T::*LinkPtr = &T::m_Link>
+class SList {
+protected:
+  // used as sentinel
+  SLink m_link; // slink.m_pNext == Null
+  PTR_SLink m_pHead;
+  PTR_SLink m_pTail;
+
+  // get the list node within the object
+  static SLink *GetLink(T *pLink) { return &(pLink->*LinkPtr); }
+
+  // move to the beginning of the object given the pointer within the object
+  static T *GetObject(SLink *pLink) {
+    if (pLink == NULL) {
+      return NULL;
+    } else {
+      // GCC defines offsetof to be __builtin_offsetof, which doesn't use the
+      // old-school memory model trick to determine offset.
+      const UINT_PTR offset =
+          (((UINT_PTR) & (((T *)0x1000)->*LinkPtr)) - 0x1000);
+      return (T *)__PTR((ULONG_PTR)(pLink)-offset);
+    }
+  }
+
+public:
+  SList() {
+    m_pHead = &m_link;
+    m_pTail = &m_link;
+  }
+
+  bool IsEmpty() { return m_pHead->m_pNext == NULL; }
+
+  void InsertTail(T *pObj) {
+    _ASSERTE(pObj != NULL);
+    SLink *pLink = GetLink(pObj);
+
+    m_pTail->m_pNext = pLink;
+    m_pTail = pLink;
+  }
+
+  T *RemoveHead() {
+    SLink *pLink = m_pHead->m_pNext;
+    if (pLink != NULL) {
+      m_pHead->m_pNext = pLink->m_pNext;
+    }
+
+    if (m_pTail == pLink) {
+      m_pTail = m_pHead;
+    }
+
+    return GetObject(pLink);
+  }
+
+  T *GetHead() { return GetObject(m_pHead->m_pNext); }
+
+  static T *GetNext(T *pObj) {
+    _ASSERTE(pObj != NULL);
+    return GetObject(GetLink(pObj)->m_pNext);
+  }
+};
+
+//*****************************************************************************
+//  ArrayList Implementation
+//*****************************************************************************
+
+//*****************************************************************************
+// StructArrayList is an ArrayList, where the element type can be any
+// arbitrary type.  Elements can only be accessed sequentially.  This is
+// basically just a more efficient linked list - it's useful for accumulating
+// lots of small fixed-size allocations into larger chunks, which would
+// otherwise have an unnecessarily high ratio of heap overhead.
+//
+// The allocator provided must throw an exception on failure.
+//
+// The ArrayList has two properties:
+// -> Creates an initial array of specified size, and creates subsequent
+//    chunks of previous-size times the growth factor, up to a maximum
+// -> The pointers into the ArrayList are not invalidated
+//*****************************************************************************
+
+struct StructArrayListEntryBase {
+  StructArrayListEntryBase *pNext;
+};
+
+template <class ELEMENT_TYPE>
+struct StructArrayListEntry : StructArrayListEntryBase {
+  ELEMENT_TYPE rgItems[1];
+};
+
+class StructArrayListBase {
+protected:
+  typedef void *AllocProc(void *pvContext, SIZE_T cb);
+  typedef void FreeProc(void *pvContext, void *pv);
+
+  StructArrayListBase() {
+    m_pChunkListHead = NULL;
+    m_pChunkListTail = NULL;
+    m_nTotalItems = 0;
+  }
+
+  void Destruct(FreeProc *pfnFree) {
+    StructArrayListEntryBase *pList = m_pChunkListHead;
+    while (pList) {
+      StructArrayListEntryBase *pTrash = pList;
+      pList = pList->pNext;
+      pfnFree(this, pTrash);
+    }
+  }
+
+  size_t roundUp(size_t size, size_t mult = sizeof(size_t)) {
+    assert(mult && ((mult & (mult - 1)) == 0)); // power of two test
+
+    return (size + (mult - 1)) & ~(mult - 1);
+  }
+
+  void CreateNewChunk(SIZE_T InitialChunkLength, SIZE_T ChunkLengthGrowthFactor,
+                      SIZE_T cbElement, AllocProc *pfnAlloc, SIZE_T alignment);
+
+  class ArrayIteratorBase {
+  protected:
+    void SetCurrentChunk(StructArrayListEntryBase *pChunk,
+                         SIZE_T nChunkCapacity) {
+      m_pCurrentChunk = pChunk;
+
+      if (pChunk) {
+        if (pChunk == m_pArrayList->m_pChunkListTail)
+          m_nItemsInCurrentChunk = m_pArrayList->m_nItemsInLastChunk;
+        else
+          m_nItemsInCurrentChunk = nChunkCapacity;
+
+        m_nCurrentChunkCapacity = nChunkCapacity;
+      }
+    }
+
+    StructArrayListEntryBase *m_pCurrentChunk;
+    SIZE_T m_nItemsInCurrentChunk;
+    SIZE_T m_nCurrentChunkCapacity;
+    StructArrayListBase *m_pArrayList;
+  };
+  friend class ArrayIteratorBase;
+
+  StructArrayListEntryBase *
+      m_pChunkListHead; // actually StructArrayListEntry<ELEMENT_TYPE>*
+  StructArrayListEntryBase *
+      m_pChunkListTail; // actually StructArrayListEntry<ELEMENT_TYPE>*
+  SIZE_T m_nItemsInLastChunk;
+  SIZE_T m_nTotalItems;
+  SIZE_T m_nLastChunkCapacity;
+};
+
+template <class ELEMENT_TYPE, SIZE_T INITIAL_CHUNK_LENGTH,
+          SIZE_T CHUNK_LENGTH_GROWTH_FACTOR, class ALLOCATOR>
+class StructArrayList : public StructArrayListBase {
+private:
+  friend class ArrayIterator;
+
+public:
+  StructArrayList() {}
+
+  ~StructArrayList() { Destruct(&ALLOCATOR::Free); }
+
+  ELEMENT_TYPE *AppendThrowing() {
+    if (!m_pChunkListTail || m_nItemsInLastChunk == m_nLastChunkCapacity)
+      CreateNewChunk(INITIAL_CHUNK_LENGTH, CHUNK_LENGTH_GROWTH_FACTOR,
+                     sizeof(ELEMENT_TYPE), &ALLOCATOR::Alloc,
+                     __alignof(ELEMENT_TYPE));
+
+    m_nTotalItems++;
+    m_nItemsInLastChunk++;
+    return &((StructArrayListEntry<ELEMENT_TYPE> *)m_pChunkListTail)
+                ->rgItems[m_nItemsInLastChunk - 1];
+  }
+
+  SIZE_T Count() { return m_nTotalItems; }
+
+  VOID CopyTo(ELEMENT_TYPE *pDest) {
+    ArrayIterator iter(this);
+    ELEMENT_TYPE *pSrc;
+    SIZE_T nSrc;
+
+    while ((pSrc = iter.GetNext(&nSrc))) {
+      memcpy(pDest, pSrc, nSrc * sizeof(ELEMENT_TYPE));
+      pDest += nSrc;
+    }
+  }
+
+  ELEMENT_TYPE *GetIndex(SIZE_T index) {
+    ArrayIterator iter(this);
+
+    ELEMENT_TYPE *chunk;
+    SIZE_T count;
+    SIZE_T chunkBaseIndex = 0;
+
+    while ((chunk = iter.GetNext(&count))) {
+      SIZE_T nextBaseIndex = chunkBaseIndex + count;
+      if (nextBaseIndex > index) {
+        return (chunk + (index - chunkBaseIndex));
+      }
+      chunkBaseIndex = nextBaseIndex;
+    }
+    // Should never reach here
+    assert(false);
+    return NULL;
+  }
+
+  class ArrayIterator : public ArrayIteratorBase {
+  public:
+    ArrayIterator(StructArrayList *pArrayList) {
+      m_pArrayList = pArrayList;
+      SetCurrentChunk(pArrayList->m_pChunkListHead, INITIAL_CHUNK_LENGTH);
+    }
+
+    ELEMENT_TYPE *GetCurrent(SIZE_T *pnElements) {
+      ELEMENT_TYPE *pRet = NULL;
+      SIZE_T nElements = 0;
+
+      if (m_pCurrentChunk) {
+        pRet = &((StructArrayListEntry<ELEMENT_TYPE> *)m_pCurrentChunk)
+                    ->rgItems[0];
+        nElements = m_nItemsInCurrentChunk;
+      }
+
+      *pnElements = nElements;
+      return pRet;
+    }
+
+    // Returns NULL when there are no more items.
+    ELEMENT_TYPE *GetNext(SIZE_T *pnElements) {
+      ELEMENT_TYPE *pRet = GetCurrent(pnElements);
+
+      if (pRet)
+        SetCurrentChunk(m_pCurrentChunk->pNext,
+                        m_nCurrentChunkCapacity * CHUNK_LENGTH_GROWTH_FACTOR);
+
+      return pRet;
+    }
+  };
+};
+
+//*****************************************************************************
+//  SimplerHashTable Implementation
+//*****************************************************************************
+
+// This SimplerHashTable implementation simply uses std::unordered_map
+// with the hashing nad equality functions provided.
+
+// DefaultSimplerHashBehavior is the only behavior supported -- it simply
+// follows std::unordered_map's default allocation behavior
+class DefaultSimplerHashBehavior;
+
+template <typename Key, typename KeyFuncs, typename Value, typename Behavior>
+class SimplerHashTable {
+private:
+  class Hasher {
+  public:
+    size_t operator()(Key const &key) const {
+      return KeyFuncs::GetHashCode(key);
+    }
+  };
+
+  class Comparer {
+  public:
+    bool operator()(Key const &key1, Key const &key2) const {
+      return KeyFuncs::Equals(key1, key2);
+    }
+  };
+
+  typedef std::unordered_map<Key, Value, Hasher, Comparer> HashMap;
+  HashMap payload;
+
+public:
+  SimplerHashTable(IAllocator *allocator) : payload() {}
+
+  bool Lookup(Key key, Value *pVal) {
+    typename HashMap::const_iterator iterator = payload.find(key);
+
+    if (iterator != payload.end()) {
+      if (pVal != NULL) {
+        *pVal = iterator->second;
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  bool Set(Key key, Value value) {
+    bool preExisting = Lookup(key, NULL);
+    payload[key] = value;
+    return preExisting;
+  }
+
+  class KeyIterator {
+    friend class SimplerHashTable;
+
+  private:
+    typename HashMap::iterator keyIterator;
+
+  public:
+    KeyIterator(typename HashMap::iterator kIterator) {
+      keyIterator = kIterator;
+    }
+
+    const Key &Get() const { return keyIterator->first; }
+
+    const Value &GetValue() const { return keyIterator->second; }
+
+    void SetValue(const Value &value) const { keyIterator->second = value; }
+
+    void Next() { keyIterator++; }
+
+    bool Equal(KeyIterator kIterator) {
+      return (keyIterator == kIterator.keyIterator);
+    }
+  };
+
+  KeyIterator Begin() { return KeyIterator(payload.begin()); }
+
+  KeyIterator End() { return KeyIterator(payload.end()); }
+};
+
+#endif // GCINFOUTIL_H

--- a/include/GcInfo/eexcp.h
+++ b/include/GcInfo/eexcp.h
@@ -1,0 +1,33 @@
+//===----------------- include/clr/eexcp.h ----------------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Definition of some Exception handling structure definitions
+///  used in partially interruptible GC scenarios.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef __EEXCP_X__
+#define __EEXCP_X__
+
+struct EE_ILEXCEPTION_CLAUSE {
+  CorExceptionFlag Flags;
+  DWORD TryStartPC;
+  DWORD TryEndPC;
+  DWORD HandlerStartPC;
+  DWORD HandlerEndPC;
+  union {
+    void *TypeHandle;
+    mdToken ClassToken;
+    DWORD FilterOffset;
+  };
+};
+
+#endif // __EEXCP_X__

--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -233,8 +233,7 @@ private:
 
   /// Output GC info to the EE.
   /// \param JitContext Context record for the method's jit request.
-  /// \returns \p true if GC info was successfully reported.
-  bool outputGCInfo(LLILCJitContext *JitContext);
+  void outputGCInfo(LLILCJitContext *JitContext);
 
 public:
   /// A pointer to the singleton jit instance.

--- a/include/clr/misc.h
+++ b/include/clr/misc.h
@@ -1,0 +1,57 @@
+//===----------------- include/clr/misc.h -----------------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Miscellaneous helper functions defined in Windows CRT
+///  Explicitly defined here for use in other platforms.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef _MISC_H_
+#define _MISC_H_
+
+#if !defined(_MSC_VER)
+
+//-- Bit Manipulation --
+
+inline unsigned int __cdecl _rotl(unsigned int value, int shift)
+{
+  unsigned int retval = 0;
+
+  shift &= 0x1f;
+  retval = (value << shift) | (value >> (sizeof(int)* 8 - shift));
+  return retval;
+}
+
+inline unsigned int __cdecl _rotr(unsigned int value, int shift)
+{
+  unsigned int retval;
+
+  shift &= 0x1f;
+  retval = (value >> shift) | (value << (sizeof(int)* 8 - shift));
+  return retval;
+} 
+
+//-- Memory move/copy/set/cmp operations
+
+#define RtlEqualMemory(Destination,Source,Length) (!memcmp((Destination),(Source),(Length)))
+#define RtlMoveMemory(Destination,Source,Length) memmove((Destination),(Source),(Length))
+#define RtlCopyMemory(Destination,Source,Length) memcpy((Destination),(Source),(Length))
+#define RtlFillMemory(Destination,Length,Fill) memset((Destination),(Fill),(Length))
+#define RtlZeroMemory(Destination,Length) memset((Destination),0,(Length))
+
+#define MoveMemory RtlMoveMemory
+#define CopyMemory RtlCopyMemory
+#define FillMemory RtlFillMemory
+#define ZeroMemory RtlZeroMemory
+
+
+#endif // defined(MSC_VER)
+#endif // _MISC_H_

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Reader)
 add_subdirectory(Jit)
+add_subdirectory(GcInfo)

--- a/lib/GcInfo/CMakeLists.txt
+++ b/lib/GcInfo/CMakeLists.txt
@@ -1,0 +1,22 @@
+get_filename_component(LLILC_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../include ABSOLUTE)
+
+include_directories(${LLILC_INCLUDES}/clr
+                    ${LLILC_INCLUDES}/GcInfo
+                    ${LLILC_INCLUDES}/Jit
+                    ${LLILC_INCLUDES}/Pal)
+
+if( WIN32 )
+  set(CMAKE_CXX_FLAGS "-EHsc")
+endif()
+					
+add_definitions(-DSTANDALONE_BUILD)
+					
+if(CLR_CMAKE_PLATFORM_UNIX)
+    add_compile_options(-fPIC)
+endif(CLR_CMAKE_PLATFORM_UNIX)
+
+add_llilcjit_library(GcInfo
+    STATIC
+	${CORECLR_GCINFO}/gcinfoencoder.cpp
+	GcInfoUtil.cpp
+)

--- a/lib/GcInfo/GcInfoUtil.cpp
+++ b/lib/GcInfo/GcInfoUtil.cpp
@@ -1,0 +1,110 @@
+//===---- include/gcinfo/gcinfoutil.cpp -------------------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Implementation of utility classes used by GCInfoEncoder library
+///
+//===----------------------------------------------------------------------===//
+
+#include "GcInfoUtil.h"
+
+//*****************************************************************************
+//  GcInfoAllocator
+//*****************************************************************************
+
+int GcInfoAllocator::ZeroLengthAlloc = 0;
+
+//*****************************************************************************
+//  Utility Functions
+//*****************************************************************************
+
+//------------------------------------------------------------------------
+// BitPosition: Return the position of the single bit that is set in 'value'.
+//
+// Return Value:
+//    The position (0 is LSB) of bit that is set in 'value'
+//
+// Notes:
+//    'value' must have exactly one bit set.
+//    The algorithm is as follows:
+//    - PRIME is a prime bigger than sizeof(unsigned int), which is not of the
+//      form 2^n-1.
+//    - Taking the modulo of 'value' with this will produce a unique hash for
+//      all powers of 2 (which is what "value" is).
+//    - Entries in hashTable[] which are -1 should never be used. There
+//      should be PRIME-8*sizeof(value) entries which are -1 .
+//------------------------------------------------------------------------
+
+unsigned BitPosition(unsigned value) {
+  _ASSERTE((value != 0) && ((value & (value - 1)) == 0));
+  const unsigned PRIME = 37;
+
+  static const char hashTable[PRIME] = {
+      -1, 0,  1,  26, 2,  23, 27, -1, 3, 16, 24, 30, 28, 11, -1, 13, 4,  7, 17,
+      -1, 25, 22, 31, 15, 29, 10, 12, 6, -1, 21, 14, 9,  5,  20, 8,  19, 18};
+
+  _ASSERTE(PRIME >= 8 * sizeof(value));
+  _ASSERTE(sizeof(hashTable) == PRIME);
+
+  unsigned hash = value % PRIME;
+  unsigned index = hashTable[hash];
+  _ASSERTE(index != (unsigned char)-1);
+
+  return index;
+}
+
+//*****************************************************************************
+//  ArrayList
+//*****************************************************************************
+
+void StructArrayListBase::CreateNewChunk(SIZE_T InitialChunkLength,
+                                         SIZE_T ChunkLengthGrowthFactor,
+                                         SIZE_T cbElement, AllocProc *pfnAlloc,
+                                         SIZE_T alignment) {
+  _ASSERTE(InitialChunkLength > 0);
+  _ASSERTE(ChunkLengthGrowthFactor > 0);
+  _ASSERTE(cbElement > 0);
+
+  SIZE_T cbBaseSize =
+      SIZE_T(roundUp(sizeof(StructArrayListEntryBase), alignment));
+  SIZE_T maxChunkCapacity = (MAXSIZE_T - cbBaseSize) / cbElement;
+
+  _ASSERTE(maxChunkCapacity > 0);
+
+  SIZE_T nChunkCapacity;
+  if (!m_pChunkListHead)
+    nChunkCapacity = InitialChunkLength;
+  else
+    nChunkCapacity = m_nLastChunkCapacity * ChunkLengthGrowthFactor;
+
+  if (nChunkCapacity > maxChunkCapacity) {
+    // Limit nChunkCapacity such that cbChunk computation does not overflow.
+    nChunkCapacity = maxChunkCapacity;
+  }
+
+  SIZE_T cbChunk = cbBaseSize + SIZE_T(cbElement) * SIZE_T(nChunkCapacity);
+
+  StructArrayListEntryBase *pNewChunk =
+      (StructArrayListEntryBase *)pfnAlloc(this, cbChunk);
+
+  if (m_pChunkListTail) {
+    _ASSERTE(m_pChunkListHead);
+    m_pChunkListTail->pNext = pNewChunk;
+  } else {
+    _ASSERTE(!m_pChunkListHead);
+    m_pChunkListHead = pNewChunk;
+  }
+
+  pNewChunk->pNext = NULL;
+  m_pChunkListTail = pNewChunk;
+
+  m_nItemsInLastChunk = 0;
+  m_nLastChunkCapacity = nChunkCapacity;
+}

--- a/lib/Jit/CMakeLists.txt
+++ b/lib/Jit/CMakeLists.txt
@@ -2,6 +2,7 @@ get_filename_component(LLILC_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../include 
 
 include_directories(${LLILC_INCLUDES}/clr
                     ${LLILC_INCLUDES}/Pal
+                    ${LLILC_INCLUDES}/GcInfo
                     ${LLILC_INCLUDES}/Jit
                     ${LLILC_INCLUDES}/Reader)
 
@@ -18,7 +19,7 @@ set(LLVM_LINK_COMPONENTS
   native
   )
 
-set(LLILCJIT_LINK_LIBRARIES LLILCReader)
+set(LLILCJIT_LINK_LIBRARIES LLILCReader GcInfo)
 
 if (WIN32)
   set(CMAKE_CXX_FLAGS "-EHsc")
@@ -68,7 +69,7 @@ add_llilcjit_library(
   ${LLILCJIT_EXPORTS_DEF}
   )
 
-add_dependencies(llilcjit LLILCReader)
+add_dependencies(llilcjit LLILCReader GcInfo)
 
 target_link_libraries(
   llilcjit

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -13,6 +13,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "GcInfo.h"
 #include "jitpch.h"
 #include "LLILCJit.h"
 #include "jitoptions.h"
@@ -347,25 +348,18 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
   return IsOk;
 }
 
-// Stop gap function to allocate and emit stub GCInfo for the method.
-// This avoids a crash in the EE.
-// Assuming that this will be replaced by an override of the GCMetaData
-// or similar writer in LLVM once we move to the safepoint design.
-bool LLILCJit::outputGCInfo(LLILCJitContext *JitContext) {
-  size_t Size = 5;
-  void *GCInfoBuffer = JitContext->JitInfo->allocGCInfo(Size);
+void LLILCJit::outputGCInfo(LLILCJitContext *JitContext) {
+  GcInfoAllocator Allocator;
+  GcInfoEncoder gcInfoEncoder(JitContext->JitInfo, JitContext->MethodInfo,
+                              &Allocator);
 
-  if (GCInfoBuffer == nullptr) {
-    return false;
-  }
+  // The Encoder currently only encodes the CodeSize
+  // TODO: Encode pointer liveness information for GC-safepoints in the method
 
-  // First word of the GCInfoBuffer should be the size of the method.
-  *(uint32_t *)GCInfoBuffer = JitContext->HotCodeSize;
+  gcInfoEncoder.SetCodeLength(JitContext->HotCodeSize);
 
-  // 0x8 is the end sentinel of the buffer.
-  *(((char *)GCInfoBuffer) + 4) = 0x8;
-
-  return true;
+  gcInfoEncoder.Build();
+  gcInfoEncoder.Emit();
 }
 
 // Notification from the runtime that any caches should be cleaned up.


### PR DESCRIPTION
This change build LLILC with CoreCLR's GcInfoEncoding Library.
-> The GcInfoEncoder headers and implementation are available in CoreCLR's
   Output directory.
-> include\GcInfoUtil provides (alternate implementations for) some
   data-structures and utilities used by the encoder
-> LLILC generates GcInfo correctly using the encoder.

GcInfoUtil provides the following utilities used by the GcInfoEncoder:
1) Logging functions used by the encoder
2) Helpers for bit-manipulation and overflow checking
3) A simple allocator (using new and delete)
4) SList -- a singly linked list that supports insert-at-tail.
   This is a subset of SList in CoreCLR tree, with only necessary functionality.
5) CQuickSort - A simple quick sort implementation with comparer
   overridden by the GcInfo encoder library -- from the CoreClr tree.
6) StructArrayList -- a list of arrays which has specific growth and location
   preserving characteristics -- simplified version from CoreCLR tree.
7) SimplerHashTable -- a wrapper around standard unordered map, with
   the encoder's own hashing and comparison functions.

Testing:

All LLILC Unit tests pass
Rosly builds without the need for code-size workarounds.