### PR TITLE
Modify to use Intrinsic::localescape instead of Intrinsic::frameescape.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -544,7 +544,7 @@ void GenIR::insertIRToKeepGenericContextAlive() {
   // store to the scratch local.
   LLVMBuilder->SetInsertPoint(InsertPoint->getNextNode());
   Value *FrameEscape = Intrinsic::getDeclaration(JitContext->CurrentModule,
-                                                 Intrinsic::frameescape);
+                                                 Intrinsic::localescape);
   Value *Args[] = {ContextLocalAddress};
   const bool MayThrow = false;
   makeCall(FrameEscape, MayThrow, Args);


### PR DESCRIPTION
LLVM renamed Intrinsic::frameescape to be Intrinsic::localescape,
so use the new name.