### PR TITLE
Don't use LLVMBuilder after removing unused blocks.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2929,6 +2929,9 @@ public:
   // Called between building the flow graph and inserting the IR
   virtual void readerMiddlePass(void) = 0;
 
+  // Called after reading all MSIL, before removing unreachable blocks
+  virtual void readerPostVisit() = 0;
+
   // Called when reader has finished processing method.
   virtual void readerPostPass(bool IsImportOnly) = 0;
 

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -520,6 +520,9 @@ public:
   // Called between building the flow graph and inserting the IR
   void readerMiddlePass(void) override;
 
+  // Called after reading all MSIL, before removing unreachable blocks
+  void readerPostVisit() override;
+
   // Called when reader has finished processing method.
   void readerPostPass(bool IsImportOnly) override;
 

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -8060,6 +8060,10 @@ void ReaderBase::msilToIR(void) {
     }
   }
 
+  // Give client a chance to do any bookkeeping necessary after reading MSIL
+  // for all blocks but before removing unreachable ones.
+  readerPostVisit();
+
   // Remove blocks that weren't marked as visited.
   fgRemoveUnusedBlocks(FgHead);
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -479,7 +479,7 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
 
 void GenIR::readerMiddlePass() { return; }
 
-void GenIR::readerPostPass(bool IsImportOnly) {
+void GenIR::readerPostVisit() {
   // If the generic context must be kept live, make it so.
   if (KeepGenericContextAlive) {
     insertIRToKeepGenericContextAlive();
@@ -489,7 +489,9 @@ void GenIR::readerPostPass(bool IsImportOnly) {
   if (NeedsSecurityObject) {
     insertIRForSecurityObject();
   }
+}
 
+void GenIR::readerPostPass(bool IsImportOnly) {
   if (JitContext->Options->DoInsertStatepoints) {
 
     // Precise GC using statepoints cannot handle aggregates that contain


### PR DESCRIPTION
Removing unused blocks may invalidate LLVMBuilder's insert point.
Currently we insert IR to keep generic context alive and IR for security object in readerPostPass,
which runs after removal of unused blocks. That results in AV on some tests with debug llilc jit.

The reason we haven't seen this in the lab is that we use ReleaseWithDebugInfo build.
It uses msvcr120.dll (debug build uses msvcr120d.dll) and its implementation of operator delete
doesn't overwrite deallocated memory. So we are accessing deallocated memory without an AV.

@JosephTremoulet recently introduced readerPostVisit pass in his EH branch.
It runs after reading all MSIL and before removing unused blocks.
So it's a perfect place to move code that inserts IR to keep generic context alive
and IR for security object.

Closes #709.