### PR TITLE
Make copy of ORC SimpleCompiler functor for LLILCCompiler

### DIFF
--- a/include/Jit/compiler.h
+++ b/include/Jit/compiler.h
@@ -1,0 +1,63 @@
+//===--------------- include/Jit/compiler.h ---------------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Declaration of the compiler functor used in the ORC infrastructure
+///        to compile a module.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef COMPILER_H
+#define COMPILER_H
+
+#include "llvm/ExecutionEngine/ObjectMemoryBuffer.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Target/TargetMachine.h"
+
+namespace llvm {
+namespace orc {
+
+/// \brief Default compile functor: Takes a single IR module and returns an
+///        ObjectFile.
+class LLILCCompiler {
+public:
+  /// \brief Construct a simple compile functor with the given target.
+  LLILCCompiler(TargetMachine &TM) : TM(TM) {}
+
+  /// \brief Compile a Module to an ObjectFile.
+  object::OwningBinary<object::ObjectFile> operator()(Module &M) const {
+    SmallVector<char, 0> ObjBufferSV;
+    raw_svector_ostream ObjStream(ObjBufferSV);
+
+    legacy::PassManager PM;
+    MCContext *Ctx;
+    if (TM.addPassesToEmitMC(PM, Ctx, ObjStream))
+      llvm_unreachable("Target does not support MC emission.");
+    PM.run(M);
+    ObjStream.flush();
+    std::unique_ptr<MemoryBuffer> ObjBuffer(
+        new ObjectMemoryBuffer(std::move(ObjBufferSV)));
+    ErrorOr<std::unique_ptr<object::ObjectFile>> Obj =
+        object::ObjectFile::createObjectFile(ObjBuffer->getMemBufferRef());
+    // TODO: Actually report errors helpfully.
+    typedef object::OwningBinary<object::ObjectFile> OwningObj;
+    if (Obj)
+      return OwningObj(std::move(*Obj), std::move(ObjBuffer));
+    return OwningObj(nullptr, nullptr);
+  }
+
+private:
+  TargetMachine &TM;
+};
+} // namespace orc
+} // namespace llvm
+#endif // COMPILER_H

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -18,6 +18,7 @@
 #include "jitpch.h"
 #include "LLILCJit.h"
 #include "jitoptions.h"
+#include "compiler.h"
 #include "readerir.h"
 #include "abi.h"
 #include "EEMemoryManager.h"
@@ -251,7 +252,7 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
     ObjectLoadListener Listener(&Context);
     orc::ObjectLinkingLayer<decltype(Listener)> Loader(Listener);
     orc::IRCompileLayer<decltype(Loader)> Compiler(Loader,
-                                                   orc::SimpleCompiler(*TM));
+                                                   orc::LLILCCompiler(*TM));
 
     // Now jit the method.
     if (Context.Options->DumpLevel == DumpLevel::VERBOSE) {


### PR DESCRIPTION
New functor will be extended to implement LLILC specific phase lists.