### PR TITLE
Adjust GC transition codegen to accomodate patchable statepoints.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -4048,7 +4048,7 @@ IRNode *GenIR::mdArrayRefAddr(uint32_t Rank, llvm::Type *ElemType) {
       LLVMBuilder->CreateInBoundsGEP(Array, ElementAddressIndices);
 
   return (IRNode *)ElementAddress;
-};
+}
 
 void GenIR::branch() {
   TerminatorInst *TermInst = LLVMBuilder->GetInsertBlock()->getTerminator();


### PR DESCRIPTION
Patchable statepoint support added 2 additional arguments to the start of
the statepoint intrinsic. Pass zeroes for these arguments, as we don't need
either of them.