### PR TITLE
TEST: Run tests with INSERTSTATEPOINTS

### DIFF
--- a/test/llilc_runtest.py
+++ b/test/llilc_runtest.py
@@ -156,6 +156,7 @@ def main(argv):
             test_env.write('set COMPlus_AltJit=*\n')
             test_env.write('set COMPlus_AltJitName=' + time_stamped_jit_name + '\n')
             test_env.write('set COMPlus_GCConservative=1\n')
+            test_env.write('set COMPlus_INSERTSTATEPOINTS=1\n')
             test_env.write('set COMPlus_ZapDisable=1\n')
             test_env.write('chcp 65001\n')
             if args.dump_level is not None:


### PR DESCRIPTION
I am **not** planning to checkin this change.
This PR is only to run the standard tests with statepoints inserted.
If this succeeds, we'll add test legs to run the standard tests with COMPLUS_InsertStatepoints set.