### PR TITLE
Switch to ORC jit infrastructure

### DIFF
--- a/Documentation/llilc-arch.md
+++ b/Documentation/llilc-arch.md
@@ -61,12 +61,8 @@ BitCode creation.
 
 [LLVM](http://llvm.org/) is a great code generator that supports lots of platforms and CPU targets.  It also has 
 facilities to be used as both a JIT and AOT compiler.  This combination of features, lots of targets, and ability 
-to compile across a spectrum of compile times, attracted us to LLVM.  For our JIT we use the LLVM MCJIT. This 
-infrastructure allows us to use all the different targets supported by the MC infrastructure as a JIT.  This was our 
-quickest path to running code.  We're aware of the ORC JIT infrastructure but as the CoreCLR only notifies the JIT 
-to compile a method one method at a time, we currently would not get any benefit from the particular features of ORC. 
-(We already compile one method per module today and we don't have to do any of the inter module fixups as that is 
-performed by the runtime.)
+to compile across a spectrum of compile times, attracted us to LLVM.  For our JIT we use LLVM's ORC JIT
+infrastructure.
 
 There is a further discussion of how we're modeling the managed code semantics within LLVM in a following 
 [section](#managed-semantics-in-llvm).

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -22,9 +22,6 @@
 #include "abi.h"
 #include "EEMemoryManager.h"
 #include "llvm/CodeGen/GCs.h"
-#include "llvm/ExecutionEngine/ExecutionEngine.h"
-#include "llvm/ExecutionEngine/MCJIT.h"
-#include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
@@ -42,8 +39,10 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #include <string>
 
 using namespace llvm;
@@ -172,33 +171,31 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
 
   Context.Options = &JitOptions;
 
-  EngineBuilder Builder(std::move(M));
+  // Construct the TargetMachine that we will emit code for
   std::string ErrStr;
-  Builder.setErrorStr(&ErrStr);
-
-  std::unique_ptr<RTDyldMemoryManager> MM(new EEMemoryManager(&Context));
-  Builder.setMCJITMemoryManager(std::move(MM));
-
-  TargetOptions Options;
-  if (Context.Options->OptLevel != OptLevel::DEBUG_CODE) {
-    Builder.setOptLevel(CodeGenOpt::Level::Default);
-  } else {
-    Builder.setOptLevel(CodeGenOpt::Level::None);
-    // Options.NoFramePointerElim = true;
-  }
-
-  Builder.setTargetOptions(Options);
-
-  ExecutionEngine *NewEngine = Builder.create();
-
-  if (!NewEngine) {
-    errs() << "Could not create ExecutionEngine: " << ErrStr << "\n";
+  const llvm::Target *TheTarget =
+      TargetRegistry::lookupTarget(LLILC_TARGET_TRIPLE, ErrStr);
+  if (!TheTarget) {
+    errs() << "Could not create Target: " << ErrStr << "\n";
     return CORJIT_INTERNALERROR;
   }
+  TargetOptions Options;
+  CodeGenOpt::Level OptLevel;
+  if (Context.Options->OptLevel != OptLevel::DEBUG_CODE) {
+    OptLevel = CodeGenOpt::Level::Default;
+  } else {
+    OptLevel = CodeGenOpt::Level::None;
+    // Options.NoFramePointerElim = true;
+  }
+  TargetMachine *TM = TheTarget->createTargetMachine(
+      LLILC_TARGET_TRIPLE, "", "", Options, Reloc::Default, CodeModel::Default,
+      OptLevel);
+  Context.TM = TM;
 
-  // Don't allow the EE to search for external symbols.
-  NewEngine->DisableSymbolSearching();
-  Context.EE = NewEngine;
+  // Construct the jitting layers.
+  EEMemoryManager MM(&Context);
+  LoadLayerT Loader;
+  CompileLayerT Compiler(Loader, orc::SimpleCompiler(*TM));
 
   // Now jit the method.
   CorJitResult Result = CORJIT_INTERNALERROR;
@@ -221,17 +218,17 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
       PMBuilder.populateModulePassManager(Passes);
 
       Passes.add(createRewriteStatepointsForGCPass(false));
-      Passes.run(*Context.CurrentModule);
+      Passes.run(*M);
     }
 
-    Context.EE->generateCodeForModule(Context.CurrentModule);
+    // Don't allow the LoadLayer to search for external symbols, by supplying
+    // it a NullResolver.
+    NullResolver Resolver;
+    auto HandleSet =
+        Compiler.addModuleSet<ArrayRef<Module *>>(M.get(), &MM, &Resolver);
 
-    // You need to pick up the COFFDyld changes from the MS branch of LLVM
-    // or this will fail with an "Incompatible object format!" error
-    // from LLVM's dynamic loader.
-    uint64_t FunctionAddress =
-        Context.EE->getFunctionAddress(Context.MethodName);
-    *NativeEntry = (BYTE *)FunctionAddress;
+    *NativeEntry =
+        (BYTE *)Compiler.findSymbol(Context.MethodName, false).getAddress();
 
     // TODO: ColdCodeSize, or separated code, is not enabled or included.
     *NativeSizeOfCode = Context.HotCodeSize + Context.ReadOnlyDataSize;
@@ -245,13 +242,16 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
     // Dump out any enabled timing info.
     TimerGroup::printAll(errs());
 
+    // Give the jit layers a chance to free resources.
+    Compiler.removeModuleSet(HandleSet);
+
     // Tell the CLR that we've successfully generated code for this method.
     Result = CORJIT_OK;
   }
 
   // Clean up a bit
-  delete Context.EE;
-  Context.EE = nullptr;
+  delete Context.TM;
+  Context.TM = nullptr;
   delete Context.TheABIInfo;
   Context.TheABIInfo = nullptr;
 


### PR DESCRIPTION
This will simplify some aspects of funclet management, and also gets LLILC
on top of the newer jitting framework that active development is focused
on.

ORC jits are created by composing `layers`.  LLILC's functionality is
covered by two "off-the-shelf" layers: the IRCompileLayer (using the
SimpleComplier utility) for compiling IR to machine code, and the
ObjectLinkingLayer for resolving fixups and relocations and interfacing
with the EEMemoryManager to load the machine code into appropriate memory.

Closes #610