### PR TITLE
Support {add,sub}.ovf.un when the result is a pointer.

### DIFF
--- a/include/clr/misc.h
+++ b/include/clr/misc.h
@@ -21,6 +21,7 @@
 
 //-- Bit Manipulation --
 
+#ifndef _rotl
 inline unsigned int __cdecl _rotl(unsigned int value, int shift)
 {
   unsigned int retval = 0;
@@ -29,7 +30,9 @@ inline unsigned int __cdecl _rotl(unsigned int value, int shift)
   retval = (value << shift) | (value >> (sizeof(int)* 8 - shift));
   return retval;
 }
+#endif
 
+#ifndef _rotr
 inline unsigned int __cdecl _rotr(unsigned int value, int shift)
 {
   unsigned int retval;
@@ -37,7 +40,8 @@ inline unsigned int __cdecl _rotr(unsigned int value, int shift)
   shift &= 0x1f;
   retval = (value >> shift) | (value << (sizeof(int)* 8 - shift));
   return retval;
-} 
+}
+#endif
 
 //-- Memory move/copy/set/cmp operations
 


### PR DESCRIPTION
ECMA-335 supports addition and subtraction with overflow under the rules
given in table III.8. Because overflowing arithmetic in LLVM requires
calling an intrinsic that only accepts integral arguments, supporting
these operations requires converting the incoming operands to an
intermediate integral type, then converting the result to the ultimate
result type.

This also includes a small fix for errors encountered when compiling with
GCC 4.9.2 on Linux.