### PR TITLE
Verify and dump entire module, not just function.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -392,8 +392,7 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
     return false;
   }
 
-  Function *Func = JitContext->CurrentModule->getFunction(FuncName);
-  bool IsOk = !verifyFunction(*Func, &dbgs());
+  bool IsOk = !verifyModule(*JitContext->CurrentModule, &dbgs());
   assert(IsOk && "verification failed");
 
   if (IsOk) {
@@ -408,7 +407,7 @@ bool LLILCJit::readMethod(LLILCJitContext *JitContext) {
   }
 
   if (DumpLevel == ::DumpLevel::VERBOSE) {
-    Func->dump();
+    JitContext->CurrentModule->dump();
   }
 
   return IsOk;


### PR DESCRIPTION
This will be necessary when we outline filter functions.