### PR TITLE
Cleanup and improve LLILC debug facilities

### DIFF
--- a/Documentation/Debugging.md
+++ b/Documentation/Debugging.md
@@ -1,0 +1,222 @@
+# Debugging LLILC
+
+## Background
+Currently LLILC is used as a Just-in-time compiler. This means
+that as a test is being run control passes between these agents:
+
+* The CoreRun.exe or CoreConsole.exe programs are invoked from 
+  the Windows command line (or programatically). These then
+  start up 
+* The CoreClr which includes
+  * The CLR Virtual Machine
+  * The CLR JIT (RyuJit)
+  * Runtime support routines that may be called by JITed code.
+* The LLILC JIT, which mostly replaces RyuJit when the 
+  COMPlus_AltJit options are specified.
+* The LLVM compilation system.
+* The code that was produced by LLVM on behalf of LLILC.
+
+Execution starts in the CLR which first sets up the execution
+environment, e.g. creating an APPDomain. The process of doing
+this involves executing some managed code so the JIT is
+called to compile this code which is then executed. 
+
+After the execution environment has been setup the CLR
+loads the test assembly and starts the test execution by
+first requesting that the JIT compile the main program entrypoint
+and then by passing control to the entrypoint.
+
+Control then alternates between the Jit and the code generated
+by the JIT, with the CLR managing the transitions between them.
+
+Bugs may be present in any of the above agents but we will 
+classify them as either:
+
+1. Compile-time failure bugs: These are bugs that cause LLILC code
+   to terminate, or give unexpected error messages.
+   It includes hitting features that are not-yet-implemented.
+2. Compile-time translation bugs: These are bugs in LLILC
+   translation to LLVM that result in bad code.
+3. LLVM bugs: These are bugs in LLVM that result in bad code.
+4. Runtime bugs: These are bugs in the code generated
+   by LLVM on behalf of LLILC, due either to bugs in LLILC
+   or LLVM. Or these could be caused by bugs in RyuJit
+   for methods it compiled (see below), though this
+   is less likely.
+5. Environmental bugs: These are bugs in the runtime library,
+   or in the CLR. 
+   
+Debugging these problems will generally require running
+LLILC under the control of a debugger. However there are
+environment variables that can be set to cause LLILC
+to output useful diagnostic information as it run, so
+that information may be sufficient to diagnose some
+problems without use of the debugger.
+
+## LLILC Setup
+
+Currently LLILC runs as an alternate JIT for the CoreClr, 
+with RyuJit being the primary (or backup) JIT. The 
+way this works is that environment variables
+(described below) specify which methods LLILC should 
+attempt to compile. When LLILC attempts to compile a 
+method it may either succeed (or at least think it has
+succeeded) or fail. Methods which LLILC has either
+not attempted to compile, or which LLILC attempted
+but failed to compile, are compiled by RyuJit.
+
+### Method Set Syntax
+Some of the environment variables mentioned below
+take a string value that is interpreted as specifying
+a set of methods. The syntax for such specifications
+is given by the following grammar, which follows
+the usual EBNF convention:
+
+* Items surrounded by "{" and "}" are repeated
+  zero or more times.
+* Items surrounded by "[" and "]" are optional
+* Alternates are separated by "|"
+* Literal characters are enclosed in double quotes.
+* Upper-case names are used for non-terminals
+* Lower-case names are used for lexical entities
+* Lexical entities are specified using regular expressions.
+
+```
+MethodSet = MethodId { whiteSpace MethodId }
+MethodId = "*"
+     | [ ClassName ":" ] MethodName [ "(" NumArgs ")" ]
+
+ClassName = token
+MethodName = token
+NumArgs = { digit }
+whitespace = {[ \t]}
+digit = [0-9]
+token = {[^ :()]}
+```
+
+The methods represented by a MethodSet are the union
+of those specified by the MethodIds, or
+all methods if "*" is given.
+
+A non-"*" MethodId may have three components:
+
+* The ClassName of the method. This can be empty if
+  the MethodId starts with a ":"
+* The name of method within the class. this can be
+  empty if there is a preceding ":" or following
+  "(". 
+* A specified number of arguments.
+
+Any combination of these may be absent (but not all of them). 
+
+A method that is a candidate for compilation is matched
+against each MethodId of the MethodSet. If any of them
+give a match the method is considered a member of the set.
+
+A method is matched against a non-"*" MethodId by comparing
+its class name, method-name, and number of arguments
+against those specified in the MethodId. There is a
+mismatch only if a property specified in the MethodId
+does not match the method's property. 
+
+If an environment variable whose value is logically 
+a MethodSet is either not given, or else has an empty 
+string as value, then the corresponding method set
+is empty.
+
+### Environment Variables Controlling LLILC
+The environment variables controlling LLILC are the following.
+The environemnt variable names are not case-sensitive,
+however we use some capitalization for the sake of readability.
+All of the environment variables must start with the 
+"COMPlus_" prefix, otherwise the CLR will ignore them.
+
+* COMPlus_AltJit. This is a MethodSet. Its conventional value is
+  "*" which means compile all methods with LLILC. Note that if
+  this environment variable is not set LLILC will not even be 
+  loaded by the CLR and RyuJit will be used for all compilation.
+* COMPlus_AltJitName. This is the file name of the LLILC JIT
+  dll including its ".dll" suffix. To be used the LLICL JIT
+  dll must be placed in the same directory as the CLR,
+  so the name does not include any directory part. 
+  The name of this dll as built is "llilc.dll". However
+  some of our tools insert a time-stamp in the name when
+  copying it to the CLR directory. 
+* COMPlus_GCConservative, if non-null use conservative garbage collection.
+* COMPlus_InsertStatePoints, if non-null use precise garbage collection. 
+* COMPlus_ZapDisable. If set to 1 means CLR should not use
+  precompiled NGen methods but require that all methods be
+  JITed. 
+* COMPlus_DumpLLVMIR may be given the value of either
+  "summary" or "verbose" (case insensitive). If either
+  is specified then LLILC reports on the success or failure
+  of JITTING each method. If the method failed to compile
+  a reason is given. If "verbose" is specified then in 
+  addition the LLVM IR is dumped for every method.
+* COMPlus_JitGCInfoLogging, if non-null, 
+  GCInfo encoding logs should be emitted
+* COMPlus_ALtJitExclude is a MethodSet. LLILC will only
+  attempt to compile methods which are in the COMPlus_AltJit
+  set, but not in the COMPlus_ALtJitExclude set.
+* COMPlus_AltJitBreakAtJitStart is a MethodSet. This is used
+  when running LLILC under the control of a debugger.
+  It causes a "break" message to be written for
+  matching methods when the method is about to be
+  jitted. The message is written from the 
+  LLILCJit::compileMethod method in file
+  llilc\lib\Jit\LLILCJit.cpp. The user must put
+  a breakpoint on the statement the write
+  out the message in order to actually get a
+  break.    
+* COMPlus_ALtJitMSILDump is a MethodSet. The MSIL for
+  methods in the set is dumped before JITTING the 
+  method. 
+* COMPlus_ALtJitLLVMDump is a MethodSet. The LLVM IR for
+  methods in the set is dumped just after LLILC has
+  finished reading the MSIL and converting it to LLVM IR.
+* COMPlus_ALtJitCodeRangeDump is a MethodSet. For methods
+  in the set, the starting and ending address of the method's
+  code, and the code size, is printed after the method has
+  been JITTED. This can be useful in identifying which
+  method contains a given address.
+
+### Environment Variables Affecting the CoreCLR
+There are a large number environment variables that
+can affect the CoreCLR. These are described in the
+"coreclr\src\inc\clrconfigvalues.h" file.
+
+### Environment Variables Affecting the CoreRun.exe
+When CoreRun.exe is used to run a managed program
+the following environment variables are consulted:
+
+* CORE_ROOT, if specified, is used to find the coreclr.dll
+  and related dlls.
+* CORE_LIBRARIES, if specified, is used to find additional
+  assemblies that may be required by the program that
+  is executing. It is a semi-colon-separated list of
+  directories in which to look for the assemblies.
+
+
+### Code Page Bug
+There is (or was) a bug which caused an exception to be
+thrown if the current code page is not 65001. 
+Since LLILC is not currently able to produce code that
+catches exception, testing must be done in an environment
+where the code page is 65001. This may be set using
+the command
+
+```
+chcp 65001
+```
+
+The LLILC scripts that run tests set this code page, but
+if you are setting up to run LLILC by hand, e.g. so
+you can run a single test, possibly under the control of
+a debugger, then you may need to set this manually.
+
+## Running A Single Test from the command line
+TBD
+## Running A Single Test using Visual Studio
+TBD
+## Runing A Single Test using windbg
+TBD

