### PR TITLE
Remove typedefs for jit layers

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -28,7 +28,6 @@
 #include "llvm/Config/config.h"
 
 class ABIInfo;
-class ObjectLoadListener;
 struct LLILCJitPerThreadState;
 
 /// \brief This struct holds per-jit request state.
@@ -189,9 +188,6 @@ public:
 /// top-level invocations of the jit is held in thread local storage.
 class LLILCJit : public ICorJitCompiler {
 public:
-  typedef llvm::orc::ObjectLinkingLayer<ObjectLoadListener> LoadLayerT;
-  typedef llvm::orc::IRCompileLayer<LoadLayerT> CompileLayerT;
-
   /// \brief Construct a new jit instance.
   ///
   /// There is only one LLILC jit instance per process, so this

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -237,8 +237,9 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   // Construct the jitting layers.
   EEMemoryManager MM(&Context);
   ObjectLoadListener Listener(&Context);
-  LoadLayerT Loader(Listener);
-  CompileLayerT Compiler(Loader, orc::SimpleCompiler(*TM));
+  orc::ObjectLinkingLayer<decltype(Listener)> Loader(Listener);
+  orc::IRCompileLayer<decltype(Loader)> Compiler(Loader,
+                                                 orc::SimpleCompiler(*TM));
 
   // Now jit the method.
   CorJitResult Result = CORJIT_INTERNALERROR;


### PR DESCRIPTION
The jit layers are really an implementation detail, and don't need to be
exposed from LLILCJit.h.  Even in LLILCJit.cpp, they're only used to
declare the layers; this change inlines them into the declarations (using
decltype(PreviousLayer) to avoid excessive repetition of lower layer
types) and removes them entirely.

This avoids needing to make parallel changes in the typedefs and
declarations when adding/changing layers.