### PR TITLE
Fix the type of refanyval.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -3211,9 +3211,17 @@ public:
 
   /// Create an operand that will be used to pass to the boxing helper
   ///
-  /// \param Class CORINFO_CLASS_HANDLE of the type to be boxed
+  /// \param Class \p CORINFO_CLASS_HANDLE for the type to be boxed
   /// \returns Operand
   virtual IRNode *makeBoxDstOperand(CORINFO_CLASS_HANDLE Class) = 0;
+
+  /// Create an operand that will be used to determine the return type
+  /// of the refanytype helper.
+  ///
+  /// \param Class  \p CORINFO_CLASS_HANDLE for the type being extracted
+  ///               from the \p TypedReference.
+  /// \returns The appropriately-typed operand.
+  virtual IRNode *makeRefAnyDstOperand(CORINFO_CLASS_HANDLE Class) = 0;
 
   virtual IRNode *makePtrDstGCOperand(bool IsInteriorGC) = 0;
   virtual IRNode *makePtrNode(ReaderPtrType PointerType = Reader_PtrNotGc) = 0;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -795,6 +795,8 @@ public:
                          bool IsCallTarget,
                          bool IsFrozenObject = false) override;
 
+  IRNode *makeRefAnyDstOperand(CORINFO_CLASS_HANDLE Class) override;
+
   // Create an operand that will be used to hold a pointer.
   IRNode *makePtrDstGCOperand(bool IsInteriorGC) override {
     return makePtrNode(IsInteriorGC ? Reader_PtrGcInterior : Reader_PtrGcBase);

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -3711,8 +3711,8 @@ IRNode *ReaderBase::refAnyVal(IRNode *RefAny,
   // second argument is the refany (passed by reference)
   IRNode *Arg2 = RefAny;
 
-  // Create Dst operand, interior gc ptr
-  Dst = makePtrDstGCOperand(true);
+  // Create dest operand
+  Dst = makeRefAnyDstOperand(ResolvedToken->hClass);
 
   // Make the helper call
   const bool MayThrow = true;

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -5769,6 +5769,13 @@ IRNode *GenIR::handleToIRNode(mdToken Token, void *EmbHandle, void *RealHandle,
   return (IRNode *)HandleValue;
 }
 
+IRNode *GenIR::makeRefAnyDstOperand(CORINFO_CLASS_HANDLE Class) {
+  CorInfoType CorType = ReaderBase::getClassType(Class);
+  Type *ElementTy = getType(CorType, Class);
+  Type *Ty = getManagedPointerType(ElementTy);
+  return (IRNode *)Constant::getNullValue(Ty);
+}
+
 // TODO: currently PtrType telling base or interior pointer is ignored.
 // So for now, deliberately we keep this API to retain the call site.
 IRNode *GenIR::makePtrNode(ReaderPtrType PtrType) { return loadNull(); }

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -250,6 +250,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\format.cmd" >
              <Issue>592</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\gcreport.cmd" >
+             <Issue>13</Issue>
+        <ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\virtcall.cmd" >
              <Issue>13</Issue>
         </ExcludeList>


### PR DESCRIPTION
refanyval was returning an interior pointer to a byte instead of
an interior pointer to the type given as an operand to the
refanyval instruction. This was causing downstream code to assert.