### PR TITLE
Improve llilc_checkpass failure detection.

### DIFF
--- a/test/llilc_checkpass.py
+++ b/test/llilc_checkpass.py
@@ -4,18 +4,21 @@
 #description     :
 # 
 # llilc_checkpass compares two test results, no matter summary or verbose,
-# and checks if any function successfully jitted by LLILC in base result
-# failed jitting in diff result.
+# and checks if any function successfully compiled by LLILC in base result
+# failed to compile in the target result or if any function that was newly
+# submitted for compilation failed to compile. Either of these situations
+# is considered an unexpected failure. The script returns the number of
+# unexpected failures, where 0 indicates that all tests passed. If the script
+# fails due to an unexpected environmental issue, the return value will be
+# negative, and has no relation to the number of unexpected failures.
 #
-# If the check passed, the script return 0. In case of 0, it might have
-# jitted more functions in diff result than in base result. The two results
-# are not necessary the same in this case. Counting result is reported.
+# Whether or not all tests passed, the set of methods submitted for compilation
+# may differ between the base result and the target result. The number of
+# methods that were only submitted to the base compiler and the number of
+# methods that were onty submitted to the target compiler are reported on
+# stdout.
 # 
-# If the check failed due to newly faily routine, return 1.
-#     
-# If the check failed due to unexpected reason, return negative numbers.
-#
-# usage: llilc_checkpass.py [-h] -b BASE_RESULT_PATH -d DIFF_RESULT_PATH
+# usage: llilc_checkpass.py [-h] -b BASE_RESULT_PATH -d TARGET_RESULT_PATH
 # 
 # optional arguments:
 #   -h, --help            show this help message and exit
@@ -23,8 +26,8 @@
 # required arguments:
 #   -b BASE_RESULT_PATH, --base-result-path BASE_RESULT_PATH
 #                         full path to base result
-#   -d DIFF_RESULT_PATH, --diff-result-path DIFF_RESULT_PATH
-#                         full path to diff result
+#   -d TARGET_RESULT_PATH, --diff-result-path TARGET_RESULT_PATH
+#                         full path to target result
 #
 #==========================================================================================
 
@@ -32,13 +35,11 @@ import argparse
 import re
 import sys
 import os
-import difflib
 import const
+import traceback
 
 def main(argv):
-    # define return code const value
-    const.CheckPassFail = 1
-    const.CheckPassOK = 0
+    # Define return code constants
     const.GeneralError = -1
     const.UnknownArguments = -2
     const.MissingResult = -3
@@ -49,11 +50,11 @@ def main(argv):
     required.add_argument('-b', '--base-result-path', type=str, required=True,
                         help='full path to base result')
     required.add_argument('-d', '--diff-result-path', type=str, required=True,
-                        help='full path to diff result')
+                        help='full path to target result')
     args, unknown = parser.parse_known_args(argv)
 
     if unknown:
-        print('Unknown argument(s): ', ', '.join(unknown))
+        print 'Unknown argument(s): ', ', '.join(unknown)
         return const.UnknownArguments
 
     try:
@@ -66,62 +67,123 @@ def main(argv):
                     relative_path = os.path.join(relative_path, file)
                     base_files.append(relative_path)
  
-        # Collect a list of summary result file relative path in diff result    
-        diff_files = []
+        # Collect a list of summary result file relative path in target result
+        target_files = []
         for root, dirs, files in os.walk(args.diff_result_path):
             for file in files:
                 if file.endswith('sum.txt'):
                     relative_path = os.path.relpath(root, args.diff_result_path)
                     relative_path = os.path.join(relative_path, file)
-                    diff_files.append(relative_path)
+                    target_files.append(relative_path)
     except:
         e = sys.exc_info()[0]
-        print('Error: CheckPass failed due to ', e)
+        print 'Error: CheckPass failed due to ', e
+        traceback.print_exc()
         return const.GeneralError
 
     # Check if results are empty
     if len(base_files) == 0:
-        print('Error: base result is empty')
+        print 'Error: base result is empty'
         return const.MissingResult
 
-    if len(diff_files) == 0:
-        print('Error: diff result is empty')
+    if len(target_files) == 0:
+        print 'Error: target result is empty'
         return const.MissingResult
 
-    # Counting the newly failed or passed test cases
-    count_new_failed = 0
-    count_new_passed = 0
+    # Track the number of methods meeting any of the following criteria:
+    # 1. Compiled cleanly in the baseline and are now failing to compile
+    # 2. Failed to compile in the baseline and are now compiling cleanly
+    # 3. Processed in the baseline but not processed now
+    # 4. Not processed in the baseline, processed now, and compiling cleanly
+    # 5. Not processed in the baseline, processed now, and failing to compile
+    #
+    # The sum of categories (1) and (5) is the number of unexpected compilation
+    # failures.
 