--- a/Documentation/Welcome.md
+++ b/Documentation/Welcome.md
@@ -12,6 +12,7 @@ generator built on the LLVM infrastructure.
 * [Getting Started for Windows](Getting-Started-For-Windows.md)
 * [Getting Started For Linux and OS X](Getting-Started-For-Linux-and-OS-X.md)
 * [Testing](Testing.md)
+* [Debugging](Debugging.md)
 * [Contribution Guide](Contributing.md)
 * [Areas To Contribute](Areas-To-Contribute.md)
 * [LLILC Coding Conventions and Commenting Style](llilc-Coding-Conventions-and-Commenting-Style.md)

--- a/Documentation/llilc-Coding-Conventions-and-Commenting-Style.md
+++ b/Documentation/llilc-Coding-Conventions-and-Commenting-Style.md
@@ -5,7 +5,8 @@
 The LLILC project is structured as a subproject of LLVM so we are using the
 same coding conventions as LLVM. The LLVM coding conventions are at
 <http://llvm.org/docs/CodingStandards.html>.  We use clang-format to
-check/enforce some formatting rules, as described on our [code formatting document](Code-Formatting.md).
+check/enforce some formatting rules, as described on our 
+[code formatting document](Code-Formatting.md).
 
 ## Commenting Guidelines
 
