### PR TITLE
Handle ref classes with missing fields.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1412,10 +1412,11 @@ Type *GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool IsRefClass,
       CORINFO_FIELD_HANDLE FieldHandle = getFieldInClass(ClassHandle, I);
       if (FieldHandle == nullptr) {
         // Likely a class that derives from System.__ComObject. See
-        // LLILC issue #557.
-        throw NotYetImplementedException("can't account for all fields");
+        // LLILC issue #557. We'll just have to cope with an incomplete
+        // picture of this type.
+        assert(IsRefClass && "need to see all fields of value classes");
+        break;
       }
-      ASSERT(FieldHandle != nullptr);
       const uint32_t FieldOffset = getFieldOffset(FieldHandle);
       DerivedFields.push_back(std::make_pair(FieldOffset, FieldHandle));
     }


### PR DESCRIPTION
This is a more aggressive workaround for #557. We already have the ability to tolerate missing fields in codegen. So we fall back to that if we're building up a model of a ref class and can't account for all of its fields.

For value classes we still insist that we get a complete picture, because we intend to use the LLVM types to produce GC info.