### PR TITLE
Modify SymbolRef getName and getAddress calls for new signature.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -475,12 +475,16 @@ void ObjectLoadListener::getDebugInfoForObject(
       continue;
 
     // Function info
-    StringRef Name;
-    uint64_t Addr;
-    if (Symbol.getName(Name))
-      continue;
-    if (Symbol.getAddress(Addr))
-      continue;
+    ErrorOr<StringRef> NameOrError = Symbol.getName();
+    if (!NameOrError) {
+      continue; // Error.
+    }
+    StringRef Name = NameOrError.get();
+    ErrorOr<uint64_t> AddrOrError = Symbol.getAddress();
+    if (!AddrOrError) {
+      continue; // Error.
+    }
+    uint64_t Addr = AddrOrError.get();
     uint64_t Size = Pair.second;
 
     unsigned LastDebugOffset = -1;


### PR DESCRIPTION
The SymbolRef::getName and SymbolRef.getAddress methods
now use ErrorOr<T> return types to return either an
error code or the desired value. The calls to these
were changed to capture the ErrorOr<T> value and
then test for error. If no error then extract the
value and proceed to use it.