### PR TITLE
Change call to SymbolRef::getType() to match LLVM changed signature.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -455,9 +455,7 @@ void ObjectLoadListener::getDebugInfoForObject(
 
   for (const auto &Pair : SymbolSizes) {
     object::SymbolRef Symbol = Pair.first;
-    SymbolRef::Type SymType;
-    if (Symbol.getType(SymType))
-      continue;
+    SymbolRef::Type SymType = Symbol.getType();
     if (SymType != SymbolRef::ST_Function)
       continue;
 


### PR DESCRIPTION
LLVM changed the signature of SymbolRef::getType() by removing
its parameter, so modify call to match.