### PR TITLE
Fix build flags and several compiler warnings

### DIFF
--- a/include/Jit/EEMemoryManager.h
+++ b/include/Jit/EEMemoryManager.h
@@ -18,7 +18,7 @@
 
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
 
-class LLILCJitContext;
+struct LLILCJitContext;
 
 namespace llvm {
 

--- a/include/Reader/abi.h
+++ b/include/Reader/abi.h
@@ -139,7 +139,8 @@ public:
 /// The \p ABIInfo class provides ABI-specific services. Currently, this is
 /// limited to computing the details of how arguments are passed to functions
 /// for a given platform.
-struct ABIInfo {
+class ABIInfo {
+public:
   /// \brief Gets an \p ABIInfo that corresponds to the target of the given
   ///        \p Module.
   ///

--- a/include/Reader/abisignature.h
+++ b/include/Reader/abisignature.h
@@ -33,7 +33,7 @@ protected:
   ///
   /// \param Signature   The function signature.
   /// \param Reader      The \p GenIR instance that will be used to emit IR.
-  /// \oaram TheABIInfo  The target \p ABIInfo.
+  /// \param TheABIInfo  The target \p ABIInfo.
   ABISignature(const ReaderCallSignature &Signature, GenIR &Reader,
                const ABIInfo &TheABIInfo);
 

--- a/lib/GcInfo/CMakeLists.txt
+++ b/lib/GcInfo/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${LLILC_INCLUDES}/clr
                     ${LLILC_INCLUDES}/Pal)
 
 if( WIN32 )
-  set(CMAKE_CXX_FLAGS "-EHsc")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc")
 endif()
 					
 add_definitions(-DSTANDALONE_BUILD)

--- a/lib/Jit/CMakeLists.txt
+++ b/lib/Jit/CMakeLists.txt
@@ -23,7 +23,7 @@ set(LLVM_LINK_COMPONENTS
 set(LLILCJIT_LINK_LIBRARIES LLILCReader GcInfo)
 
 if (WIN32)
-  set(CMAKE_CXX_FLAGS "-EHsc")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc")
 
   # Create .def file containing a list of exports preceeded by
   # 'EXPORTS'.  The file "LLILCJit.exports" already contains the list, so we

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -145,8 +145,6 @@ extern "C" void __stdcall sxsJitStartup(void *CcCallbacks) {
 }
 
 void LLILCJitContext::outputDebugMethodName() {
-  const size_t SizeOfBuffer = 512;
-  char TempBuffer[SizeOfBuffer];
   const char *DebugClassName = nullptr;
   const char *DebugMethodName = nullptr;
 
@@ -439,9 +437,6 @@ void ObjectLoadListener::getDebugInfoForObject(
     const ObjectFile &Obj, const RuntimeDyld::LoadedObjectInfo &L) {
   OwningBinary<ObjectFile> DebugObjOwner = L.getObjectForDebug(Obj);
   const ObjectFile &DebugObj = *DebugObjOwner.getBinary();
-
-  // Get the address of the object image for use as a unique identifier
-  const void *ObjData = DebugObj.getData().data();
 
   // TODO: This extracts DWARF information from the object file, but we will
   // want to also be able to eventually extract WinCodeView information as well

--- a/lib/Reader/CMakeLists.txt
+++ b/lib/Reader/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${LLILC_INCLUDES}/clr
                     ${LLILC_INCLUDES}/Jit)
 
 if( WIN32 )
-  set(CMAKE_CXX_FLAGS "-EHsc")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc")
 endif()
 
 add_llilcjit_library(LLILCReader

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -4858,7 +4858,6 @@ ReaderBase::rdrCall(ReaderCallTargetData *Data, ReaderBaseNS::CallOpcode Opcode,
         case CORINFO_INTRINSIC_InterlockedXAdd64:
         case CORINFO_INTRINSIC_InterlockedXchg32:
         case CORINFO_INTRINSIC_InterlockedXchg64: {
-          IRNode *CallTargetNode = nullptr;
           IntrinsicArg2 = (IRNode *)ReaderOperandStack->pop();
           IntrinsicArg1 = (IRNode *)ReaderOperandStack->pop();
 

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -4693,11 +4693,10 @@ ReaderBase::rdrMakeNewObjReturnNode(ReaderCallTargetData *CallTargetData,
                                     IRNode *ThisArg, IRNode *CallReturnNode) {
   uint32_t ClassAttribs = CallTargetData->getClassAttribs();
 
-  bool IsMDArray = ((ClassAttribs & CORINFO_FLG_ARRAY) != 0);
   bool IsVarObjSize = ((ClassAttribs & CORINFO_FLG_VAROBJSIZE) != 0);
 
   // MDArrays should already have been taken care of.
-  ASSERT(!IsMDArray);
+  ASSERT((ClassAttribs & CORINFO_FLG_ARRAY) == 0);
 
   if (IsVarObjSize) {
     // Storage for variably-sized objects is allocated by the callee; the result
@@ -7982,10 +7981,10 @@ void ReaderBase::msilToIR(void) {
   uint32_t LastInsertedInOrderBlockEndOffset = 0;
   for (FlowGraphNode *Block = FgHead; Block != nullptr;
        Block = fgNodeGetNext(Block)) {
-    uint32_t StartOffset = fgNodeGetStartMSILOffset(Block);
     uint32_t EndOffset = fgNodeGetEndMSILOffset(Block);
     if (fgNodeIsVisited(Block)) {
-      assert(LastInsertedInOrderBlockEndOffset <= StartOffset);
+      assert(LastInsertedInOrderBlockEndOffset <=
+             fgNodeGetStartMSILOffset(Block));
       LastInsertedInOrderBlockEndOffset = EndOffset;
       FlowGraphMSILOffsetOrder.push_back(Block);
     }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3108,6 +3108,9 @@ IRNode *GenIR::binaryOp(ReaderBaseNS::BinaryOpcode Opcode, IRNode *Arg1,
           Type::getIntNTy(*JitContext->LLVMContext, TargetPointerSizeInBits);
       break;
     }
+    default:
+      // No fixup required
+      break;
     }
   }
 
@@ -5612,6 +5615,9 @@ bool GenIR::interlockedIntrinsicBinOp(IRNode *Arg1, IRNode *Arg2,
   case CORINFO_INTRINSIC_InterlockedXchg32:
   case CORINFO_INTRINSIC_InterlockedXchg64:
     Op = AtomicRMWInst::BinOp::Xchg;
+    break;
+  default:
+    // Leave Op unchanged
     break;
   }
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -7002,7 +7002,7 @@ void GenIR::AddPHIOperand(PHINode *PHI, Value *NewOperand,
       // Change the type of the PHI instruction and the types of all of its
       // operands.
       PHI->mutateType(NewPHITy);
-      for (int i = 0; i < PHI->getNumOperands(); ++i) {
+      for (unsigned i = 0; i < PHI->getNumOperands(); ++i) {
         Value *Operand = PHI->getIncomingValue(i);
         if (!isa<UndefValue>(Operand)) {
           BasicBlock *OperandBlock = PHI->getIncomingBlock(i);


### PR DESCRIPTION
Our cmake files were inadvertently clobbering build flags set by LLVM's cmake files when trying to append -EHsc.  Fix that, and the ensuing fall-out from enabling -W4.