### PR TITLE
Supress Gcinfo-Debug Logs in Release build

### DIFF
--- a/include/GcInfo/GcInfo.h
+++ b/include/GcInfo/GcInfo.h
@@ -50,7 +50,10 @@ private:
   const uint8_t *CodeBlockStart;
   const uint8_t *LLVMStackMapData;
   GcInfoEncoder Encoder;
+
+#if !defined(NDEBUG)
   bool EmitLogs;
+#endif // !NDEBUG
 
 #if defined(PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED)
   size_t NumCallSites;

--- a/lib/GcInfo/GcInfo.cpp
+++ b/lib/GcInfo/GcInfo.cpp
@@ -38,10 +38,12 @@ GCInfo::GCInfo(LLILCJitContext *JitCtx, uint8_t *StackMapData,
 }
 
 void GCInfo::encodeHeader() {
+#if !defined(NDEBUG)
   if (EmitLogs) {
     dbgs() << "GcTable for Function: " << JitContext->MethodName << "\n"
            << "  Size: " << JitContext->HotCodeSize << "\n";
   }
+#endif // !NDEBUG
 
   // TODO: Set Code Length accurately.
   // https://github.com/dotnet/llilc/issues/679


### PR DESCRIPTION
Add a missing #ifdef(!NDEBUG) clause around
GcInfo log generation code.