-    print('Checking started.')    
+    target_failure_diff = 0
+    target_success_diff = 0
+    missing_base_methods = 0
+    new_target_successes = 0
+    new_target_failures = 0
+
+    # This script expects input that contains lines of the form:
+    # - "Successfully read <method name>" to indicate successsful compilation of
+    #   a method
+    # - "Failed to read <method name>[<failure reason>]" to indicate that a
+    #   method failed to compile
+    #
+    # All other lines are ignored.
+    prog = re.compile(r'^(Successfully read (.*))|(Failed to read (.*)\[.*\])$')
+
+    print 'Checking started.'
     for file in base_files:
-        if file in diff_files:
+        if file in target_files:
             try:
                 base_file_path = os.path.join(args.base_result_path, file)
-                diff_file_path = os.path.join(args.diff_result_path, file)
-                with open(base_file_path, 'r') as bases, open(diff_file_path, 'r') as diffs:
-                    diff = difflib.ndiff(bases.readlines(),diffs.readlines())
-                    for line in diff:
-                        if re.search('- Successfully read ', line):
-                            count_new_failed = count_new_failed + 1
-                        if re.search('\+ Successfully read ', line):
-                           count_new_passed = count_new_passed + 1
+                target_file_path = os.path.join(args.diff_result_path, file)
+                with open(base_file_path, 'r') as base, open(target_file_path, 'r') as target:
+                    # base_passing and base_failing track the set of methods that were
+                    # successfully compiled and unsuccessfully compiled by the baseline
+                    # JIT, respectively. The value for each entry is used to track whether
+                    # or not a method that was processed by the baseline JIT was also
+                    # processed by the new JIT.
+                    base_passing, base_failing = {}, {}
+                    for line in base:
+                        m = prog.match(line)
+                        if m is not None:
+                            if m.group(1) is not None:
+                                base_passing[m.group(2)] = False
+                            else:
+                                base_failing[m.group(4)] = False
+
+                    base_matched_methods = 0
+                    for line in target:
+                        m = prog.match(line)
+                        if m is not None:
+                            def update(method, good_set, bad_set, matched_count, new_count, bad_count):
+                                if method in good_set:
+                                    if not good_set[method]:
+                                        good_set[method] = True
+                                        matched_count += 1
+                                elif method in bad_set:
+                                    if not bad_set[method]:
+                                        bad_set[method] = True
+                                        matched_count, bad_count = matched_count + 1, bad_count + 1
+                                else:
+                                    new_count += 1
+
+                                return matched_count, new_count, bad_count
+
+                            if m.group(1) is not None:
+                                base_matched_methods, new_target_successes, target_failure_diff = update(m.group(2), base_passing, base_failing, base_matched_methods, new_target_successes, target_failure_diff)
+                            else:
+                                base_matched_methods, new_target_failures, target_success_diff = update(m.group(4), base_failing, base_passing, base_matched_methods, new_target_failures, target_success_diff)
+
+                    missing_base_methods += len(base_passing) + len(base_failing) - base_matched_methods
             except:
                 e = sys.exc_info()[0]
-                print('Error: CheckPass failed due to ', e)
+                print 'Error: CheckPass failed due to ', e
+                traceback.print_exc()
                 return const.GeneralError
         else:
             missing_result_file = os.path.join(args.diff_result_path, file)
-            print('Error: diff result does not result file ', missing_result_file)
+            print 'Error: diff directory does not have result file ', missing_result_file
             return const.MissingResult
 
-    print('CheckPass: ', count_new_failed, ' test cases passed in base result but failed in diff result.')
-    print('CheckPass: ', count_new_passed, ' test cases failed in base result but passed in diff result.') 
-    if count_new_failed == 0:
-        print('CheckPass Passed.')
-        return const.CheckPassOK
+    print 'CheckPass:', target_failure_diff, 'method(s) compiled successfully in base result that failed in target result.'
+    print 'CheckPass:', target_success_diff, 'method(s) failed in base result that compiled successfully in target result.'
+    print 'CheckPass:', missing_base_methods, 'method(s) processed in base result that were not processed in target result.'
+    print 'CheckPass:', new_target_successes, 'method(s) not processed in base result that compiled successfully in target result.'
+    print 'CheckPass:', new_target_failures, 'method(s) not processed in base result that failed to compile in target result.'
+
+    unexpected_failures = target_failure_diff + new_target_failures
+
+    if unexpected_failures == 0:
+        print 'There were no unexpected failures.'
     else:
-        print('CheckPass Failed.\n')
-        return const.CheckPassFail
+        print 'There were unexpected failures.'
+
+    return unexpected_failures
 
 if __name__ == '__main__':
     return_code = main(sys.argv[1:])


### PR DESCRIPTION
llilc_checkpass was previously checking for failures by hunting for lines
in a diff that began with '-'. Unfortunately, this is not accurate: most
importantly, it fails to account for the fact that methods may simply no
longer be submitted for compilation (generally due to changes to the
libraries or tests).

This change switches to a set-based implementation in order to accurately
detect methods meeting any of the following criteria:
- Compiled cleanly in the baseline and are now failing to compile
- Failed to compile in the baseline and are now compiling cleanly
- Processed in the baseline but not processed now
- Not processed in the baseline and processed now

A run is only a failure if there are methods that used to compile cleanly
that now fail to compile. A count for each category is reported in the output.