### PR TITLE
Emit catch clauses

### DIFF
--- a/include/Jit/EEMemoryManager.h
+++ b/include/Jit/EEMemoryManager.h
@@ -97,6 +97,12 @@ public:
   void reserveAllocationSpace(uintptr_t CodeSize, uintptr_t DataSizeRO,
                               uintptr_t DataSizeRW) override;
 
+  /// Inform the memory manager about the amount of memory required to hold
+  /// unwind codes for the function and funclets being loaded.
+  ///
+  /// \param Obj - the Object being loaded
+  void reserveUnwindSpace(const object::ObjectFile &Obj);
+
   /// \brief Override to enable the reserveAllocationSpace callback.
   ///
   /// The CoreCLR's EE requires an up-front resevation of the total allocation

--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -27,6 +27,9 @@
 
 class ABIInfo;
 struct LLILCJitPerThreadState;
+namespace llvm {
+class EEMemoryManager;
+}
 
 /// \brief This struct holds per-jit request state.
 ///
@@ -174,6 +177,47 @@ public:
   }
 };
 
+// Object layer that notifies the memory manager to reserve unwind space for
+// each object and otherwise passes processing on to the underlying base
+// object layer
+template <typename BaseLayerT> class ReserveUnwindSpaceLayer {
+public:
+  typedef llvm::orc::ObjectLinkingLayerBase::ObjSetHandleT ObjSetHandleT;
+
+  ReserveUnwindSpaceLayer(BaseLayerT *BaseLayer, llvm::EEMemoryManager *MM) {
+    this->BaseLayer = BaseLayer;
+    this->MM = MM;
+  }
+
+  template <typename ObjSetT, typename MemoryManagerPtrT,
+            typename SymbolResolverPtrT>
+  ObjSetHandleT addObjectSet(const ObjSetT &Objects, MemoryManagerPtrT MemMgr,
+                             SymbolResolverPtrT Resolver) {
+    for (const auto &Obj : Objects) {
+      MM->reserveUnwindSpace(*Obj);
+    }
+    return BaseLayer->addObjectSet(Objects, MemMgr, Resolver);
+  }
+
+  void removeObjectSet(ObjSetHandleT H) {
+    BaseLayer->removeObjectSet(std::move(H));
+  }
+
+  llvm::orc::JITSymbol findSymbol(llvm::StringRef Name,
+                                  bool ExportedSymbolsOnly) {
+    return BaseLayer->findSymbol(Name, ExportedSymbolsOnly);
+  }
+
+  template <typename OwningMBSet>
+  void takeOwnershipOfBuffers(ObjSetHandleT H, OwningMBSet MBs) {
+    BaseLayer->takeOwnershipOfBuffers(std::move(H), std::move(MBs));
+  }
+
+private:
+  BaseLayerT *BaseLayer;
+  llvm::EEMemoryManager *MM;
+};
+
 /// \brief The Jit interface to the CoreCLR EE.
 ///
 /// This class implements the Jit interface to the CoreCLR EE. The EE uses this
@@ -187,7 +231,8 @@ public:
 class LLILCJit : public ICorJitCompiler {
 public:
   typedef llvm::orc::ObjectLinkingLayer<> LoadLayerT;
-  typedef llvm::orc::IRCompileLayer<LoadLayerT> CompileLayerT;
+  typedef ReserveUnwindSpaceLayer<LoadLayerT> ReserveUnwindSpaceLayerT;
+  typedef llvm::orc::IRCompileLayer<ReserveUnwindSpaceLayerT> CompileLayerT;
 
   /// \brief Construct a new jit instance.
   ///

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -354,17 +354,6 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
     Func->dump();
   }
 
-  if (IsOk) {
-    for (BasicBlock &BB : *Func) {
-      if (BB.getLandingPadInst() != nullptr) {
-        // Don't try to push the EH code downstream (we'll currently fail on
-        // the first method with EH if we do that, which prevents being able
-        // to see IR for later methods)
-        return false;
-      }
-    }
-  }
-
   return IsOk;
 }
 

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -200,7 +200,8 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   // Construct the jitting layers.
   EEMemoryManager MM(&Context);
   LoadLayerT Loader;
-  CompileLayerT Compiler(Loader, orc::SimpleCompiler(*TM));
+  ReserveUnwindSpaceLayerT UnwindReserver(&Loader, &MM);
+  CompileLayerT Compiler(UnwindReserver, orc::SimpleCompiler(*TM));
 
   // Now jit the method.
   CorJitResult Result = CORJIT_INTERNALERROR;

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2667,7 +2667,7 @@ LandingPadInst *GenIR::createLandingPad(EHRegion *TryRegion,
   }
 
   // If we didn't break out to a handler, continue propagating the exception.
-  LLVMBuilder->CreateResume(FauxException);
+  LLVMBuilder->CreateResume(LandingPad);
 
   // Return the insertion point to where the caller had it.
   LLVMBuilder->restoreIP(SavedInsertPoint);

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2579,8 +2579,10 @@ void GenIR::fgEnterRegion(EHRegion *Region) {
 
   LandingPadInst *LandingPad = Parent->HandlerLandingPad;
 
-  if (Region->Kind == ReaderBaseNS::RegionKind::RGN_Try &&
-      !SuppressExceptionHandlers && !hasNYIClause(Region)) {
+  if (LandingPad != nullptr) {
+    // Nested landing pads are NYI
+  } else if (Region->Kind == ReaderBaseNS::RegionKind::RGN_Try &&
+             !SuppressExceptionHandlers && !hasNYIClause(Region)) {
     // Create a new inner landing pad
     LandingPad = createLandingPad(Region, LandingPad);
   }


### PR DESCRIPTION
This is a PR for changes going into the EH branch.  They enable emission and execution of simple catch handlers (nested handlers and references to locals NYI) when built against LLVM with corresponding changes (Microsoft/llvm#43).  The approach to Windows-style EH support in LLVM is [undergoing a change](http://thread.gmane.org/gmane.comp.compilers.llvm.devel/85783) that will necessitate reworking at least the reader portion of these changes.  The EEMemoryManager changes, or something along these lines, will likely survive (but see [this llvmdev thread](http://thread.gmane.org/gmane.comp.compilers.llvm.devel/86316) for discussion of the approach).  I'm parking these changes in the EH branch so anyone curious can see where things are/were heading and provide feedback, and planning shift my immediate focus to aspects of EH that are independent of the impending rewrite (e.g. filter function outlining).