### PR TITLE
Add Debug Line Information Support to LLILC

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -19,13 +19,16 @@
 #include "Pal/LLILCPal.h"
 #include "options.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
+#include "llvm/ExecutionEngine/RuntimeDyld.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/ThreadLocal.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
+#include "llvm/Config/config.h"
 
 class ABIInfo;
+class ObjectLoadListener;
 struct LLILCJitPerThreadState;
 
 /// \brief This struct holds per-jit request state.
@@ -186,7 +189,7 @@ public:
 /// top-level invocations of the jit is held in thread local storage.
 class LLILCJit : public ICorJitCompiler {
 public:
-  typedef llvm::orc::ObjectLinkingLayer<> LoadLayerT;
+  typedef llvm::orc::ObjectLinkingLayer<ObjectLoadListener> LoadLayerT;
   typedef llvm::orc::IRCompileLayer<LoadLayerT> CompileLayerT;
 
   /// \brief Construct a new jit instance.

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2972,6 +2972,7 @@ public:
 
   virtual EHRegion *rgnAllocateRegion() = 0;
   virtual EHRegionList *rgnAllocateRegionList() = 0;
+  virtual void setDebugLocation(uint32_t CurrOffset, bool IsCall) = 0;
 
   //
   // REQUIRED Flow and Region Graph Manipulation Routines

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -25,6 +25,8 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/CallSite.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "reader.h"
 #include "abi.h"
 #include "abisignature.h"
@@ -558,6 +560,10 @@ public:
 
   EHRegion *rgnAllocateRegion() override;
   EHRegionList *rgnAllocateRegionList() override;
+  void setDebugLocation(uint32_t CurrOffset, bool IsCall) override;
+  llvm::DISubroutineType *createFunctionType(llvm::Function *F,
+                                             llvm::DIFile *Unit);
+  llvm::DIType *convertType(llvm::Type *Ty);
 
   //
   // REQUIRED Flow and Region Graph Manipulation Routines
@@ -1555,6 +1561,7 @@ private:
   // where they should be inserted (the gen- methods do not take explicit
   // insertion point parameters).
   llvm::IRBuilder<> *LLVMBuilder;
+  llvm::DIBuilder *DBuilder;
   std::map<CORINFO_CLASS_HANDLE, llvm::Type *> *ClassTypeMap;
   std::map<llvm::Type *, CORINFO_CLASS_HANDLE> *ReverseClassTypeMap;
   std::map<CORINFO_CLASS_HANDLE, llvm::Type *> *BoxedTypeMap;
@@ -1610,6 +1617,10 @@ private:
                                                 ///< helper function.
                                                 ///< This constant is from the
                                                 ///< legacy jit.
+  struct DebugInfo {
+    llvm::DICompileUnit *TheCU;
+    llvm::DIScope *FunctionScope;
+  } LLILCDebugInfo;
 };
 
 #endif // MSIL_READER_IR_H

--- a/lib/Jit/CMakeLists.txt
+++ b/lib/Jit/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LLVM_LINK_COMPONENTS
   Analysis
   CodeGen
   Core
+  DebugInfoDWARF
   ExecutionEngine
   IPO
   IRReader

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -22,30 +22,67 @@
 #include "abi.h"
 #include "EEMemoryManager.h"
 #include "llvm/CodeGen/GCs.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/DebugInfo/DIContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #include "llvm/IR/DataLayout.h"
+#include "llvm/Support/DataTypes.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugLoc.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Errno.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Timer.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/Format.h"
-#include "llvm/Support/Signals.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
-#include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #include <string>
 
 using namespace llvm;
+using namespace llvm::object;
+
+class ObjectLoadListener {
+public:
+  ObjectLoadListener(LLILCJitContext *Context) { this->Context = Context; }
+
+  template <typename ObjSetT, typename LoadResult>
+  void operator()(llvm::orc::ObjectLinkingLayerBase::ObjSetHandleT ObjHandles,
+                  const ObjSetT &Objs, const LoadResult &LoadedObjInfos) {
+    int I = 0;
+
+    for (const auto &PObj : Objs) {
+
+      const object::ObjectFile &Obj = *PObj;
+      const RuntimeDyld::LoadedObjectInfo &L = *LoadedObjInfos[I];
+
+      getDebugInfoForObject(Obj, L);
+
+      ++I;
+    }
+  }
+
+  void getDebugInfoForObject(const ObjectFile &Obj,
+                             const RuntimeDyld::LoadedObjectInfo &L);
+
+private:
+  LLILCJitContext *Context;
+};
 
 // The one and only Jit Object.
 LLILCJit *LLILCJit::TheJit = nullptr;
