### PR TITLE
Move wiki contents to Documentation directory

### DIFF
--- a/Documentation/Areas-To-Contribute.md
+++ b/Documentation/Areas-To-Contribute.md
@@ -1,0 +1,89 @@
+# Areas to Contribute
+
+Below is a list of areas where LLILC needs work.
+Their order follows the path to creating a functioning JIT, that can compile
+most C# programs; and doing so with contributions from the Community - so good
+documentation comes early.
+Each item is given a "star" rating: 1 star denotes easy; many stars denote challenging.
+
+We always keep a [list of open issues](https://github.com/dotnet/llilc/issues)
+in the repo, to track open work items.  This is a good place to start.  But
+beware that it changes day-by-day.  So if you spot an item you'd like to work
+on, assign it to yourself, so everyone can see it's being worked on.
+
+As you work on an issue, it will likely spawn more work.  So enter these as issues.
+
+## Major Areas
+
++ (*) Areas where documentation needs improving.
+  Eg: [#122](https://github.com/dotnet/llilc/issues/122) thru
+      [#176](https://github.com/dotnet/llilc/issues/176)
+
++ (**) Extend the Reader
+  Eg: [#278](https://github.com/dotnet/llilc/issues/278) thru
+      [#286](https://github.com/dotnet/llilc/issues/286) thru
+
++ (**) Add support for more MSIL opcodes.
+  Eg: [#187](https://github.com/dotnet/llilc/issues/187) thru
+      [#192](https://github.com/dotnet/llilc/issues/192)
+
++ (**) Implement missing TODO features.  Eg:
+  + Synchronized methods [#271](https://github.com/dotnet/llilc/issues/271)
+  + Just my code [#272](https://github.com/dotnet/llilc/issues/272)
+  + Explicit class initialization [#274](https://github.com/dotnet/llilc/issues/274)
+  + Union types [#275](https://github.com/dotnet/llilc/issues/275)
+  + Virtual stub dispatch [#267](https://github.com/dotnet/llilc/issues/267)
+  + Intrinsic calls
+
++ (***) Finish support for CoreCLR Generics.
+
++ (****) Exception Handling.
+  Eg: [#63](https://github.com/dotnet/llilc/issues/63) thru
+      [#77](https://github.com/dotnet/llilc/issues/77)
+
++ (**) Memory allocation [#233](https://github.com/dotnet/llilc/issues/233)
+
++ (***) Function inlining [#239](https://github.com/dotnet/llilc/issues/239)
+
++ (*) Enable vectorization (System.Numerics.Vector)
+
++ (**) Add aliasing information for loads that are known to be
+  invariants (eg array length, vtables, etc).
+  [#291](https://github.com/dotnet/llilc/issues/291)
+
++ (**) GC Lifetime Checker.
+  [#34](https://github.com/dotnet/llilc/issues/34)
+
++ (***) Ports to other platforms.
+  +  Linux and MAC OSX are basically working, but need refining
+  +  Other platforms (eg: ARM-64)
+
++ (**) Enable deferred lowering of certain runtime
+  contructs [#292](https://github.com/dotnet/llilc/issues/292)
+  + Helper calls (eg: double->int conversions)
+  + Write barriers
+  + Struct copying
+
+
++ (***)Design & Architecture.
+  Eg: [#22](https://github.com/dotnet/llilc/issues/22); Object-Model Operators;
+
++ (**) Optimizations specific to C#:
+  + null check
+  + bounds check
+  + type check
+  + overflow check
+  + etc
+
++ (*) Add benchmarks for optimization
+
++ (\*\*) Add web-crawler to *harvest* MSIL tests and execute
+
++ (***) Generator for random (but legal) MSIL code [#503](https://github.com/dotnet/llilc/issues/503)
+
++ (**) Bugs
+  +  If you want to fix an existing bug, assign to yourself and go
+  +  If you find a new bug, please check it's not a
+  duplicate, then enter as an issue, with as simple a repro as you can devise
+
++ (**) NGEN support [#287](https://github.com/dotnet/llilc/issues/287)

--- a/Documentation/Background.md
+++ b/Documentation/Background.md
@@ -1,0 +1,14 @@
+# Background
+
+LLILC is an Open-Source project that Compiles msIL (.NET) code to native
+binary, using the LLVM compiler framework.  We pronounce it "lilac". The
+project will provide both a JIT ("Just-In-Time") and an AOT ("Ahead-Of-Time")
+compiler targeting [CoreCLR](https://github.com/dotnet/coreclr).  
+
+The LLILC LLVM based toolchain is a companion project to the CoreCLR RyuJIT
+providing the community with an accessible infrastructure for experimentation
+and porting to new targets. Our goal is to make it easy(-ier) to make new
+tools or take C# to new platforms.  Our initial supported platform is Windows
+but we plan to extend support to Linux and Mac in the near term.  
+
+For more background on the .NET Architecture, see its [ECMA Specification](http://www.ecma-international.org/publications/standards/Ecma-335.htm).

--- a/Documentation/Code-Formatting.md
+++ b/Documentation/Code-Formatting.md
@@ -1,0 +1,61 @@
+# Code Formatting
+
+The LLILC project is structured as a subproject of LLVM so we are using the
+same coding conventions as LLVM. See the [coding convention document](llilc-Coding-Conventions-and-Commenting-Style.md)
+for more details.  To maintain these conventions, we require all contributors
+to run our code formatting script over their changes before submitting a pull
+request. The code formatting script is found at LLILC\utils\ccformat.py.
+
+## Prerequisites
+
+* clang-format should be on your path. clang-format can either be installed
+  by downloading Clang's prebuilt binaries from LLVM directly (http://llvm.org/releases/download.html)
+  or building clang from source.
+
+## Checking Formatting
+
+To check the formatting of any submissions, contributors should run from
+their main LLILC enlistment directory:
+
+> utils\ccformat.py
+
+This will run clang-format.exe over all of the LLILC source, and print any
+formatting errors that it found.
+
+If you do not have clang-format on your path, you can specify where the
+script should look for clang-format:
+
+> utils\ccformat.py --clang-format \<full path to clang-format\>
+
+If you do not want to see the diffs, but only want to know if you have
+formatting errors, you can run with --hide-diffs:
+
+> utils\ccformat.py --hide-diffs
+
+## Fixing Formatting errors
+
+If ccformat.py informs you that there are diffs between your code and the
+formatted version returned by clang-format, contributors need to run with
+--fix to automatically fix formatting errors:
+
+> utils\ccformat.py --fix
+
+## Running clang-tidy
+
+Currently, we do not run clang-tidy by default with ccformat.py. If a
+contributor would like to run clang-tidy, he can run ccformat.py with --tidy:
+
+> utils\ccformat.py --tidy
+
+There are various options contributors can pass to clang-tidy which can be
+seen by running:
+
+> utils\ccformat.py --help
+
+## Running ccformat without clang-format
+
+Contributors may choose to run ccformat.py without running clang-format
+(when running tidy, for example). To do so, run ccformat.py with the
+--noformat switch:
+
+> utils\ccformat.py --noformat

--- a/Documentation/Contributing.md
+++ b/Documentation/Contributing.md
@@ -1,0 +1,36 @@
+# Contribution Guide
+
+## Workflow
+We follow the standard [GitHub workflow](https://guides.github.com/introduction/flow/).
+We like to track ongoing work using GitHub issues as described in the
+[developer workflow document](Developer-Workflow.md).
+ - To submit changes, please create a personal fork of the LLILC repo, push
+   your changes there, and issue a pull request to merge those changes into
+   the master branch of the main repository.
+ - Please be sure to perform the appropriate [formatting](#coding-conventions-and-formatting)
+   and [testing](#testing) as described below before submitting your pull
+   request.
+ - Whenever possible, please divide any changes you want to make into a
+   series of small, incremental changes that can be submitted and reviewed
+   independently.  Doing so will
+    - Make the code easier to review (allowing for higher quality review
+      feedback)
+    - Keep your work aligned with LLILC's direction and architecture along
+      the way (avoiding wasted time pursuing a direction that ultimately
+      gets abandoned)
+    - Spare you the pain of keeping large outstanding changes up-to-date
+      with tip-of-tree
+ - Occasionally we'll deviate from this model and use long-lived branches,
+   which follow [another workflow](Long-Running-Branch-Workflow.md).
+
+## Coding Conventions and Formatting
+Any code being submitted must be formatted per the instructions in the
+[code formatting document](Code-Formatting.md).  We follow LLVM's coding
+conventions, as described in our [coding conventions document](llilc-Coding-Conventions-and-Commenting-Style.md).
+
+## Testing
+The [test harness document](Testing.md) describes the tests we expect to be
+run for each submission and how to run them.
+
+## Open Areas
+Looking for an area to contribute to?  See our [list of open areas](Areas-To-Contribute.md).

--- a/Documentation/Developer-Workflow.md
+++ b/Documentation/Developer-Workflow.md
@@ -1,0 +1,84 @@
+# Developer Workflow
+
+## Introduction
+
+This documents our typical workflow. At a high level this covers how we
+expect issues to work, what our development cadence is, and how we do design
+for larger features.  And by we, we mean the whole community. These guidelines
+hopefully foster collaboration and high quality, useful software.
+(Some fun wouldn't hurt either.)
+
+## Issues
+
+We use GitHub issues to track work, so if you're working on something, open
+an issue.  It gives the community a place to have a conversation about the
+fix/feature that's being worked on.  In addition it helps everybody keep
+track of who is working on what so that we can minimize duplication and
+redundant work.
+
+The typical issue flow is as follows:
+- Have a great idea, or find a bug, and open issue.
+- Issue is discussed on GitHub and a direction is established.
+- Somebody signs up to do the work and potentially a sprint milestone is
+  assigned if the work directly effects a particular near term project
+  [goal](https://github.com/dotnet/llilc/blob/master/Documentation/llilc-milestones.md).
+- Ongoing notes on the implementation are added to the issue as work progresses.
+- Work is completed, tested, PR'd, and merged in.
+- Issue is closed
+
+Note on 'assigning' issues: The only people that can be assigned to an issue
+in GitHub are people that are in one of the project groups (either *llilc* -
+read/write access, or *llilc-community* - read only access).  We add people
+to the Community group after their first PR is accepted by the collaborators.
+This enables you to be added as the assignee for issues.  So if this is your
+first issue, note your Github account name in the issue as the person
+working on it and others will understand that it's in flight.
+
+Note on read/write access: We'd like to develop a broad set of committers to
+the project from the community (we don't have any non-MS committers at this
+point) we think that this should happen after people build a track record in
+the llilc-community group.  The expectation is that after few (3-5) non-trivial
+contributions a community member can request to be added to the project group
+and gain read/write access to the source.  With this access also comes the
+expectation that the collaborator will help review others PR's, help maintain
+documentation, as well as generally facilitate the smooth running of the project.
+
+## Workflow
+
+We use 3 week sprints in a agile(-ish) model.  These sprints are added as
+Milestones in Github (not to be confused with the project [Milestones](llilc-milestones.md)
+which are larger granularity proof points of functionality.)  Look at the
+[Github milestones page](https://github.com/dotnet/llilc/milestones) to see
+the individual sprints and their end dates. These sprints are used by core
+members of the team to managed work toward near term goals, but it is not
+necessary for community contributors to use these milestones.  The only place
+where this could potentially cause some complication is if a particular
+feature/fix is needed for a near term goal.  In this case we would have a
+conversation about assigning the issue to a milestone and potentially moving
+the work to a collaborator that can commit to a solution in the needed time
+frame. We're attempting to have a balance between an open and friendly
+environment to hack and the necessity to drive functionality (as well as
+  meet product goals).
+
+A typical flow is as follows:
+- Day one of a sprint milestone work is self-assigned by developers based on
+  a combination of priority and what the think that they can get done in a 3
+  week period.
+- Through out the sprint notes are added to the issues assigned to the sprint
+  outlining progress.
+- Issues are closed as they are merged back in and the CI system stays green.
+- On the first day of the next sprint, any items not completed are triaged
+  and moved to the appropriate sprint. (Typically this is the next sprint)
+
+## Design process
+
+As stated above, all features start as issues.  If as part of the conversation
+about an issue, the community decides that a particular feature is large or
+complicated enough to warrant a separate write up a document will be created
+by interested parties describing the design and the staging of bring up.
+This document will be reviewed via PR and checked in as separate markdown in
+the project Documentation directory off the root.  A good example of this is
+the [EH design document](llilc-jit-eh.md). As you can see today only larger,
+more complicated areas warrant this treatment.  I want to highlight that
+typical work will be handled via issues, reserving this process for areas
+that require months of development to bring to fruition.

--- a/Documentation/Getting-Started-For-Linux-and-OS-X.md
+++ b/Documentation/Getting-Started-For-Linux-and-OS-X.md
@@ -1,0 +1,72 @@
+# Getting Started for Linux and OS X
+
+## Caveats
+
+Support for LLILC on Linux and OS X is still in its early stages. While the
+instructions below should get you up and running, the workflow is a bit rough
+around the edges and there are certainly holes with respect to what is
+supported. The most obvious missing piece is that without following the steps
+on the [CoreCLR wiki](https://github.com/dotnet/coreclr/wiki/Building-and-Running-CoreCLR-on-Linux)
+to obtain a version of mscorlib that is functional on these platforms, there
+is no way to run or test the output of the LLILC build.
+
+## Prerequisites
+
+The prerequisites for building LLILC on Linux and OS X are the same as the
+[prerequisites for building LLVM](http://llvm.org/docs/GettingStarted.html#software)
+with CMake unioned with the prerequisites for building [CoreCLR](https://github.com/dotnet/coreclr).
+
+* [GCC](http://gcc.gnu.org) >= 4.7.0
+* [Clang](http://clang.llvm.org/) >= 3.5.0
+* [Python](http://python.org) >= 2.7
+* [CMake](http://cmake.org) >= 2.8.8
+* [libunwind](http://www.nongnu.org/libunwind/) >= 1.1
+
+In addition, LLILC requires very recent builds of the [Microsoft fork of LLVM](https://github.com/microsoft/llvm)
+and [CoreCLR](https://github.com/dotnet/coreclr). Instructions for fetching
+and building both can be found below.
+
+## Getting and building the code
+
+1. Clone and build CoreCLR:
+
+    ```
+    $ git clone https://github.com/dotnet/coreclr
+    $ cd coreclr
+    $ ./build.sh
+    $ cd ..
+    ```
+
+    After it completes, the build will indicate where the CoreCLR binaries
+    are available. Make a note of this location
+    (typically binaries/Product/<os>.x64.debug).
+
+2. Clone the Microsoft fork of LLVM:
+
+    ```
+    $ git clone -b MS https://github.com/microsoft/llvm
+    ```
+
+3. Clone LLILC:
+
+    ```
+    $ cd llvm/tools
+    $ git clone https://github.com/dotnet/llilc
+    $ cd ..
+    ```
+
+4. Configure LLVM and LLILC:
+
+    ```
+    $ mkdir build
+    $ cd build
+    $ cmake -DWITH_CORECLR=../../coreclr/path/to/CoreCLR/binaries ..
+    ```
+
+5. Build LLVM and LLILC:
+
+    ```
+    $ make
+    ```
+
+    If all goes well, the build will complete without errors.

--- a/Documentation/Getting-Started-For-Windows.md
+++ b/Documentation/Getting-Started-For-Windows.md
@@ -1,0 +1,116 @@
+# Getting Started for Windows
+
+Note: all commands are typed from a Windows Command Prompt, and `c:\dotnet`
+may be replaced in all commands below with the directory of your choice.
+
+* Install Git
+  * Follow the instructions at [git-scm downloads](http://git-scm.com/downloads).
+    All of the installer's defaults are acceptable.
+
+* Install CMake
+  * Follow the instructions at [CMake Install](http://www.cmake.org/install/)
+  * Make sure to select "Add CMake to the system PATH for all users" when
+    running the installer (all other defaults are acceptable).
+
+* Clone and build CoreCLR:
+    ```
+    $ git clone https://github.com/dotnet/coreclr
+    $ cd coreclr
+    $ .\build.cmd
+    $ cd ..
+    ```
+    After it completes, the build will indicate where the CoreCLR binaries
+    are available. Make a note of this location
+    (typically bin/Product/Windows_NT.x64.debug).
+
+* Clone the Microsoft fork of LLVM to your PC
+  * Change directories to where you want to place your clone and run `git`
+    to clone the Microsoft fork of LLVM:
+        ```
+        > cd c:\dotnet
+        > git clone -b MS https://github.com/microsoft/llvm
+        ```
+
+  * This will create a directory tree under `llvm` that contains the cloned
+    sources.
+
+* Clone LLILC to your PC
+  * Because LLILC is structured as an LLVM tool, it is canonically cloned
+    into the `tools` subdirectory of the LLVM tree created above:
+
+        ```
+        > cd c:\dotnet\llvm\tools
+        > git clone https://github.com/dotnet/llilc
+        ```
+
+  * This will create a directory tree under `llilc` that contains the cloned
+    sources.
+
+* Install Python
+  * Follow the instructions at [Python Downloads](https://www.python.org/downloads/)
+  * Choose Python 2.7.9 for Windows
+
+* Install Visual Studio 2013
+  * Follow the instructions at [Visual Studio](http://www.visualstudio.com/en-us/products/visual-studio-community-vs)
+    to install the free Community edition of Visual Studio 2013.
+
+* If you want to run [Doxygen](http://www.stack.nl/~dimitri/doxygen/) to
+  produce documentation from your code comments, then in addition do the following:
+  * Install [Doxygen](http://www.stack.nl/~dimitri/doxygen/) using the
+    instructions on its web site. The LLVM web site is using Doxygen 1.7.6.1
+    however the 1.8 series added support for Markdown formatting. We would like
+    to use Markdown in our comments, so use the latest version of Doxygen.
+  * Install [graphviz](http://graphviz.org/) using instructions on their
+    site. The current version no longer modifies your path, so you should
+    manually modify your path so that it includes "dot".
+* Create a Visual Studio Solution for LLVM + LLILC
+  * Create a directory to hold the LLVM build output:
+
+        ```
+        > cd c:\dotnet
+        > mkdir llvm-build
+        ```
+
+  * Run cmake from within the newly-created `llvm-build` directory with the
+    Visual Studio backend to generate the LLVM solution:
+
+        ```
+        > cd llvm-build
+        > cmake -G "Visual Studio 12 2013 Win64" ..\llvm -DWITH_CORECLR=<coreclr path>\bin\Product\$platform.$arch.$build>
+        ```
+        note: for Windows $platform should resolve to 'Windows_NT'
+
+  * However if you also want to run Doxygen, use the following instead:
+
+        ```
+        > cd llvm-build
+        > cmake -G "Visual Studio 12 2013 Win64" ..\llvm -DLLVM_ENABLE_DOXYGEN=ON -DWITH_CORECLR=<coreclr path>\bin\Product\$platform.$arch.$build>
+        ```
+
+  * This will generate `LLVM.sln` inside the `llvm-build` directory.
+
+* Build LLVM + LLILC from the command line
+  * Change directories to the LLVM build directory and set up environment
+    variables for the Visual Studio toolchain:
+
+        ```
+        > cd c:\dotnet\llvm-build
+        > "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x64
+        ```
+
+  * Start the build. Note that If you have a multi-core machine, you may
+    request a faster, parallel build by adding the `/m` flag to the command
+    line, optionally specifying the degree of parallelism (e.g. `/m:4`).
+
+        ```
+        > msbuild LLVM.sln /p:Configuration=Debug /p:Platform=x64 /t:ALL_BUILD
+        ```
+  * To run doxygen over the LLILC sources use the following command line:
+
+        ```
+        > msbuild LLVM.sln /p:Configuration=Debug /p:Platform=x64 /t:doxygen-llilc
+        ```
+
+The build steps above can also be done from Visual Studio by going to the
+solution explorer, right clicking the desired project (e.g. ALL_BUILD or
+  doxygen-llilc) and selecting "build".

--- a/Documentation/Long-Running-Branch-Workflow.md
+++ b/Documentation/Long-Running-Branch-Workflow.md
@@ -1,0 +1,49 @@
+# Long-Running Branches
+
+The first rule of long-running branches on the main LLILC repo is that they
+should be the exception, not the norm.  Most changes should be pushed to a
+personal fork and a pull request issued to merge from the fork directly to
+the master branch of the main LLILC repo, per the [contribution guide](Contributing.md#workflow).
+
+Occasionally, however, we'll need to make changes that simultaneously
+ - Involve a lot of code
+ - Will take a long time to develop
+ - Will begin with tentative/exploratory changes that are likely to be revised
+   before the feature is complete
+ - Are likely to destabilize the codebase until complete
+ - Don't have a reasonably efficient incremental implementation path available
+
+For such changes, it makes sense to work in a long-lived branch, then
+retroactively parcel out the change into non-destabilizing pieces, as
+incremental as possible, for integration back into the master branch.  When
+key features meet these criteria, we may create a long-lived branch on the
+main repo where the work will occur, to publicize it and facilitate
+collaboration/review in even the early tentative stages.  For example, the
+initial bring-up of [exception handling support](https://github.com/dotnet/llilc/tree/EH)
+and [precise garbage collection support](https://github.com/dotnet/llilc/tree/GC)
+are both following this model.
+
+The expected workflow for long-lived branches in the main repo is:
+ 1. The branch maintainer(s) will regularly push merges from master to the
+    long-lived branch
+    - Merging is preferred over rebasing to simplify collaboration
+    - Pull requests are not expected for these merges (there's not really
+      anything to review); the branch maintainer(s) will push them directly
+ 2. All other changes in the branch should be made via pull requests from
+    personal forks.  These changes should be small and incremental, but may
+    be destabilizing (when warranted to make forward progress).  Getting
+    code reviews along the way should help us end up with higher quality code
+    and fewer late-stage surprises than delaying review until merging back to
+    master would.
+ 3. Any such branch may have its own policy for what level of testing is
+    expected/required to maintain the quality bar as changes are made.
+    Code style/formatting should be held to [the usual standards](Code-Formatting.md).
+ 4. When the feature is stable/complete, the branch maintainer(s) should
+    rebase/repackage the changes in a way that is logical to merge into master.
+    - The individual changes to be merged must be stable, and should be as
+      incremental as possible.
+    - Pull requests should be opened to merge the changes into master.
+    - Typically, each incremental change should have its own pull request.
+    - A single pull request for a series of incremental changes is ok if
+      they are a straightforward replay of already-reviewed commits from the
+      branch.

--- a/Documentation/Setup-With-LLILC-Out-Of-LLVM-Tree.md
+++ b/Documentation/Setup-With-LLILC-Out-Of-LLVM-Tree.md
@@ -1,0 +1,139 @@
+# Setup With LLILC Out-Of LLVM Tree
+
+The [Getting Started for Windows doc](Getting-Started-For-Windows.md) tells
+how to configure LLILC when the LLILC repository is placed in the LLVM/tools
+subdirectory. This page tells how to configure LLVM and LLILC when the LLILC
+workspace is separate from the LLVM workspace. This might be desirable, for
+example, if you want to have multiple LLILC workspaces (for working on
+multiple branches simultaneously) but want to share a single LLVM workspace
+and LLVM build.
+
+We document which steps are the same and which steps that are different
+from the [Getting Started for Windows document](Getting-Started-For-Windows.md).
+
+Steps that are the same are:
+
+* Install Git
+* Clone and build CoreCLR:
+* Clone the Microsoft fork of LLVM to your PC
+* Install Python
+* Install CMake
+* Install Visual Studio 2013
+* Install [Doxygen](http://www.stack.nl/~dimitri/doxygen/)
+* Install [graphviz](http://graphviz.org/)
+
+In what follows, let
+
+* $coreclr-repo-dir be the directory where the the coreclr was cloned.
+* $coreclr-build-dir be $coreclr-repo-dir\bin\Product\$platform.$arch.$build> directory.
+* $llvm-repo-dir be the directory where LLVM was cloned.
+* $llvm-build-dir be the directory where LLVM was built.
+* $llilc-repo-dir be the directory where LLILC was cloned
+* $llilc-build-dir be the directory where LLILC is built
+
+$coreclr-build-dir is fixed relative to $coreclr-repo-dir, but all of the others can be
+placed wherever you like. Below we use paths like $llilc-repo-dir/.. to denote the
+parent directory of $llilc-repo-dir. When we do a `cd` to a directory we assume you
+have previously created the directory. To simplify the description we also assume you
+will be enabling Doxygen.
+
+Steps that are different:
+
+* Clone LLILC to your PC
+  * Unlike the [Getting Started for Windows](Getting-Started-For-Windows.md)
+    directions, create a separate LLILC directory.:
+
+        ```
+        > cd $llilc-repo-dir/..
+        > git clone https://github.com/dotnet/llilc
+        ```
+
+  * This will create a directory tree under $llilc-repo-dir that contains
+    the cloned sources.
+
+* Create a Visual Studio Solution for LLVM
+  * Create a directory to hold the LLVM build output:
+
+        ```
+        > mkdir $llvm-build-dir
+        ```
+
+  * Run cmake from within the newly-created `llvm-build` directory with the
+    Visual Studio backend to generate the LLVM solution:
+
+        ```
+        > cd $llvm-build-dir
+        > cmake -G "Visual Studio 12 2013 Win64" $llvm-repo-dir -DLLVM_TARGETS_TO_BUILD:STRING=X86 -DLLVM_ENABLE_DOXYGEN=ON
+        ```
+
+  * This will generate `LLVM.sln` inside the $llvm-build-dir directory.
+
+* Build LLVM from the command line
+  * Change directories to the LLVM build directory and set up environment
+    variables for the Visual Studio toolchain:
+
+        ```
+        > cd $llvm-build-dir
+        > "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x64
+        ```
+
+  * Start the build. Note that If you have a multi-core machine, you may
+    request a faster, parallel build by adding the `/m` flag to the command
+    line, optionally specifying the degree of parallelism (e.g. `/m:4`).
+
+        ```
+        > msbuild LLVM.sln /p:Configuration=Debug /p:Platform=x64 /t:ALL_BUILD
+        ```
+* Create a Visual Studio Solution for LLILC
+  * Create a directory to hold the LLILC build output:
+
+        ```
+        > mkdir $llilc-build-dir
+        ```
+
+  * Run cmake from within the newly-created `llilc-build` directory with the
+    Visual Studio backend to generate the LLVM solution:
+
+        ```
+        > cd $llilc-build-dir
+        > cmake -G "Visual Studio 12 2013 Win64" $llilc-repo-dir -DWITH_CORECLR=$coreclr-build-dir -DWITH_LLVM=$llvm-build-dir -DLLVM_TARGETS_TO_BUILD:STRING=X86 -DLLVM_ENABLE_DOXYGEN=ON
+        ```
+  * This will generate `LLILC.sln` inside the $llilc-build-dir directory.
+  * Currently there is a bug in the LLVM configuration that leaves some file
+    paths in Windows format with back slashes. If you get an error message
+    when configuring, like
+       ```
+       Syntax error in cmake code at
+
+         share/llvm/cmake/LLVMExports.cmake:233
+
+       when parsing string
+
+          ...C:\Program Files (x86)\...
+
+      Invalid escape sequence \P
+      ```
+    you can work around it by editing the offending line by
+    changing the back slashes to forward slashes.
+
+* Build LLILC from the command line
+  * Change directories to the LLVM build directory and set up environment
+    variables for the Visual Studio toolchain:
+
+        ```
+        > cd $llilc-build-dir
+        > "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x64
+        ```
+
+  * Start the build. Note that If you have a multi-core machine, you may
+    request a faster, parallel build by adding the `/m` flag to the command
+    line, optionally specifying the degree of parallelism (e.g. `/m:4`).
+
+        ```
+        > msbuild LLILC.sln /p:Configuration=Debug /p:Platform=x64 /t:ALL_BUILD
+        ```
+  * To run doxgen over the LLILC sources use the following command line:
+
+        ```
+        > msbuild LLVM.sln /p:Configuration=Debug /p:Platform=x64 /t:doxygen-llilc
+        ```

--- a/Documentation/Testing.md
+++ b/Documentation/Testing.md
@@ -1,0 +1,155 @@
+# Testing LLILC
+
+## Test Harness
+
+LLILC's test harness uses CoreCLR's test assets as underlying engine. It
+provides a LLILC-specific wrapper layer above it. The test harness is located
+at llilc\test. Please add this path to your PATH environment variable before
+using it.
+
+There are three steps in LLILC testing: building tests, running tests, and
+checking results.
+
+## Building tests:
+
+Building tests is performed with CoreCLR script directly. A CoreCLR build
+automatically performs building tests. If it is done already, you can choose
+to skip this step. If you want to build test as a separate step, do the following:
+
+ ```
+cd C:\coreclr\tests
+buildtest.cmd clean
+ ```
+https://github.com/dotnet/coreclr/wiki/Test-instructions for more information.
+
+## Running tests:
+
+Use llilc_runtest.py to run tests. With specified LLILC JIT and pre-built
+CoreCLR runtime, llilc_runtest runs CoreCLR testing. You can choose to create
+a running result if you want to. The result contains LLILC specific dumps:
+per function summary or detailed LLVM IR dumps. You need to run this script
+from coreclr\tests directory.
+ ```
+cd C:\coreclr\tests
+llilc_runtest -d verbose -j C:\llvm-build\bin\Debug\llilcjit.dll -c C:\coreclr\bin\Product\Windows_NT.x64.Debug -r C:\results\base
+ ```
+llilc_runtest --help for more information.
+
+**Note:** You may find that running tests with a pure DEBUG build of LLILC
+is very slow.  To get a faster build that still has assertion checking, pass
+`-DCMAKE_BUILD_TYPE=RELWITHDEBINFO -DLLVM_ENABLE_ASSERTIONS=ON` to cmake and
+`/p:Configuration=RelWithDebInfo` to msbuild when you configure/build LLILC/LLVM.
+
+## Checking results:
+
+Use llilc_checkpass to check the results. It takes two test results, using
+one as base result, one as diff result to perform the checking. This step is
+LLILC-specific. Because LLILC is still under early stage of development, we
+need to guarantee that any function that was successfully jitted by LLILC is
+not broken by new change.
+ ```
+llilc_checkpass -b C:\results\base -d C:\results\diff
+ ```
+llilc_checkpass --help for more information.
+
+It is required that developer has to guarantee all LLVM IR changes are benign.
+It can be achieved with any diff tool.
+
+## Running individual tests:
+
+The process for running individual test cases on Windows in cmd is:
+* Copy the LLILCJit.dll in `llvm-build/bin/Debug` to the CoreCLR binary
+  directory (`coreclr/bin/Product/<build>/`)
+* Run the `llilc/test/LLILCTestEnv.cmd` to set the needed env variables. If
+  debug printing is desired, also run `set COMPlus_DumpLLVMIR=[summary, verbose]`.
+* Set the code page to 65001 (See #527 and #12).
+* Run the test binary via CoreRun.exe.
+
+## Using llilc as an ngen jit:
+
+crossgen.exe is the tool used to generate ngen images for CoreCLR. The
+generated native image has .ni.exe or .ni.dll suffix. crossgen requires
+mscorlib.ni.dll to be available – you have to generate mscorlib.ni.dll first.
+The following environment variable needs to be set (in addition to running
+llilc/test/LLILCTestEnv.cmd):
+`set COMPlus_AltJitNgen=*`.
+
+## Use Cases
+
+### Developer Use Case
+Step 1: Update CoreCLR to latest, and build CoreCLR
+
+Step 2: Update LLILC master to latest, and build your baseline JIT
+
+Step 3: Create a verbose baseline result:
+
+```
+cd coreclr\tests
+llilc_runtest -j <JIT_PATH> -c <CORECLR_RUNTIME_PATH> -d verbose -r <BASE_RESULT_PATH>
+```
+Step 4: Create your own branch
+
+Step 5: Do new development or fix issues on your branch, and build your new diff JIT
+
+Step 6: Check your change pass overall testing:
+
+```
+cd coreclr\tests
+llilc_runtest -j <JIT_PATH> -c <CORECLR_RUNTIME_PATH>
+```
+If failed, back to step 5 for fixing.
+
+Step 7: Check you change does not cause new jitting failure:
+
+```
+cd coreclr\tests
+llilc_runtest -j <JIT_PATH> -c <CORECLR_RUNTIME_PATH> -d summary -r <DIFF_RESULT_PATH>
+llilc_checkpass -b <BASE_RESULT_PATH> -d <DIFF_RESULT_PATH>
+```
+If failed, back to step 5 for fixing.
+
+Step 8: Check your change does not cause bad LLVM IR change.
+
+```
+llilc_runtest -j <JIT_PATH> -c <CORECLR_RUNTIME_PATH> -d verbose -r <DIFF_RESULT_PATH>
+```
+Use any diff tool to compare \<BASE_RESULT_PATH\> and \<DIFF_RESULT_PATH\>.
+If there is bad LLVM IR change, back to step 5 for fixing.
+
+Step 9: Now you are ready for a pull request.
+
+### Lab CI Use Case
+Lab CI usage is the most simplified version. It only checks for overall
+pass/fail and does not keep any result.
+```
+cd coreclr\tests
+llilc_runtest -j <JIT_PATH> -c <CORECLR_RUNTIME_PATH>
+```
+
+### Lab Nightly Use Case
+Step 1. Create a summary result with last-known-good JIT as a baseline or use
+a previous last-known-good summary result as a baseline
+```
+cd  coreclr\tests
+llilc_runtest -j <LAST_KNOWN_GOOD_JIT_PATH> -c <CORECLR_RUNTIME_PATH> -d summary -c <BASE_RESULT_PATH>
+```
+
+Step 2. Create a summary result with latest JIT as diff result
+```
+cd coreclr\tests
+llilc_runtest -j <LASTEST_JIT_PATH> -c <CORECLR_RUNTIME_PATH> -d summary -r <DIFF_RESULT_PATH>
+```
+
+Step 3. Check if there is any new jitting failure
+```
+cd coreclr\tests
+llilc_checkpass -b <BASE_RESULT_PATH> -d <DIFF_RESULT_PATH>
+```
+
+Step 4. If llilc_checkpass result is negative, there is unexpected error.
+
+Step 5.If llilc_checkpass result is 0, mark latest JIT as last-known-good JIT.
+Result \<DIFF_RESULT_PATH\> could be kept as last-known-good summary result.
+
+Step 6.If llilc_checkpass result is 1, send out failure notice to branch owner.
+Branch owner should analyze the case and bring relevant developer for fixing.

--- a/Documentation/Welcome.md
+++ b/Documentation/Welcome.md
@@ -1,0 +1,30 @@
+# Welcome to LLILC
+
+We pronounce it 'lilac'.  LLILC is comprised of a JIT and AOT compiler for C#.
+They work with the dotnet [CoreCLR](https://github.com/dotnet/coreclr) and
+will complement the current CoreCLR JIT by providing an alternate code
+generator built on the LLVM infrastructure.
+
+## Developer Guides
+
+* [Background](Background.md)
+* [FAQ](llilc-faq.md)
+* [Getting Started for Windows](Getting-Started-For-Windows.md)
+* [Getting Started For Linux and OS X](Getting-Started-For-Linux-and-OS-X.md)
+* [Testing](Testing.md)
+* [Contribution Guide](Contributing.md)
+* [Areas To Contribute](Areas-To-Contribute.md)
+* [LLILC Coding Conventions and Commenting Style](llilc-Coding-Conventions-and-Commenting-Style.md)
+
+## Architecture
+
+* [LLILC Architecture Overview](llilc-arch.md)
+
+### Supporting managed constructs in LLVM
+* [LLILC MSIL Reader](llilc-reader.md)
+* [GC Support in LLILC](llilc-gc.md)
+* [EH Support in LLILC](llilc-jit-eh.md)
+
+## Other Resources
+* [dotnet/CoreCLR](https://github.com/dotnet/coreclr)
+* [dotnet/CoreFx](https://github.com/dotnet/corefx)

--- a/Documentation/llilc-Coding-Conventions-and-Commenting-Style.md
+++ b/Documentation/llilc-Coding-Conventions-and-Commenting-Style.md
@@ -1,0 +1,87 @@
+# LLILC Coding Guidelines
+
+## General Coding Guidelines
+
+The LLILC project is structured as a subproject of LLVM so we are using the
+same coding conventions as LLVM. The LLVM coding conventions are at
+<http://llvm.org/docs/CodingStandards.html>.  We use clang-format to
+check/enforce some formatting rules, as described on our [code formatting document](Code-Formatting.md).
+
+## Commenting Guidelines
+
+In particular <http://llvm.org/docs/CodingStandards.html#commenting> has
+guidelines for commenting code and using Doxygen markup. For a complete
+description of Doxygen markup see <http://www.doxygen.org/manual/docblocks.html>.
+
+We can summarize these as follows:
+
+* Use the "///" style of comment unless that file is written in C or may be
+  included into a C file.
+
+* For Doyxygen markup, use the "\" form, e.g. \brief, rather than the "@"
+  form, e.g. @brief.
+
+* Use the \file command to turn the standard file header into a file-level
+  comment.
+
+* Include descriptive \brief paragraphs for all public interfaces (public
+  classes, member and non-member functions). Explain API use and purpose in
+  \brief paragraphs, don’t just restate the information that can be inferred
+  from the API name. Put detailed discussion into separate paragraphs.
+
+* To refer to parameter names inside a paragraph, use the \p name command.
+  Don’t use the \arg name command since it starts a new paragraph that
+  contains documentation for the parameter.
+
+* Wrap non-inline code examples in \code ... \endcode.
+
+* To document a function parameter, start a new paragraph with the \param
+  name command. If the parameter is used as an out or an in/out parameter,
+  use the \param [out] name or \param [in,out] name command, respectively.
+
+* To describe function return value, start a new paragraph with the \returns
+  command
+
+* For classes and class members that are declared in a header, put the Doxygen
+  comments there. Otherwise put the comments in the implementation file.
+
+* For virtual methods, put the documentation on the method declaration in the
+  base class that first introduced the method. Do not put documentation on
+  the method overrides. In the Doxygen output the comments from the base
+  class method will also be shown for the overriding methods.
+
+In addition to these recommendations from the LLVM coding standards I have
+the following recommendations:
+
+* Doxygen supports Markdown, so use it in your comments when it can do what
+  you want. See <http://www.stack.nl/~dimitri/doxygen/manual/markdown.html>
+
+* In order to provide greater logical clarity on the semantics of classes
+  and methods I suggest using the Doxygen
+    [\pre](http://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdpre),
+    [\post](http://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdpost),
+    and [\invariant](http://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdinvariant)
+    [special commands](http://www.stack.nl/~dimitri/doxygen/manual/commands.html)
+    to specify method preconditions and postconditions and class invariants.
+
+## Use of LLVM I/O APIs
+
+Rather than using the printf family of output functions the LLILC team
+uses the LLVML I/O APIs. This is a simplified form of C++ output.
+
+- The base type is raw_ostream.
+- Derived classes are:
+  - raw_fd_ostream, for output to a file descriptor. Two of these are
+    made and accessed as follows:
+    - outs() is connected to stdout
+    - errs() is connected to stderr.
+    - dbgs() is a debug stream that is connected to stderr but which
+      may optionally have circular buffering but by default it is
+      an unbuffered connection to errs().
+  - raw_string_ostream connects to a std::string given in its
+    - constructor. Any output to that stream is appended to the
+    end of the string.
+- As with C++ the "<<" operator has overloads for outputting all the
+  common data types.
+- In addition the form "<< format(formatstring, args)" may be
+  used to get the usual printf-stype formatting to a stream.

--- a/Documentation/llilc-faq.md
+++ b/Documentation/llilc-faq.md
@@ -1,0 +1,58 @@
+# LLILC FAQ
+
++ Q: What is LLILC?  
+  A: LLILC is an MSIL code generator based on LLVM.  Today LLILC can produce a JIT
+  compiler that can be used with [CoreCLR](https://github.com/dotnet/coreclr), but our
+  over-arching aim is to allow easier porting of managed languages to any platform
+  while supporting a spectrum of compilation strategies.
+
++ Q: What targets will LLILC generate code for?  
+  A: Initially x64.  In future: any target that LLVM supports is
+  possible (x86,  ARM-64, ...)
+
++ Q: What platforms will LLILC target?  
+  A: LLILC targets the same platforms as CoreCLR: Linux, MAC OS X and Windows
+
++ Q: How does the LLILC JIT compiler relate to the CoreCLR RyuJIT compiler?  
+  A: Their aims are different: RyuJIT is a high-performance,
+  custom JIT, in that it implements its own optimizatons
+  and codegen, specific to C#.  It matches the high throughput required by
+  the CoreCLR runtime.  LLILC, by contrast, uses the LLVM framework,
+  which provides industrial-strength optimizations, leveraged by
+  the Clang C++ compiler.  It thereby offers a familiar environment
+  within which developers can implement low-level, ‘backend’ tools,
+  such as code analyzers, obfuscators, verifiers, etc.
+
++ Q: How do I get started?  
+  A: See the [Welcome Document](Welcome.md)
+
++ Q: Are there any demos?  
+  A: Not as yet.  We need to extend the JIT to handle more
+  tests first.
+
++ Q: How does LLILC differ from Roslyn in the features it provides
+  for building software tools?  
+  A: Roslyn provides *frontend* support, whilst LLILC
+  (via LLVM) provides *backend* support:
+
+  + Roslyn exposes the data structures of a *frontend* – so it’s ideal
+  for building tools such as IDEs, with syntax coloring, warning
+  squiggles, use/definition lookup, refactoring, etc; or
+  translators that convert C# to some other language; or
+  pretty-print formatters; or analyzers that check conformance
+  with coding guidelines (think FxCop).  
+
+  + LLILC, via LLVM, exposes the data structures of a *backend* – so
+  it’s ideal for building tools that inject extra code (eg: performance
+  profiler, code tracer, debugger, parallelism analyzer, race
+  detector); or super-optimizing code (eg: auto-vectorizer, auto-parallelizer);
+  or test-case reduction.
+
++ Q: When will the LLILC AOT (Ahead-Of-Time) compiler be ready?  
+  A: At the moment, CoreCLR does not include an AOT.  We envisage
+  that the LLILC AOT will work in two kinds of environment – those
+  that allow runtime codegen, and those where the entire code is converted to native binary.
+
++ Q: How does LLILC relate to the .NET Native work?  
+  A: .NET Native provides a broad tool-chain, targeting Windows.  The LLILC AOT could
+  be used as the compiler component of .NET Native to target other platforms.

--- a/Documentation/llilc-milestones.md
+++ b/Documentation/llilc-milestones.md
@@ -1,12 +1,13 @@
-# LLILC Bring up Milestones
+# LLILC Bring-Up Milestones
 
-To meet the overarching goal of fully functional JIT and AOT code 
-generators we've broken out some intermediate milestones that we 
-think are good steps along the way.  Each of these milestones represent 
-a new level of functionality or robustness on the way to a production 
+To meet the overarching goal of fully functional JIT and AOT code
+generators we've broken out some intermediate milestones that we
+think are good steps along the way.  Each of these milestones represent
+a new level of functionality or robustness on the way to a production
 quality tool.
 
-### Milestones
+## Milestones
+
 * **"Hello World"** - Using LLILC, JIT all the methods for runtime start-up
    and "Hello World" console app execution.  This is the classic first
    app. Success is that the CLR comes up, and prints "Hello World" and
@@ -25,7 +26,7 @@ quality tool.
 * **AOT Roslyn on Linux** - Full Roslyn compiling itself as a command line
   AOT tool.
 
-We'll cross these off as we get through them but we're evaluating open issues 
+We'll cross these off as we get through them but we're evaluating open issues
 with respect to how fixing them will advance these goals.
 
 Note:  To add a milestone to this list open an issue to start the discussion,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ with a goal of producing a set of cross-platform .NET code generation tools.
 Today LLILC is being developed against [dotnet/CoreCLR](https://github.com/dotnet/coreclr)
 for use as a JIT, but an ahead of time (AOT) compiler is planned for the future.  
 
-See the [wiki](https://github.com/dotnet/llilc/wiki) for more information.
+See the [documentation](Documentation/Welcome.md) for more information.
 It has a more complete discussion of our background and goals as well as
 "getting started" details and developer information.
 
@@ -28,8 +28,8 @@ It has a more complete discussion of our background and goals as well as
 Supported Platforms
 -------------------
 
-Our initial supported platform is [Windows](https://github.com/dotnet/llilc/wiki/Getting-Started-For-Windows),
-but [Linux and Mac OS X](https://github.com/dotnet/llilc/wiki/Getting-Started-For-Linux-and-OS-X)
+Our initial supported platform is [Windows](Documentation/Getting-Started-For-Windows.md),
+but [Linux and Mac OS X](Documentation/Getting-Started-For-Linux-and-OS-X.md)
 support are under development.
 
 
@@ -38,5 +38,5 @@ Contributions
 
 LLILC is just starting up.  Only a few tests are working and there are lots
 of places where we need help.  Please see our [issues](https://github.com/dotnet/llilc/issues)
-or the [contributing page](https://github.com/dotnet/llilc/wiki/Areas-To-Contribute)
+or the [contributing document](Documentation/Areas-To-Contribute.md)
 for how to pitch in.


### PR DESCRIPTION
Bulk move with minimal editing (just wrapping lines and fixing up links)
to get our documentation in a place where changes can be made via pull
request and it will be versioned with the code.

Resolves #612.
Resolves #622.