### PR TITLE
Exclude Regression\CLR-x86-EJIT test case that has issue with LLILC

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -316,5 +316,15 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-RTM\b539509\b539509.cmd" >
              <Issue>601</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M11-Beta1\b40138\b40138.cmd" >
+             <Issue>616</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M11-Beta1\b45679\b45679.cmd" >
+             <Issue>616</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M12-Beta2\b46847\b46847.cmd" >
+             <Issue>616</Issue>
+        </ExcludeList>
+
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Core CLR PR dotnet/coreclr#1088 added multiple test directories under Regression. Three of the test cases failed if run with LLILC. https://github.com/dotnet/llilc/issues/616 is created for investigation. Exclude the test case for now.