### PR TITLE
ccFormat: Enable Clang-Tidy checks

### DIFF
--- a/include/Jit/utility.h
+++ b/include/Jit/utility.h
@@ -28,11 +28,11 @@
 #include "llvm/Config/llvm-config.h"
 
 // The MethodID.NumArgs field may hold either of 2 values:
-//   EMPTY   => the input string was all-blank, or empty.
-//   ANYARGS => the pattern did not specify any constraint on the number of
+//   Empty   => the input string was all-blank, or empty.
+//   AnyArgs => the pattern did not specify any constraint on the number of
 //              arguments.  Eg: "foo" as opposed to "foo()", "foo(3)", etc
 
-enum MethodIDState { EMPTY = -7, ANYARGS = -1 };
+enum MethodIDState { Empty = -7, AnyArgs = -1 };
 
 /// \brief MethodID struct represents a Method Signature.
 ///
@@ -45,45 +45,45 @@ public:
   std::unique_ptr<std::string> ClassName;
   /// Method Name
   std::unique_ptr<std::string> MethodName;
-  ///  Number of method arguments.  MethodIDState::ANYARGS => not specified
+  ///  Number of method arguments.  MethodIDState::AnyArgs => not specified
   int NumArgs;
 
   /// Default constructor.
   MethodID()
       : ClassName(nullptr), MethodName(nullptr),
-        NumArgs(MethodIDState::ANYARGS) {}
+        NumArgs(MethodIDState::AnyArgs) {}
 
   /// Copy constructor.
