### PR TITLE
Add support for EH filters

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2947,6 +2947,9 @@ public:
   // Called between building the flow graph and inserting the IR
   virtual void readerMiddlePass(void) = 0;
 
+  // Called after reading all MSIL, before removing unreachable blocks
+  virtual void readerPostVisit() = 0;
+
   // Called when reader has finished processing method.
   virtual void readerPostPass(bool IsImportOnly) = 0;
 

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -399,8 +399,7 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
     return false;
   }
 
-  Function *Func = JitContext->CurrentModule->getFunction(FuncName);
-  bool IsOk = !verifyFunction(*Func, &dbgs());
+  bool IsOk = !verifyModule(*JitContext->CurrentModule, &dbgs());
   assert(IsOk && "verification failed");
 
   if (IsOk) {
@@ -415,7 +414,7 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
   }
 
   if (DumpLevel == ::DumpLevel::VERBOSE) {
-    Func->dump();
+    JitContext->CurrentModule->dump();
   }
 
   return IsOk;

--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -250,7 +250,7 @@ CallSite ABICallSignature::emitUnmanagedCall(GenIR &Reader, Value *Target,
   // 1) Address of the GC mode field
   // 2) Address of the thread trap global
   // 3) Address of CORINFO_HELP_STOP_FOR_GC
-  Module *M = Reader.Function->getParent();
+  Module *M = Reader.RootFunction->getParent();
   Type *CallTypeArgs[] = {Target->getType()};
   Function *CallIntrinsic = Intrinsic::getDeclaration(
       M, Intrinsic::experimental_gc_statepoint, CallTypeArgs);

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -3026,7 +3026,8 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
       break;
 
     case ReaderBaseNS::CEE_ENDFILTER:
-      // Do nothing...
+      fgNodeSetEndMSILOffset(Block, NextOffset);
+      Block = makeFlowGraphNode(NextOffset, Block);
       break;
 
     case ReaderBaseNS::CEE_ENDFINALLY: {
@@ -8069,6 +8070,10 @@ void ReaderBase::msilToIR(void) {
 #endif
     }
   }
+
+  // Give client a chance to do any bookkeeping necessary after reading MSIL
+  // for all blocks but before removing unreachable ones.
+  readerPostVisit();
 
   // Remove blocks that weren't marked as visited.
   fgRemoveUnusedBlocks(FgHead);


### PR DESCRIPTION
Filters are outlined during initial IR generation (which includes
explicitly escaping any locals referenced in filters), to simplify
modeling their effects in the IR (invoking the outlined function must be
included as a possible side-effect of any invoke that may throw an
exception, since this must bottom out in a call to the throw helper [which
is external code] and the filter function has external linkage).

The ReaderBase class is unaware of the outlining.  GenIR generates the
filter code inline in the main function (except for an initial point
block) during its main passes, and then moves filter blocks to the correct
function in the readerPostVisit pass that this change adds between reading
MSIL and removing unreachable code.

The CurrentRegion tracked by the reader is used by GenIR to check whether
code currently being generated is destined for an outlined filter or not,
in the places where that is needed.  References to parameters and locals
check if the use is in a filter and insert escape code in the parent
function and recover code in the filter as necessary.

Any invoke in a filter-protected region needs a nominal edge to the filter
as well as to its landingpad (the landingpad doesn't have explicit flow to
the filter); this is achieved by having FlowGraphSuccessorEdgeList track
down and iterate through the entry blocks of any filters referenced in the
landingpad.

There's also some juggling in fgNodeGetNext to ensure that the point
blocks for filter entries are visited in their correct place in MSIL
order.

This change renames GenIR's Function field to RootFunction as reminder
that some methods will have multiple functions.  A few places are updated
to iterate through all functions in the module where previously they were
just operating on the one Function, including marking functions with
unmanaged call frames and removing unreachable code.