### PR TITLE
Initialize Scalar opts

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -80,9 +80,14 @@ ICorJitCompiler *__stdcall getJit() {
 
 // Construct the JIT instance
 LLILCJit::LLILCJit() {
+  PassRegistry &Registry = *PassRegistry::getPassRegistry();
+  initializeCore(Registry);
+  initializeScalarOpts(Registry);
+
   InitializeNativeTarget();
   InitializeNativeTargetAsmPrinter();
   InitializeNativeTargetAsmParser();
+
   llvm::linkCoreCLRGC();
 }
 


### PR DESCRIPTION
Call Core and Scalar opts initializers so that the
dependencies for Safepoint placement and rewriting 
are initialized correctly.