### PR TITLE
Ensure Array operations use correct Array type.

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -70,6 +70,10 @@ struct LLILCJitContext {
   /// Write an informational message about this jit request to LLVM's dbgs().
   void outputDebugMethodName();
 
+  /// Write an informational message about skipping this jit request to LLVM's
+  /// dbgs().
+  void outputSkippingMethodName();
+
 public:
   /// \name CoreCLR EE information
   //@{


### PR DESCRIPTION
Because we do not yet properly do type substitution on the
result of calls to generic-shared methods (#676), sometimes
the result of a call is not the correct type. In particular
sometimes we attempt an array operation on such a result
when the type of the result is not an array type. Typically
it is something like the "canonical" type used to represent
any reference type.

In such cases we need to cast the value to an LLVM type that
represents the correct MSIL type. Prior to this fix we were
just using a single "array of reference" type for these,
but that gives incorrect address arithmetic when the element
type has a size different from the size of a reference.

This change restructures and extends a number of methods
so that array types referencing the proper element type
are created.

For the case of ldelem and stelem instructions we know
what the element type should be, except for the
ldelem.ref and stelem.ref cases where the element type
should be taken from the input Array. In that case if
the input is not an array we settle for using
"array of ref".

For the ldlen instruction that loads the length of an
array, the result does not depend on the element type,
so if the element type is not known we just use
"array of ref" again.

In addition to these fixes, this change also modifies
LLILCJit::compileMethod so that it uses
JitOptions.IsAltJit so that only methods selected
by the ComPlusAltJit environment variables are
JITed by LLILC.

Resolves #630.