### PR TITLE
Change getSize to getCommonSize to match LLVM change.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -464,7 +464,7 @@ void ObjectLoadListener::getDebugInfoForObject(
       continue;
     if (SI->getAddress(Addr))
       continue;
-    uint64_t Size = SI->getSize();
+    uint64_t Size = SI->getCommonSize();
 
     unsigned LastDebugOffset = -1;
     unsigned NumDebugRanges = 0;


### PR DESCRIPTION
LLVM renamed SymbolRef::getSize to SymbolRef::getCommonSize,
so change LLILC code to use the new name.