### PR TITLE
Parse the string value of COMPLUS_AltJit.  This specifies which methods

### DIFF
--- a/lib/Jit/jitoptions.cpp
+++ b/lib/Jit/jitoptions.cpp
@@ -112,10 +112,12 @@ bool JitOptions::queryIsAltJit(LLILCJitContext &Context) {
   }
 
 #ifdef ALT_JIT
-  if (AltJit->contains(Context.MethodName.data(), nullptr,
-                       Context.MethodInfo->args.pSig)) {
-    IsAlternateJit = true;
-  }
+  const char *ClassName = nullptr;
+  const char *MethodName = nullptr;
+  MethodName =
+      Context.JitInfo->getMethodName(Context.MethodInfo->ftn, &ClassName);
+  IsAlternateJit =
+      AltJit->contains(MethodName, ClassName, Context.MethodInfo->args.pSig);
 #endif // ALT_JIT
 
 #else

--- a/lib/Jit/utility.cpp
+++ b/lib/Jit/utility.cpp
@@ -1,58 +1,165 @@
-//===----------------- lib/Jit/utility.cpp ----------------------*- C++ -*-===//
-//
-// LLILC
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license.
-// See LICENSE file in the project root for full license information.
-//
-//===----------------------------------------------------------------------===//
-///
-/// \file
-/// \brief Definitions of utility classes.
-///
-//===----------------------------------------------------------------------===//
+// Utility code
+
+#include <cstdlib>
 
 #include "global.h"
 #include "jitpch.h"
+
+#include "cor.h" // CorSigUncompressData
 #include "utility.h"
 #include "llvm/Support/ConvertUTF.h"
 
-using namespace llvm;
+using std::string;
+using std::unique_ptr;
 
