### PR TITLE
Fix a small bug in getDebugInfoForObject.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -451,6 +451,9 @@ void ObjectLoadListener::getDebugInfoForObject(
 
   for (symbol_iterator SI = DebugObj.symbol_begin(), E = DebugObj.symbol_end();
        SI != E; ++SI) {
+    if ((SI->getFlags() & SymbolRef::SF_Common) == 0)
+      continue;
+
     SymbolRef::Type SymType;
     if (SI->getType(SymType))
       continue;


### PR DESCRIPTION
`getCommonSize` is only valid on symbols that have the `SF_Common` flag
set. Check for this flag before attempting to get symbol sizes.