@@ -45,6 +46,15 @@ We can summarize these as follows:
 * For classes and class members that are declared in a header, put the Doxygen
   comments there. Otherwise put the comments in the implementation file.
 
+* For declaration of fields of a class, if the declaration is short
+  use the "//<" form of document comments at the end of the line,
+  if the comment will fit on not more than two lines.
+  If the comment would be longer than two lines, put the documentation
+  comment before the declaration.
+  
+* When a documentation comment precedes a declaration, separate it from
+  preceding declarations by a blank line.
+  
 * For virtual methods, put the documentation on the method declaration in the
   base class that first introduced the method. Do not put documentation on
   the method overrides. In the Doxygen output the comments from the base

--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -67,13 +67,6 @@ struct LLILCJitContext {
   std::unique_ptr<llvm::Module>
   getModuleForMethod(CORINFO_METHOD_INFO *MethodInfo);
 
-  /// Write an informational message about this jit request to LLVM's dbgs().
-  void outputDebugMethodName();
-
-  /// Write an informational message about skipping this jit request to LLVM's
-  /// dbgs().
-  void outputSkippingMethodName();
-
 public:
   /// \name CoreCLR EE information
   //@{

--- a/include/Jit/jitoptions.h
+++ b/include/Jit/jitoptions.h
@@ -77,12 +77,51 @@ private:
   /// \returns true if COMPLUS_JitGCInfoLogging is set in the environment.
   static bool queryLogGcInfo(LLILCJitContext &JitContext);
 
+  /// \brief Define set of methods to exclude from LLILC compilation
+  ///
+  /// \returns true if current method is in that set.
+  static bool queryIsExcludeMethod(LLILCJitContext &JitContext);
+
+  /// \brief Define set of methods on which to break.
+  ///
+  /// \returns true if current method is in that set.
+  static bool queryIsBreakMethod(LLILCJitContext &JitContext);
+
+  /// \brief Define set of methods for which to dump MSIL
+  ///
+  /// \returns true if current method is in that set.
+  static bool queryIsMSILDumpMethod(LLILCJitContext &JitContext);
+
+  /// \brief Define set of methods for which to dump LLVM IR.
+  ///
+  /// \returns true if current method is in that set.
+  static bool queryIsLLVMDumpMethod(LLILCJitContext &JitContext);
+
+  /// \brief Define set of methods for which to print code address range.
+  ///
+  /// \returns true if current method is in that set.
+  static bool queryIsCodeRangeMethod(LLILCJitContext &JitContext);
+
+  static bool queryMethodSet(LLILCJitContext &JitContext, MethodSet &TheSet,
+                             const char16_t *Name);
+
 public:
-  bool IsAltJit; ///< True if running as the alternative JIT.
+  bool IsAltJit;        ///< True if running as the alternative JIT.
+  bool IsExcludeMethod; ///< True if method is to be excluded.
+                        ///< Jit if IsAltJit && !IsExcludeMethod
+  bool IsBreakMethod;   ///< True if break requested when compiling this method.
+  bool IsMSILDumpMethod;  ///< True if dump of MSIL requested.
+  bool IsLLVMDumpMethod;  ///< True if dump of LLVM requested.
+  bool IsCodeRangeMethod; ///< True if desired to dump entry address and size.
 
 private:
   static MethodSet AltJitMethodSet;     ///< Singleton AltJit MethodSet.
   static MethodSet AltJitNgenMethodSet; ///< Singleton AltJitNgen MethodSet.
+  static MethodSet ExcludeMethodSet;    ///< Methods to exclude from jitting.
+  static MethodSet BreakMethodSet;      ///< Methods to break.
+  static MethodSet MSILMethodSet;       ///< Methods to dump MSIL.
+  static MethodSet LLVMMethodSet;       ///< Methods to dump LLVM IR.
+  static MethodSet CodeRangeMethodSet;  ///< Methods to dump code range
 };
 
 #endif // JITOPTIONS_H

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1533,7 +1533,6 @@ public:
   FlowGraphNode *fgSplitBlock(FlowGraphNode *Block, uint32_t Offset,
                               IRNode *Node);
 
