### PR TITLE
Fix a bug in GenIR::arraySet.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3920,7 +3920,8 @@ bool GenIR::arraySet(CORINFO_SIG_INFO *Sig) {
     return false;
   }
 
-  IRNode *Value = ReaderOperandStack->pop();
+  IRNode *Value =
+      convertFromStackType(ReaderOperandStack->pop(), ElemCorType, ElementTy);
 
   // This call will null-check the array so the store below can assume a
   // non-null pointer.


### PR DESCRIPTION
GenIR::arraySet was not converting the value to be stored from its stack
type to its actual type. This change adds the missing call to
convertFromStackType.