@@ -199,7 +236,8 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
 
   // Construct the jitting layers.
   EEMemoryManager MM(&Context);
-  LoadLayerT Loader;
+  ObjectLoadListener Listener(&Context);
+  LoadLayerT Loader(Listener);
   CompileLayerT Compiler(Loader, orc::SimpleCompiler(*TM));
 
   // Now jit the method.
@@ -393,4 +431,98 @@ void __cdecl LLILCJit::fatal(int Errnum, ...) {
 //  this handler avoids a crash when LLVM goes down.
 void LLILCJit::signalHandler(void *Cookie) {
   // do nothing
+}
+
+void ObjectLoadListener::getDebugInfoForObject(
+    const ObjectFile &Obj, const RuntimeDyld::LoadedObjectInfo &L) {
+  OwningBinary<ObjectFile> DebugObjOwner = L.getObjectForDebug(Obj);
+  const ObjectFile &DebugObj = *DebugObjOwner.getBinary();
+
+  // Get the address of the object image for use as a unique identifier
+  const void *ObjData = DebugObj.getData().data();
+
+  // TODO: This extracts DWARF information from the object file, but we will
+  // want to also be able to eventually extract WinCodeView information as well
+  DWARFContextInMemory DwarfContext(DebugObj);
+
+  // Use symbol info to iterate functions in the object.
+  // TODO: This may have to change when we have funclets
+
+  for (symbol_iterator SI = DebugObj.symbol_begin(), E = DebugObj.symbol_end();
+       SI != E; ++SI) {
+    SymbolRef::Type SymType;
+    if (SI->getType(SymType))
+      continue;
+    if (SymType != SymbolRef::ST_Function)
+      continue;
+
+    // Function info
+    StringRef Name;
+    uint64_t Addr;
+    if (SI->getName(Name))
+      continue;
+    if (SI->getAddress(Addr))
+      continue;
+    uint64_t Size = SI->getSize();
+
+    unsigned LastDebugOffset = -1;
+    unsigned NumDebugRanges = 0;
+    ICorDebugInfo::OffsetMapping *OM;
+
+    DILineInfoTable Lines = DwarfContext.getLineInfoForAddressRange(Addr, Size);
+
+    DILineInfoTable::iterator Begin = Lines.begin();
+    DILineInfoTable::iterator End = Lines.end();
+
+    // Count offset entries. Will skip an entry if the current IL offset
+    // matches the previous offset.
+    for (DILineInfoTable::iterator It = Begin; It != End; ++It) {
+      int LineNumber = (It->second).Line;
+
+      if (LineNumber != LastDebugOffset) {
+        NumDebugRanges++;
+        LastDebugOffset = LineNumber;
+      }
+    }
+
+    // Reset offset
+    LastDebugOffset = -1;
+
+    if (NumDebugRanges > 0) {
+      // Allocate OffsetMapping array
+      unsigned SizeOfArray =
+          (NumDebugRanges) * sizeof(ICorDebugInfo::OffsetMapping);
+      OM = (ICorDebugInfo::OffsetMapping *)Context->JitInfo->allocateArray(
+          SizeOfArray);
+
+      unsigned CurrentDebugEntry = 0;
+
+      // Iterate through the debug entries and save IL offset, native
+      // offset, and source reason
+      for (DILineInfoTable::iterator It = Begin; It != End; ++It) {
+        int Offset = It->first;
+        int LineNumber = (It->second).Line;
+
+        // We store info about if the instruction is being recorded because
+        // it is a call in the column field
+        bool IsCall = (It->second).Column == 1;
+
+        if (LineNumber != LastDebugOffset) {
+          LastDebugOffset = LineNumber;
+          OM[CurrentDebugEntry].nativeOffset = Offset;
+          OM[CurrentDebugEntry].ilOffset = LineNumber;
+          OM[CurrentDebugEntry].source = IsCall
+                                             ? ICorDebugInfo::CALL_INSTRUCTION
+                                             : ICorDebugInfo::STACK_EMPTY;
+          CurrentDebugEntry++;
+        }
+      }
+
+      // Send array of OffsetMappings to CLR EE
+      CORINFO_METHOD_INFO *MethodInfo = Context->MethodInfo;
+      CORINFO_METHOD_HANDLE MethodHandle = MethodInfo->ftn;
+
+      Context->JitInfo->setBoundaries(MethodHandle, NumDebugRanges, OM);
+    }
+  }
 }

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -1,4 +1,4 @@
-//===---- lib/MSILReader/reader.cpp -----------------------------*- C++ -*-===//
+//===---- lib/Reader/reader.cpp ---------------------------------*- C++ -*-===//
 //
 // LLILC
 //
@@ -402,7 +402,7 @@ void ReaderBase::printMSIL(uint8_t *Buf, uint32_t StartOffset,
   while (Offset < NumBytes) {
     dbPrint("0x%-4x: ", StartOffset + Offset);
     Offset = parseILOpcode(Buf, Offset, NumBytes, this, &Opcode, &Operand);
-    dbPrint("%-10s ", OpcodeName[Opcode]);
+    dbPrint("%d: %-10s ", Offset, OpcodeName[Opcode]);
 
     switch (Opcode) {
     default:
@@ -6410,6 +6410,12 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
     CurrInstrOffset = CurrentOffset;
     NextInstrOffset = NextOffset;
 
+    // Set debug locations
+    if (ReaderOperandStack->empty()) {
+      const bool IsCall = false;
+      setDebugLocation(CurrentOffset, IsCall);
+    }
+
     // If we have cached a LoadFtnToken from LDFTN or LDVIRTFTN
     // then clear it if the next opcode is not NEWOBJ
     if (Opcode != ReaderBaseNS::CEE_NEWOBJ) {
@@ -6564,6 +6570,8 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
       goto GEN_BRANCH;
 
     GEN_BRANCH:
+      // We need to record the source location of branches, so insert a nop
+      nop();
       Param->HasFallThrough = false;
       Param->VerifiedEndBlock = true;
       verifyFinishBlock(TheVerificationState,
@@ -6588,6 +6596,8 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
     case ReaderBaseNS::CEE_CALL:
     case ReaderBaseNS::CEE_CALLI:
     case ReaderBaseNS::CEE_CALLVIRT: {
+      const bool IsCall = true;
+      setDebugLocation(CurrentOffset, IsCall);
       bool IsUnmarkedTailCall = false;
       Token = readValue<mdToken>(Operand);
 
@@ -6994,6 +7004,9 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
     case ReaderBaseNS::CEE_LDC_I4_8:
     case ReaderBaseNS::CEE_LDC_I4_M1:
     LOAD_CONSTANT:
+      // We need to record the source locations of ldcs, so insert a nop
+      // to record the source location.
+      nop();
       verifyLoadConstant(TheVerificationState, Opcode);
       BREAK_ON_VERIFY_ONLY;
 
@@ -7342,6 +7355,11 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
       break;
 
     case ReaderBaseNS::CEE_RET: {
+      // Insert a nop for debug and set return's IL offset to signify
+      // that it is part of the epilogue
+      nop();
+      const bool IsCall = false;
+      setDebugLocation(ICorDebugInfo::EPILOG, IsCall);
       CorInfoCallConv Conv;
       CorInfoType CorType;
       CORINFO_CLASS_HANDLE RetTypeClass;

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1,4 +1,4 @@
-//===---- lib/MSILReader/readerir.cpp ---------------------------*- C++ -*-===//
+//===---- lib/Reader/readerir.cpp -------------------------------*- C++ -*-===//
 //
 // LLILC
 //
@@ -18,11 +18,15 @@
 #include "imeta.h"
 #include "newvstate.h"
 #include "llvm/ADT/Triple.h"
+#include "llvm/IR/DebugLoc.h"
+#include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/Support/Debug.h"          // for dbgs()
 #include "llvm/Support/raw_ostream.h"    // for errs()
 #include "llvm/Support/ConvertUTF.h"     // for ConvertUTF16toUTF8
 #include "llvm/Transforms/Utils/Local.h" // for removeUnreachableBlocks
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include <cstdlib>
 #include <new>
 
@@ -312,6 +316,11 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   EntryBlock = BasicBlock::Create(LLVMContext, "entry", Function);
 
   LLVMBuilder = new IRBuilder<>(LLVMContext);
+  DBuilder = new DIBuilder(*JitContext->CurrentModule);
+  LLILCDebugInfo.TheCU = DBuilder->createCompileUnit(dwarf::DW_LANG_C_plus_plus,
+                                                     Function->getName().str(),
+                                                     ".", "LLILCJit", 0, "", 0);
+
   LLVMBuilder->SetInsertPoint(EntryBlock);
 
   // Note numArgs may exceed the IL argument count when there
@@ -428,6 +437,21 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
     }
   }
 
+  // Setup function for emiting debug locations
+  DIFile *Unit = DBuilder->createFile(LLILCDebugInfo.TheCU->getFilename(),
+                                      LLILCDebugInfo.TheCU->getDirectory());
+  bool IsOptimized = (JitContext->Flags & CORJIT_FLG_DEBUG_CODE) == 0;
+  DIScope *FContext = Unit;
+  unsigned LineNo = 0;
+  unsigned ScopeLine = ICorDebugInfo::PROLOG;
+  bool IsDefinition = true;
+  DISubprogram *SP = DBuilder->createFunction(
+      FContext, Function->getName(), StringRef(), Unit, LineNo,
+      createFunctionType(Function, Unit), Function->hasInternalLinkage(),
+      IsDefinition, ScopeLine, DINode::FlagPrototyped, IsOptimized, Function);
+
+  LLILCDebugInfo.FunctionScope = SP;
+
   // TODO: Insert class initialization check if necessary
   CorInfoInitClassResult InitResult =
       initClass(nullptr, getCurrentMethodHandle(), getCurrentContext());
@@ -484,6 +508,7 @@ void GenIR::readerPostPass(bool IsImportOnly) {
   }
 
   // Cleanup the memory we've been using.
+  DBuilder->finalize();
   delete LLVMBuilder;
 }
 
@@ -944,6 +969,108 @@ void GenIR::createSafepointPoll() {
 }
 
 bool GenIR::doTailCallOpt() { return JitContext->Options->DoTailCallOpt; }
+
+// Set the Debug Location for the current instruction
+void GenIR::setDebugLocation(uint32_t CurrOffset, bool IsCall) {
+  assert(LLILCDebugInfo.FunctionScope != nullptr);
+
+  DebugLoc Loc =
+      DebugLoc::get(CurrOffset, IsCall, LLILCDebugInfo.FunctionScope);
+
+  LLVMBuilder->SetCurrentDebugLocation(Loc);
+}
+
+llvm::DISubroutineType *GenIR::createFunctionType(llvm::Function *F,
+                                                  DIFile *Unit) {
+  SmallVector<Metadata *, 8> EltTys;
+  // for each param, etc. convert the type to DIType and add it to the array.
+  FunctionType *FunctionTy = F->getFunctionType();
+
+  DIType *ReturnTy = convertType(Function->getReturnType());
+  EltTys.push_back(ReturnTy);
+  auto ParamEnd = FunctionTy->param_end();
+
+  for (auto ParamIterator = FunctionTy->param_begin();
+       ParamIterator != ParamEnd; ParamIterator++) {
+    Type *Ty = *ParamIterator;
+    DIType *ParamTy = convertType(Ty);
+
+    EltTys.push_back(ParamTy);
+  }
+  return DBuilder->createSubroutineType(Unit,
+                                        DBuilder->getOrCreateTypeArray(EltTys));
+}
+
+llvm::DIType *GenIR::convertType(Type *Ty) {
+  StringRef TyName;
+  llvm::dwarf::TypeKind Encoding;
+
+  if (Ty->isVoidTy()) {
+    return nullptr;
+  }
+  if (Ty->isIntegerTy()) {
+    Encoding = llvm::dwarf::DW_ATE_signed;
+    unsigned BitWidth = Ty->getIntegerBitWidth();
+
+    switch (BitWidth) {
+    case 8:
+      TyName = "char";
+      Encoding = llvm::dwarf::DW_ATE_unsigned_char;
+      break;
+    case 16:
+      TyName = "short";
+      break;
+    case 32:
+      TyName = "int";
+      break;
+    case 64:
+      TyName = "long int";
+      break;
+    case 128:
+      TyName = "long long int";
+      break;
+    default:
+      TyName = "int";
+      break;
+    }
+    llvm::DIType *DbgTy =
+        DBuilder->createBasicType(TyName, BitWidth, BitWidth, Encoding);
+    return DbgTy;
+  }
+  if (Ty->isFloatingPointTy()) {
+    Encoding = llvm::dwarf::DW_ATE_float;
+    unsigned BitWidth = Ty->getPrimitiveSizeInBits();
+    if (Ty->isHalfTy()) {
+      TyName = "half";
+    }
+    if (Ty->isFloatTy()) {
+      TyName = "float";
+    }
+    if (Ty->isDoubleTy()) {
+      TyName = "double";
+    }
+    if (Ty->isX86_FP80Ty()) {
+      TyName = "long double";
+    }
+
+    llvm::DIType *DbgTy =
+        DBuilder->createBasicType(TyName, BitWidth, BitWidth, Encoding);
+    return DbgTy;
+  }
+
+  if (Ty->isPointerTy()) {
+    uint64_t Size = JitContext->TM->getDataLayout()->getPointerTypeSize(Ty);
+    uint64_t Align = JitContext->TM->getDataLayout()->getPrefTypeAlignment(Ty);
+    llvm::DIType *DbgTy = DBuilder->createPointerType(
+        convertType(Ty->getPointerElementType()), Size, Align);
+
+    return DbgTy;
+  }
+  // TODO: add support for aggregate types
+  // Types we are missing: LabelTy, MetadataTy, X86_MMXTy, FunctionTy, StructTy
+  // ArrayTy, VectoryTy
+  return nullptr;
+}
 
 #pragma endregion
 
@@ -5381,11 +5508,19 @@ void GenIR::nop() {
   // Preserve Nops in debug builds since they may carry unique source positions.
   if ((JitContext->Flags & CORJIT_FLG_DEBUG_CODE) != 0) {
     // LLVM has no high-level NOP instruction. Put in a placeholder for now.
-    // We may need to pick something else that survives lowering.
-    Value *DoNothing = Intrinsic::getDeclaration(JitContext->CurrentModule,
-                                                 Intrinsic::donothing);
+    // This will survive lowering, but we may want to do something else that
+    // is cleaner
+    // TODO: Look into creating a high-level NOP that doesn't get removed and
+    // gets lowered to the right platform-specific encoding
+
+    bool IsVariadic = false;
+    llvm::FunctionType *FTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*(JitContext->LLVMContext)), IsVariadic);
+
+    llvm::InlineAsm *AsmCode = llvm::InlineAsm::get(FTy, "nop", "", true, false,
+                                                    llvm::InlineAsm::AD_Intel);
     ArrayRef<Value *> Args;
-    LLVMBuilder->CreateCall(DoNothing, Args);
+    LLVMBuilder->CreateCall(AsmCode, Args);
   }
 }
 


### PR DESCRIPTION
This change adds support to LLILC to send source line information to
LLVM and then on to the CLR EE to be used in debugging. This change
adds:

* Support to the Reader to capture IL offsets and set them as debug
  locations for instructions. To do so, this change adds calls to the
  DIBuilder to create debug information for functions, and then to set
  the DebugLoc information for each instruction. The debugger expects
  offsets for the following: the start of a function, when the stack is
  empty, and when we have a call instruction. To get this all piped
  through LLVM properly, we had to insert extra nops for instances where
  the stack is empty, but we were looking at a store for a local (this
  gets swallowed by the following instruction). We also required extra
  nops around branches to get information about breaks piped through
  correctly. Finally, the debugger expects a location of where the
  return MSIL instruction was, but it expects the actual return logic to
  be considered part of the epilog. This is handled by the CoreCLR jit
  by inserting a nop with the IL offset of the return instruction, and
  everything after the nop has IL offset of -3 (epilog). Additionally,
  we had to change the logic for creating nops. The logic we previously
  had created a DoNothing intrinsic, which LLVM throws away. We needed
  these nops to make it all the way through to the AsmPrinter, so we
  changed nop creation to insert an inline asm nop, which LLVM preserves.
* Adds an object loaded layer to capture native and IL offsets and send
  them to the EE.