-#if !defined(NDEBUG)
   /// \brief Debug-only reader function to print MSIL of the current method.
   void printMSIL();
 
@@ -1545,8 +1544,7 @@ public:
   /// \param Buf           Buffer containing MSIL bytecode.
   /// \param StartOffset   Initial offset for the range to print.
   /// \param EndOffset     Ending offset for the range to print.
-  void printMSIL(uint8_t *Buf, uint32_t StartOffset, uint32_t EndOffset);
-#endif
+  static void printMSIL(uint8_t *Buf, uint32_t StartOffset, uint32_t EndOffset);
 
   /// \brief Determine the effect of this instruction on the operand stack.
   ///

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -336,7 +336,7 @@ uint32_t parseILOpcode(uint8_t *ILInput, uint32_t ILOffset, uint32_t ILSize,
   if (TheOpcode == ReaderBaseNS::CEE_ILLEGAL) {
     if (ReportErrors) {
       if (Reader == nullptr) {
-        ReaderBase::fatal(CORJIT_BADCODE);
+        dbPrint("parseILOpcode: Bad Opcode\n");
       } else {
         Reader->verGlobalError(MVER_E_UNKNOWN_OPCODE);
       }
@@ -363,7 +363,7 @@ uint32_t parseILOpcode(uint8_t *ILInput, uint32_t ILOffset, uint32_t ILSize,
 underflow:
   if (ReportErrors) {
     if (Reader == nullptr) {
-      ReaderBase::fatal(CORJIT_BADCODE);
+      dbPrint("parseILOpcode: Underflow\n");
     } else {
       Reader->verGlobalError(MVER_E_METHOD_END);
     }
@@ -371,17 +371,12 @@ underflow:
   return ILSize;
 }
 
-#if !defined(NDEBUG) || defined(CC_PEVERIFY)
-
 const char *OpcodeName[] = {
 #define OPDEF_HELPER OPDEF_OPCODENAME
 #include "ophelper.def"
 #undef OPDEF_HELPER
 };
 
-#endif
-
-#if !defined(NDEBUG)
 void ReaderBase::printMSIL() {
   printMSIL(MethodInfo->ILCode, 0, MethodInfo->ILCodeSize);
 }
@@ -401,7 +396,7 @@ void ReaderBase::printMSIL(uint8_t *Buf, uint32_t StartOffset,
 
   while (Offset < NumBytes) {
     dbPrint("0x%-4x: ", StartOffset + Offset);
-    Offset = parseILOpcode(Buf, Offset, NumBytes, this, &Opcode, &Operand);
+    Offset = parseILOpcode(Buf, Offset, NumBytes, nullptr, &Opcode, &Operand);
     dbPrint("%d: %-10s ", Offset, OpcodeName[Opcode]);
 
     switch (Opcode) {
@@ -444,7 +439,6 @@ void ReaderBase::printMSIL(uint8_t *Buf, uint32_t StartOffset,
     dbPrint("\n");
   }
 }
-#endif
 
 //////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
Modify LLILC options processing by adding the
following options:

* COMPlus_ALtJitExclude is a MethodSet. LLILC will only
  attempt to compile methods which are in the COMPlus_AltJit
  set, but not in the COMPlus_ALtJitExclude set.
* COMPlus_ALtJitBreak is a MethodSet. This is used
  when running LLILC under the control of a debugger.
  It causes a "break" message to be written for
  matching methods when the method is about to be
  jitted. The method is written from the
  LLILCJit::compileMethod method in file
  llilc\lib\Jit\LLILCJit.cpp. The user must put
  a breakpoint on the statement that writes
  out the message in order to actually get a
  break.
* COMPlus_ALtJitMSILDump is a MethodSet. The MSIL for
  methods in the set is dumped before JITTING the
  method.
* COMPlus_ALtJitLLVMDump is a MethodSet. The LLVM IR for
  methods in the set is dumped just after LLILC has
  finished reading the MSIL and converting it to LLVM IR.
* COMPlus_ALtJitCodeRangeDump is a MethodSet. For methods
  in the set, the starting and ending address of the method's
  code, and the code size, is printed after the method has
  been JITTED. This can be useful in identifying which
  method contains a given address.

In addition the llilc_runtest.py file was modified
to allow specification of running a single test.

In addition:

1. Delete LLILCJitContext::outputDebugMethodName and
   LLILCJitContext::outputSkippingMethodName and replace
   with simpler output using Context.MethodName.
2. ReaderBase::printMSIL(uint8_t, uint32_t, uint32_t) is made
   static so it can be called from outside ReaderBase.
   When it calls parseILOpcode, it passes nullptr as the
   Reader parameter.
3. parseILOpcode was modified so that if its Reader parameter
   is null, it uses dbPrint for error messages rather than
   terminating with a fatal error. This is friendlier as
   this only happens when called from printMSIL and we would
   like printMSIL to be robust as it is called from the
   debugger.

4. Provide printMSIL facility even for release mode.
   This fixes a build error for release mode.
   ReaderBase::printMSIL was being called but not being
   defined in release mode. I believe, at least during
   this bring-up period, that we want this facility
   even for release mode, so I removed some conditional
   compilation directives so that dumping of MSIL is
   available in any mode.

5. Added Documentation/Debugging.md file to
   document how to debug LLILC. More will be added to
   this file, but we have already added documentation
   of the environment variables used by LLILC
   (but not yet those used when LLILC is NGENing).

6. Added Python solution for the Test directory. This
   allows testing and single stepping in the
   llilc_runtest.py script (or others). The properties
   of the test.pyproj can be used to set the
   script to test and the parameters to pass.
   This required installing "Python Tools for Visual Studio"
   The checked-in test.pyproj has properties with
   template values that users should modify to fit their
   environment and desires.
