### PR TITLE
Use orc::NullResolver

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -25,6 +25,7 @@
 #include "llvm/Support/ThreadLocal.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
+#include "llvm/ExecutionEngine/Orc/NullResolver.h"
 #include "llvm/Config/config.h"
 
 class ABIInfo;
@@ -157,23 +158,6 @@ public:
   ///
   /// Used to build struct GEP instructions in LLVM IR for field accesses.
   std::map<CORINFO_FIELD_HANDLE, uint32_t> FieldIndexMap;
-};
-
-/// \brief Stub \p SymbolResolver expecting no resolution requests
-///
-/// The ObjectLinkingLayer takes a SymbolResolver ctor parameter.
-/// The CLR EE resolves tokens to addresses for the Jit during IL reading,
-/// so no symbol resolution is actually needed at ObjLinking time.
-class NullResolver : public llvm::RuntimeDyld::SymbolResolver {
-public:
-  llvm::RuntimeDyld::SymbolInfo findSymbol(const std::string &Name) final {
-    llvm_unreachable("Reader resolves tokens directly to addresses");
-  }
-
-  llvm::RuntimeDyld::SymbolInfo
-  findSymbolInLogicalDylib(const std::string &Name) final {
-    llvm_unreachable("Reader resolves tokens directly to addresses");
-  }
 };
 
 /// \brief The Jit interface to the CoreCLR EE.

--- a/lib/Jit/CMakeLists.txt
+++ b/lib/Jit/CMakeLists.txt
@@ -14,7 +14,7 @@ set(LLVM_LINK_COMPONENTS
   ExecutionEngine
   IPO
   IRReader
-  MCJIT
+  OrcJIT
   MC
   Support
   native

--- a/lib/Jit/EEMemoryManager.cpp
+++ b/lib/Jit/EEMemoryManager.cpp
@@ -17,7 +17,6 @@
 #include "jitpch.h"
 #include "LLILCJit.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
-#include "llvm/ExecutionEngine/MCJIT.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -267,7 +267,7 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
 
     // Don't allow the LoadLayer to search for external symbols, by supplying
     // it a NullResolver.
-    NullResolver Resolver;
+    orc::NullResolver Resolver;
     auto HandleSet =
         Compiler.addModuleSet<ArrayRef<Module *>>(M.get(), &MM, &Resolver);
 


### PR DESCRIPTION
LLILC doesn't need its own NullResolver class now that LLVM provides one as a utility.
Also remove some vestigial MCJit references.