### PR TITLE
Fix two small bugs in LLILCJit.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -223,15 +223,15 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   }
   TargetOptions Options;
   CodeGenOpt::Level OptLevel;
-  if (Context.Options->OptLevel != OptLevel::DEBUG_CODE) {
+  if (Context.Options->OptLevel != ::OptLevel::DEBUG_CODE) {
     OptLevel = CodeGenOpt::Level::Default;
   } else {
     OptLevel = CodeGenOpt::Level::None;
     // Options.NoFramePointerElim = true;
   }
   TargetMachine *TM = TheTarget->createTargetMachine(
-      LLILC_TARGET_TRIPLE, "", "", Options, Reloc::Default, CodeModel::Default,
-      OptLevel);
+      LLILC_TARGET_TRIPLE, "", "", Options, Reloc::Default,
+      CodeModel::JITDefault, OptLevel);
   Context.TM = TM;
 
   // Construct the jitting layers.

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -830,7 +830,7 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b39417\b39417.cmd" >
-             <Issue>639</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\volatilstind.cmd" >
              <Issue>13</Issue>
@@ -1051,9 +1051,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43160\b43160.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b05637\b05637.cmd" >
-             <Issue>639</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b69512\b69512.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
@@ -1206,9 +1203,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59478\b59478.cmd" >
              <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06595\b06595.cmd" >
-             <Issue>639</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_conv_ovf_i8_i4.cmd" >
              <Issue>13</Issue>
@@ -1489,14 +1483,8 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b75890\b75890.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08109\b08109.cmd" >
-             <Issue>639</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b54006\b54006.cmd" >
              <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b82715\b82715.cmd" >
-             <Issue>639</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\arglist64.cmd" >
              <Issue>645</Issue>
@@ -1654,9 +1642,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b54566\b54566.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08107\b08107.cmd" >
-             <Issue>639</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\localloc\verify\verify01_large.cmd" >
              <Issue>645</Issue>
         </ExcludeList>
@@ -1705,9 +1690,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b39455\b39455.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59949\b59949.cmd" >
-             <Issue>639</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\u_qsort2.cmd" >
              <Issue>634</Issue>
         </ExcludeList>
@@ -1721,6 +1703,9 @@
              <Issue>640</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b32551\b32551b.cmd" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59949\b59949.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\ptr.cmd" >
@@ -1809,9 +1794,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_sub_ovf_i2.cmd" >
              <Issue>13</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06754\b06754.cmd" >
-             <Issue>639</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25491\b25491.cmd" >
              <Issue>13</Issue>


### PR DESCRIPTION
- clang was complaining about the unqualified reference to `OptLevel` on
  line 226
- The code model passed during target machine selection was incorrect
  for JITted code, which caused bad relocations on Linux. This may also
  be the cause of #639.