-  MethodID(const MethodID &other) {
-    if (other.ClassName) {
-      ClassName = llvm::make_unique<std::string>(*other.ClassName);
+  MethodID(const MethodID &Other) {
+    if (Other.ClassName) {
+      ClassName = llvm::make_unique<std::string>(*Other.ClassName);
     } else {
-      ClassName == nullptr;
+      ClassName = nullptr;
     }
-    if (other.MethodName) {
-      MethodName = llvm::make_unique<std::string>(*other.MethodName);
+    if (Other.MethodName) {
+      MethodName = llvm::make_unique<std::string>(*Other.MethodName);
     } else {
       MethodName = nullptr;
     }
-    this->NumArgs = other.NumArgs;
+    this->NumArgs = Other.NumArgs;
   }
 
   /// Copy assignment operator.
 
-  MethodID &operator=(const MethodID &other) {
-    if (this == &other)
+  MethodID &operator=(const MethodID &Other) {
+    if (this == &Other)
       return *this;
-    if (other.ClassName) {
-      ClassName = llvm::make_unique<std::string>(*other.ClassName);
+    if (Other.ClassName) {
+      ClassName = llvm::make_unique<std::string>(*Other.ClassName);
     } else {
       ClassName = nullptr;
     }
-    if (other.MethodName) {
-      MethodName = llvm::make_unique<std::string>(*other.MethodName);
+    if (Other.MethodName) {
+      MethodName = llvm::make_unique<std::string>(*Other.MethodName);
     } else {
       MethodName = nullptr;
     }
-    NumArgs = other.NumArgs;
+    NumArgs = Other.NumArgs;
     return *this;
   }
 
@@ -145,7 +145,7 @@ public:
   /// \return true if Method is contained in Set.
 
   bool contains(const char *MethodName, const char *ClassName,
-                PCCOR_SIGNATURE sig);
+                PCCOR_SIGNATURE Sig);
 
   /// Initialize a new MethodSet - once only.
   void init(std::unique_ptr<std::string> ConfigValue);
@@ -170,7 +170,7 @@ private:
 class Convert {
 public:
   /// Convert a UTF-16 string to a UTF-8 string.
-  static std::unique_ptr<std::string> utf16ToUtf8(const char16_t *wideStr);
+  static std::unique_ptr<std::string> utf16ToUtf8(const char16_t *WideStr);
 };
 
 #endif // UTILITY_H

--- a/include/Reader/abi.h
+++ b/include/Reader/abi.h
@@ -168,6 +168,9 @@ public:
                        ABIType ResultType, llvm::ArrayRef<ABIType> ArgTypes,
                        ABIArgInfo &ResultInfo,
                        std::vector<ABIArgInfo> &ArgInfos) const = 0;
+
+  /// \brief Virtual Destructor
+  virtual ~ABIInfo() = default;
 };
 
 #endif

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -813,7 +813,7 @@ public:
   /// \param Context Context to use for name generation..
   /// \param Scope Scope to use for name generation.
   /// \returns Name for the given token, handle, context, and scope.
-  std::string GetNameForToken(mdToken Token, CORINFO_GENERIC_HANDLE Handle,
+  std::string getNameForToken(mdToken Token, CORINFO_GENERIC_HANDLE Handle,
                               CORINFO_CONTEXT_HANDLE Context,
                               CORINFO_MODULE_HANDLE Scope);
 
@@ -1406,7 +1406,7 @@ private:
   ///
   /// \param PHI PHI instruction.
   /// \param NewOperand Operand to add to the PHI instruction.
-  void AddPHIOperand(llvm::PHINode *PHI, llvm::Value *NewOperand,
+  void addPHIOperand(llvm::PHINode *PHI, llvm::Value *NewOperand,
                      llvm::BasicBlock *NewBlock);
 
   /// Change the type of a PHI instruction operand as a result of a stack merge.
@@ -1415,7 +1415,7 @@ private:
   /// \param OperandBlock Basic block corresponding to the operand.
   /// \param NewTy New type of the operand.
   /// \returns Operand with the changed type.
-  llvm::Value *ChangePHIOperandType(llvm::Value *Operand,
+  llvm::Value *changePHIOperandType(llvm::Value *Operand,
                                     llvm::BasicBlock *OperandBlock,
                                     llvm::Type *NewTy);
 

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -97,7 +97,7 @@ private:
   ///
   /// \param LLVMRelocationType LLVM relocation type to translate from.
   /// \returns EE relocation type.
-  uint64_t TranslateRelocationType(uint64_t LLVMRelocationType);
+  uint64_t translateRelocationType(uint64_t LLVMRelocationType);
 
 private:
   LLILCJitContext *Context;
@@ -582,7 +582,7 @@ void ObjectLoadListener::recordRelocations(const ObjectFile &Obj) {
           uint64_t Target = Context->NameToHandleMap[TargetName];
           Context->JitInfo->recordRelocation(MM->getCodeSection() + Offset,
                                              (void *)Target,
-                                             TranslateRelocationType(RelType));
+                                             translateRelocationType(RelType));
         }
         ++I;
       }
@@ -591,7 +591,7 @@ void ObjectLoadListener::recordRelocations(const ObjectFile &Obj) {
 }
 
 uint64_t
-ObjectLoadListener::TranslateRelocationType(uint64_t LLVMRelocationType) {
+ObjectLoadListener::translateRelocationType(uint64_t LLVMRelocationType) {
   switch (LLVMRelocationType) {
   case IMAGE_REL_AMD64_ABSOLUTE:
     return IMAGE_REL_BASED_ABSOLUTE;

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -2800,7 +2800,7 @@ EHRegion *getFinallyRegion(EHRegion *TryRegion) {
 
 #define CHECKTARGET(TargetOffset, BufSize)                                     \
   {                                                                            \
-    if (TargetOffset < 0 || TargetOffset >= BufSize)                           \
+    if ((TargetOffset) < 0 || (TargetOffset) >= (BufSize))                     \
       ReaderBase::verGlobalError(MVER_E_BAD_BRANCH);                           \
   }
 
@@ -8000,9 +8000,9 @@ void ReaderBase::msilToIR(void) {
   }
 
   // Process the nodes in MSIL offset order.
-  std::list<FlowGraphNode *>::iterator it = FlowGraphMSILOffsetOrder.begin();
-  while (it != FlowGraphMSILOffsetOrder.end()) {
-    FlowGraphNode *CurrentNode = *it;
+  std::list<FlowGraphNode *>::iterator It = FlowGraphMSILOffsetOrder.begin();
+  while (It != FlowGraphMSILOffsetOrder.end()) {
+    FlowGraphNode *CurrentNode = *It;
     readBytesForFlowGraphNode(CurrentNode, IsImportOnly);
 
 #ifndef CC_PEVERIFY
@@ -8029,15 +8029,15 @@ void ReaderBase::msilToIR(void) {
 
         // The two checks above ensure that it's safe to insert Successor after
         // CurrentNode even if that breaks MSIL offset order.
-        ++it;
-        FlowGraphMSILOffsetOrder.insert(it, Successor);
+        ++It;
+        FlowGraphMSILOffsetOrder.insert(It, Successor);
         // Point the iterator back to CurrentNode.
-        --it;
-        --it;
+        --It;
+        --It;
         fgNodeSetVisited(Successor, true);
       }
     }
-    ++it;
+    ++It;
   }
 
   // global verification dataflow


### PR DESCRIPTION
1) Change ccFormat to run clang-tidy checks by default
   Use ccFormat --untidy to only run formatting checks
2) Fix the warnings/errors generated by ccFormat