### PR TITLE
Implement support for mkrefany.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -439,9 +439,7 @@ public:
   }
 
   IRNode *makeRefAny(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                     IRNode *Object) override {
-    throw NotYetImplementedException("makeRefAny");
-  };
+                     IRNode *Object) override;
   IRNode *newArr(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1) override;
   IRNode *newObj(mdToken Token, mdToken LoadFtnToken,
                  uint32_t CurrOffset) override;

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -3708,12 +3708,15 @@ IRNode *ReaderBase::refAnyVal(IRNode *RefAny,
   // first argument is class handle
   Arg1 = genericTokenToNode(ResolvedToken);
 
+  // second argument is the refany (passed by reference)
+  IRNode *Arg2 = RefAny;
+
   // Create Dst operand, interior gc ptr
   Dst = makePtrDstGCOperand(true);
 
   // Make the helper call
   const bool MayThrow = true;
-  return callHelper(CORINFO_HELP_GETREFANY, MayThrow, Dst, Arg1, RefAny);
+  return callHelper(CORINFO_HELP_GETREFANY, MayThrow, Dst, Arg1, Arg2);
 }
 
 void ReaderBase::storeElemRefAny(IRNode *Value, IRNode *Index, IRNode *Obj) {


### PR DESCRIPTION
This implements basic support for the `mkrefany` opcode. I created a simple test but System.TypedReference is not exposed by contract assemblies so getting the test to build as part of core CLR tests is nontrivial. Note `refanyval` was buggy before the change to not allow structs on the stack. Now it works ok but is somewhat fragile.

Closes #298.