### PR TITLE
LLILC changes needed to merge latest LLVM.

### DIFF
--- a/include/Pal/earlyincludes.h
+++ b/include/Pal/earlyincludes.h
@@ -1,0 +1,21 @@
+//===--- include/Pal/WindowsPal.h ---------------------------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+//
+// Include files that must be included early to avoid interference with
+// Windows #defines.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef EARLYINCLUDES_INC
+#define EARLYINCLUDES_INC
+
+#include "llvm/Object/RelocVisitor.h"
+
+#endif // EARLYINCLUDES_INC

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -13,6 +13,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "earlyincludes.h"
 #include "GcInfo.h"
 #include "jitpch.h"
 #include "LLILCJit.h"
@@ -183,7 +184,7 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
     Builder.setOptLevel(CodeGenOpt::Level::Default);
   } else {
     Builder.setOptLevel(CodeGenOpt::Level::None);
-    Options.NoFramePointerElim = true;
+    // Options.NoFramePointerElim = true;
   }
 
   Builder.setTargetOptions(Options);

--- a/lib/Jit/jitoptions.cpp
+++ b/lib/Jit/jitoptions.cpp
@@ -14,6 +14,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "earlyincludes.h"
 #include "global.h"
 #include "jitpch.h"
 #include "LLILCJit.h"

--- a/lib/Reader/GenIRStubs.cpp
+++ b/lib/Reader/GenIRStubs.cpp
@@ -14,6 +14,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "earlyincludes.h"
 #include "reader.h"
 #include <cstdarg>
 

--- a/lib/Reader/abi.cpp
+++ b/lib/Reader/abi.cpp
@@ -13,6 +13,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "earlyincludes.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/IR/CallingConv.h"

--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -14,6 +14,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "earlyincludes.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/IR/CallingConv.h"

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -24,6 +24,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "earlyincludes.h"
 #include "reader.h"
 #include "newvstate.h"
 #include "imeta.h"

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -13,6 +13,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "earlyincludes.h"
 #include "readerir.h"
 #include "imeta.h"
 #include "newvstate.h"
@@ -526,7 +527,7 @@ void GenIR::insertIRToKeepGenericContextAlive() {
 
   // This method now requires a frame pointer.
   TargetMachine *TM = JitContext->EE->getTargetMachine();
-  TM->Options.NoFramePointerElim = true;
+  // TM->Options.NoFramePointerElim = true;
 
   // TODO: we must convey the offset of this local to the runtime
   // via the GC encoding.
@@ -5308,7 +5309,8 @@ void GenIR::nop() {
     // We may need to pick something else that survives lowering.
     Value *DoNothing = Intrinsic::getDeclaration(JitContext->CurrentModule,
                                                  Intrinsic::donothing);
-    LLVMBuilder->CreateCall(DoNothing);
+    ArrayRef<Value *> Args;
+    LLVMBuilder->CreateCall(DoNothing, Args);
   }
 }
 


### PR DESCRIPTION
LLVM now include a coff.h file that defines in enumeration types
constants with the same names that Windows defines using
in the scope of the windows #defines. To avoid that we
include related include files early before anyone has includes
windows.h.

Two other small changes made:

1. The TargetOptions.NoFramePointerElim field no longer exists.
For now I just commented out references to it, but we need to
decide if there is something else we need to do to
ensure we get a frame pointer.

2. The parameters of the LLVMBUILDER->CreateCall method changed.
Now need to pass args. We only used this for making NOPs, so
pass empty args.