### PR TITLE
Multiple small bug fixes.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -47,12 +47,7 @@
 // Debugging
 // -----------------------------------------------------------------
 
-#define ASSERTM(Predicate, Message)                                            \
-  do {                                                                         \
-    if (!(Predicate)) {                                                        \
-      ReaderBase::debugError(__FILE__, __LINE__, Message);                     \
-    }                                                                          \
-  } while (0)
+#define ASSERTM(Predicate, Message) assert((Predicate) && Message)
 #define ASSERT(Predicate) ASSERTM(Predicate, #Predicate)
 #define UNREACHED 0
 #ifndef _MSC_VER
@@ -2956,10 +2951,6 @@ public:
 
   // Remove all IRNodes from block (for verification error processing.)
   virtual void clearCurrentBlock() = 0;
-
-  // Called when an assert occurs (debug only)
-  static void debugError(const char *Filename, uint32_t LineNumber,
-                         const char *Message);
 
   // Notify client of alignment problem
   virtual void verifyStaticAlignment(void *Pointer, CorInfoType CorType,


### PR DESCRIPTION
- Change the ASSERTM macro in the reader to use `assert` rather than
  `debugError` in order to avoid losing the message argument
- In GenIR::convertFromStackType, allow zero extension to native uint
- In GenIR::binaryOpType, handle subtraction of one managed pointer
  from another managed pointer as per ECMA-335 Table III.2
- In GenIR::mdArrayRefAddr, convert array indicies from stack types to
  actual types for consitency with ECMA-335 III.1.6
- In GenIR::arrayGetDimLength, handle cases where the array argument is
  an opaque System.Array reference
- In GenIR::cmp, allow comparison between floats and doubles by extending
  the former to the size of the latter