### PR TITLE
Enable zero and sign extension for call args/results.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1110,6 +1110,15 @@ private:
 
   uint32_t size(CorInfoType CorType);
   uint32_t stackSize(CorInfoType CorType);
+
+  /// \brief Determine whether a \p CorInfoType represents a signed integral
+  ///        type.
+  ///
+  /// \param CorType  The \p CorInfoType in question.
+  ///
+  /// \returns True if \p CorType represents a signed integral type.
+  static bool isSignedIntegralType(CorInfoType CorType);
+
   static bool isSigned(CorInfoType CorType);
   llvm::Type *getStackType(CorInfoType CorType);
 

--- a/lib/Reader/abi.cpp
+++ b/lib/Reader/abi.cpp
@@ -31,10 +31,13 @@ using namespace llvm;
 class X86_64_Win64 {
 private:
   X86_64_Win64() {}
-  static ABIArgInfo classify(Type *Ty, const DataLayout &DL);
+  static ABIArgInfo classify(const ABIType Ty, const DataLayout &DL,
+                             bool IsManagedCallingConv);
 
 public:
-  static void computeSignatureInfo(Type *ResultType, ArrayRef<Type *> ArgTypes,
+  static void computeSignatureInfo(bool IsManagedCallingConv,
+                                   ABIType ResultType,
+                                   ArrayRef<ABIType> ArgTypes,
                                    const DataLayout &DL, ABIArgInfo &ResultInfo,
                                    std::vector<ABIArgInfo> &ArgInfos);
 };
@@ -45,7 +48,9 @@ private:
   X86_64_SysV() {}
 
 public:
-  static void computeSignatureInfo(Type *ResultType, ArrayRef<Type *> ArgTypes,
+  static void computeSignatureInfo(bool IsManagedCallingConv,
+                                   ABIType ResultType,
+                                   ArrayRef<ABIType> ArgTypes,
                                    const DataLayout &DL, ABIArgInfo &ResultInfo,
                                    std::vector<ABIArgInfo> &ArgInfos);
 };
@@ -58,12 +63,16 @@ private:
 public:
   X86_64ABIInfo(Triple TargetTriple, const DataLayout &DL);
 
-  void computeSignatureInfo(CallingConv::ID CC, Type *ResultType,
-                            ArrayRef<Type *> ArgTypes, ABIArgInfo &ResultInfo,
+  void computeSignatureInfo(CallingConv::ID CC, bool IsManagedCallingConv,
+                            ABIType ResultType, ArrayRef<ABIType> ArgTypes,
+                            ABIArgInfo &ResultInfo,
                             std::vector<ABIArgInfo> &ArgInfos) const override;
 };
 
-ABIArgInfo X86_64_Win64::classify(Type *Ty, const DataLayout &DL) {
+ABIArgInfo X86_64_Win64::classify(const ABIType ABITy, const DataLayout &DL,
+                                  bool IsManagedCallingConv) {
+  Type *Ty = ABITy.getType();
+
   if (Ty->isAggregateType()) {
     // If the aggregate's size in bytes is a power of 2 that is less than or
     // equal to 8, it can be passed directly once coerced to an
@@ -81,6 +90,14 @@ ABIArgInfo X86_64_Win64::classify(Type *Ty, const DataLayout &DL) {
 
   if (Ty->isIntegerTy()) {
     assert(Ty->getIntegerBitWidth() <= 64);
+
+    // RyuJIT requires that all arguments and return values smaller than 32 bits
+    // are zero- or sign-extended.
+    if (IsManagedCallingConv && Ty->getIntegerBitWidth() < 32) {
+      return ABITy.isSigned() ? ABIArgInfo::getSignExtend(Ty)
+                              : ABIArgInfo::getZeroExtend(Ty);
+    }
+
     return ABIArgInfo::getDirect(Ty);
   }
 
@@ -94,28 +111,30 @@ ABIArgInfo X86_64_Win64::classify(Type *Ty, const DataLayout &DL) {
   return ABIArgInfo::getDirect(Ty);
 }
 
-void X86_64_Win64::computeSignatureInfo(Type *ResultType,
-                                        ArrayRef<Type *> ArgTypes,
+void X86_64_Win64::computeSignatureInfo(bool IsManagedCallingConv,
+                                        ABIType ResultType,
+                                        ArrayRef<ABIType> ArgTypes,
                                         const DataLayout &DL,
                                         ABIArgInfo &ResultInfo,
                                         std::vector<ABIArgInfo> &ArgInfos) {
-  ResultInfo = classify(ResultType, DL);
+  ResultInfo = classify(ResultType, DL, IsManagedCallingConv);
 
   for (auto &Arg : ArgTypes) {
-    ArgInfos.push_back(classify(Arg, DL));
+    ArgInfos.push_back(classify(Arg, DL, IsManagedCallingConv));
   }
 }
 
-void X86_64_SysV::computeSignatureInfo(Type *ResultType,
-                                       ArrayRef<Type *> ArgTypes,
+void X86_64_SysV::computeSignatureInfo(bool IsManagedCallingConv,
+                                       ABIType ResultType,
+                                       ArrayRef<ABIType> ArgTypes,
                                        const DataLayout &DL,
                                        ABIArgInfo &ResultInfo,
                                        std::vector<ABIArgInfo> &ArgInfos) {
   // TODO: RyuJIT does not implement the SysV ABI rules as decribed in "System V
   //       Application Binary Interface". For now, agree and just use the Win64
   //       rules.
-  X86_64_Win64::computeSignatureInfo(ResultType, ArgTypes, DL, ResultInfo,
-                                     ArgInfos);
+  X86_64_Win64::computeSignatureInfo(IsManagedCallingConv, ResultType, ArgTypes,
+                                     DL, ResultInfo, ArgInfos);
 }
 
 X86_64ABIInfo::X86_64ABIInfo(Triple TargetTriple, const DataLayout &DL)
@@ -125,21 +144,24 @@ X86_64ABIInfo::X86_64ABIInfo(Triple TargetTriple, const DataLayout &DL)
 }
 
 void X86_64ABIInfo::computeSignatureInfo(
-    CallingConv::ID CC, Type *ResultType, ArrayRef<Type *> ArgTypes,
-    ABIArgInfo &ResultInfo, std::vector<ABIArgInfo> &ArgInfos) const {
+    CallingConv::ID CC, bool IsManagedCallingConv, ABIType ResultType,
+    ArrayRef<ABIType> ArgTypes, ABIArgInfo &ResultInfo,
+    std::vector<ABIArgInfo> &ArgInfos) const {
   if (CC == CallingConv::C) {
     CC = IsWindows ? CallingConv::X86_64_Win64 : CallingConv::X86_64_SysV;
   }
 
   switch (CC) {
   case CallingConv::X86_64_Win64:
-    X86_64_Win64::computeSignatureInfo(ResultType, ArgTypes, TheDataLayout,
-                                       ResultInfo, ArgInfos);
+    X86_64_Win64::computeSignatureInfo(IsManagedCallingConv, ResultType,
+                                       ArgTypes, TheDataLayout, ResultInfo,
+                                       ArgInfos);
     break;
 
   case CallingConv::X86_64_SysV:
-    X86_64_SysV::computeSignatureInfo(ResultType, ArgTypes, TheDataLayout,
-                                      ResultInfo, ArgInfos);
+    X86_64_SysV::computeSignatureInfo(IsManagedCallingConv, ResultType,
+                                      ArgTypes, TheDataLayout, ResultInfo,
+                                      ArgInfos);
     break;
 
   default:
@@ -167,6 +189,14 @@ ABIArgInfo ABIArgInfo::getDirect(llvm::Type *TheType) {
   return ABIArgInfo(Kind::Direct, TheType);
 }
 
+ABIArgInfo ABIArgInfo::getZeroExtend(llvm::Type *TheType) {
+  return ABIArgInfo(Kind::ZeroExtend, TheType);
+}
+
+ABIArgInfo ABIArgInfo::getSignExtend(llvm::Type *TheType) {
+  return ABIArgInfo(Kind::SignExtend, TheType);
+}
+
 ABIArgInfo ABIArgInfo::getIndirect(llvm::Type *TheType) {
   return ABIArgInfo(Kind::Indirect, TheType);
 }
@@ -178,3 +208,10 @@ Type *ABIArgInfo::getType() const { return TheType; }
 void ABIArgInfo::setIndex(uint32_t Index) { this->Index = Index; }
 
 uint32_t ABIArgInfo::getIndex() const { return Index; }
+
+ABIType::ABIType(llvm::Type *TheType, bool IsSigned)
+    : TheType(TheType), IsSigned(IsSigned) {}
+
+llvm::Type *ABIType::getType() const { return TheType; }
+
+bool ABIType::isSigned() const { return IsSigned; }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1915,6 +1915,21 @@ uint32_t GenIR::size(CorInfoType CorType) {
   }
 }
 
+bool GenIR::isSignedIntegralType(CorInfoType CorType) {
+  switch (CorType) {
+  case CorInfoType::CORINFO_TYPE_UNDEF:
+  case CorInfoType::CORINFO_TYPE_VOID:
+  case CorInfoType::CORINFO_TYPE_FLOAT:
+  case CorInfoType::CORINFO_TYPE_DOUBLE:
+  case CorInfoType::CORINFO_TYPE_VALUECLASS:
+  case CorInfoType::CORINFO_TYPE_REFANY:
+    return false;
+
+  default:
+    return isSigned(CorType);
+  }
+}
+
 // Given an CorInfoType, determine if it is
 // signed or unsigned. Treats pointer
 // types as unsigned.


### PR DESCRIPTION
RyuJIT expects all calls to/from managed code to follow a producer-extends
model for integral arguments that are less than four bytes in size.