### PR TITLE
Return a properly typed pointer from getStaticFieldAddress.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -6303,7 +6303,10 @@ void GenIR::condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,
 IRNode *GenIR::getStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken) {
   CORINFO_FIELD_INFO FieldInfo;
   getFieldInfo(ResolvedToken, CORINFO_ACCESS_ADDRESS, &FieldInfo);
-  return rdrGetStaticFieldAddress(ResolvedToken, &FieldInfo);
+  IRNode *Address = rdrGetStaticFieldAddress(ResolvedToken, &FieldInfo);
+  uint32_t Align;
+  return getTypedAddress(Address, FieldInfo.fieldType, FieldInfo.structType,
+                         Reader_AlignNatural, &Align);
 }
 
 IRNode *GenIR::shift(ReaderBaseNS::ShiftOpcode Opcode, IRNode *ShiftAmount,


### PR DESCRIPTION
This was causing [unexpected type in load/store primitive] in two CoreCLR tests:
static_passing_class01 and static_passing_struct01. The result of getStaticFieldAddress
is used as a pointer for a constrained virtual call. Dereferencing this pointer for
CORINFO_TYPE_REFANY resulted in the error.

With this fix we are at 100% when compiling currently enabled CoreCLR tests.

Closes #588.