-// Checks given parsed representation to see if method is in the set.
+int MethodID::parseArgs(const string &S, size_t &I) {
+  size_t Start = ++I; // skip '('
 
-bool MethodSet::contains(const char *Name, const char *ClassName,
-                         PCCOR_SIGNATURE sig) {
-  assert(isInitialized());
+  I = S.find_first_of(")", I);
+  if (I == string::npos)
+    return MethodIDState::ANYARGS;
 
-  std::list<MethodName>::const_iterator iterator;
+  string num = string(S, Start, I - Start);
+  int NArgs = atoi(num.c_str());
+  ++I; // skip )
+  return NArgs;
+}
 
-  for (iterator = MethodList->begin(); iterator != MethodList->end();
-       ++iterator) {
-    if (iterator->Name->compare("*") == 0) {
-      return true;
+unique_ptr<MethodID> MethodID::parse(const string &S, size_t &I) {
+  MethodID MID;
+  size_t SLen = S.length();
+
+  string token = MID.scan(S, I);
+
+  if (token == "") // off the end of S
+    return nullptr;
+
+  if (token == "*") {
+    MID.ClassName = llvm::make_unique<string>(token);
+    MID.MethodName = nullptr;
+    if (I >= SLen || S[I] == ' ') {
+      MID.NumArgs = MethodIDState::ANYARGS;
     }
+    return llvm::make_unique<MethodID>(MID);
+    return nullptr;
+  }
 
-    // Just matching method name.  This is way too loose but have not yet
-    // plumbed through the class name and wildcard logic.
+  if (S[I] == ':') { // C:M | C:M(A)
+    MID.ClassName = llvm::make_unique<string>(token);
+    token = MID.scan(S, ++I); // M | M(A)
+  }
 
-    if (iterator->Name->compare(Name) == 0) {
+  MID.MethodName = llvm::make_unique<string>(token);
+
+  if (I >= SLen || S[I] == ' ') {
+    MID.NumArgs = MethodIDState::ANYARGS;
+    return llvm::make_unique<MethodID>(MID);
+    return nullptr;
+  }
+
+  if (S[I] != '(') // illegal
+    return nullptr;
+
+  MID.NumArgs = MID.parseArgs(S, I);
+  return llvm::make_unique<MethodID>(MID);
+  return nullptr;
+}
+
+string MethodID::scan(const string &S, size_t &I) {
+  const size_t SLen = S.length();
+
+  if (I >= SLen) // already 'off the end'
+    return string{""};
+
+  size_t Start = I = S.find_first_not_of(" \t", I); // skip whitespace
+
+  I = S.find_first_of(" :()", I);
+
+  if (I == string::npos) // eg: S = "*"
+    I = SLen;
+
+  return string(S, Start, I - Start);
+}
+
+void MethodSet::init(unique_ptr<string> ConfigValue) {
+  if (this->isInitialized()) {
+    return;
+  }
+  insert(std::move(ConfigValue));
+}
+
+void MethodSet::insert(unique_ptr<string> Ups) {
+  size_t I = 0;
+  std::list<MethodID> *MIDL = new std::list<MethodID>();
+  string S = *Ups;
+
+  auto MID = MethodID::parse(S, I);
+  while (MID) {
+    MIDL->push_back(*MID);
+    MID = MethodID::parse(S, I);
+  }
+
+  // This write should be atomic, delete if we're not the first.
+  llvm::sys::cas_flag F = llvm::sys::CompareAndSwap(
+      (llvm::sys::cas_flag *)&(this->Initialized), 0x1, 0x0);
+  if (F != 0x0) {
+    delete MIDL;
+  } else {
+    this->MethodIDList = MIDL;
+  }
+}
+
+bool MethodSet::contains(const char *MethodName, const char *ClassName,
+                         PCCOR_SIGNATURE PCSig) {
+
+  assert(this->isInitialized());
+
+  int NumArgs = MethodIDState::ANYARGS; // assume no signature supplied
+
+  if (PCSig) {
+    PCSig++; // skip calling convention
+    NumArgs = CorSigUncompressData(PCSig);
+  }
+
+  string StrClassName = ClassName ? ClassName : "";
+  string StrMethodName = MethodName ? MethodName : "";
+
+  auto begin = this->MethodIDList->begin();
+  auto end = this->MethodIDList->end();
+
+  for (auto p = begin; p != end; ++p) { // p => "pattern"
+
+    // Check for "*", the common case, first
+    if (p->ClassName && *p->ClassName == "*")
       return true;
-    }
+
+    // Check for mis-match on NumArgs
+    if (p->NumArgs != MethodIDState::ANYARGS && p->NumArgs != NumArgs)
+      continue;
+
+    // Check for mis-match on MethodName
+    if (p->MethodName && (*p->MethodName != StrMethodName))
+      continue;
+
+    // Check for match on ClassName (we already match NumArgs and MethodName)
+    if (!p->ClassName) // no ClassName
+      return true;
+
+    if (*p->ClassName == StrClassName)
+      return true;
   }
 
   return false;
 }
 
-std::unique_ptr<std::string> Convert::utf16ToUtf8(const char16_t *WideStr) {
+unique_ptr<std::string> Convert::utf16ToUtf8(const char16_t *WideStr) {
   // Get the length of the input
   size_t SrcLen = 0;
   for (; WideStr[SrcLen] != (char16_t)0; SrcLen++)
     ;
 
-  ArrayRef<char> SrcBytes((const char *)WideStr, 2 * SrcLen);
-  std::unique_ptr<std::string> OutString(new std::string);
+  llvm::ArrayRef<char> SrcBytes((const char *)WideStr, 2 * SrcLen);
+  unique_ptr<std::string> OutString(new std::string);
   convertUTF16ToUTF8String(SrcBytes, *OutString);
 
   return OutString;


### PR DESCRIPTION
This string specifies which methods should be fed to the Alternate JIT.

The patterns recognized are as follows:
  /// *         - all methods.
  /// M         - method M, with any number of arguments.
  /// C:M       - method M in class C.
  ///
  /// C can be a simple class name, or a namespace.classname.  For example,
  /// "Sort" or "System.Array:Sort".
  ///
  /// M can be followed by the pattern (number) to specify its number of
  /// arguments.  For example, .ctor(0) or Adjust(2)
  ///
  //  Eg: "  foo  Ns.MyClass:bar System.Array.Sort " holds 3 patterns.

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
# On branch master
# Your branch is ahead of 'origin/master' by 106 commits.
#   (use "git push" to publish your local commits)
#
# Changes to be committed:
#	modified:   include/Jit/utility.h
#	modified:   lib/Jit/jitoptions.cpp
#	modified:   lib/Jit/utility.cpp
#