### PR TITLE
Use CoreCLR GCStrategy in LLILC

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -83,7 +83,7 @@ LLILCJit::LLILCJit() {
   InitializeNativeTarget();
   InitializeNativeTargetAsmPrinter();
   InitializeNativeTargetAsmParser();
-  llvm::linkStatepointExampleGC();
+  llvm::linkCoreCLRGC();
 }
 
 #ifdef LLVM_ON_WIN32

--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -574,7 +574,7 @@ Function *ABIMethodSignature::createFunction(GenIR &Reader, Module &M) {
   }
 
   if (Reader.JitContext->Options->DoInsertStatepoints) {
-    F->setGC("statepoint-example");
+    F->setGC("coreclr");
   }
 
   return F;

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -600,7 +600,7 @@ void GenIR::insertIRForUnmanagedCallFrame() {
 
   // Mark this function as requiring a frame pointer and as using GC.
   Function->addFnAttr("no-frame-pointer-elim-non-leaf");
-  Function->setGC("statepoint-example");
+  Function->setGC("coreclr");
 
   // The call frame data structure is modeled as an opaque blob of bytes.
   Type *CallFrameTy = ArrayType::get(Int8Ty, CallFrameInfo.size);


### PR DESCRIPTION
LLVM now has a GC-Strategy for supporting CoreCLR runtime.
So use this gc-strategy for functions generated by LLILC.

Expected CQ Impact
No impact on generated code is expected, because CoreCLR gc-strategy
is currently identical to statepoint-example GC.