### PR TITLE
Simd initial pull request

### DIFF
--- a/include/Jit/jitoptions.h
+++ b/include/Jit/jitoptions.h
@@ -105,6 +105,11 @@ private:
   static bool queryMethodSet(LLILCJitContext &JitContext, MethodSet &TheSet,
                              const char16_t *Name);
 
+  /// \brief Set SIMD intrinsics using.
+  ///
+  /// \returns true if SIMD_INTRINSIC is set in the environment set.
+  static bool queryDoSIMDIntrinsic(LLILCJitContext &JitContext);
+
 public:
   bool IsAltJit;        ///< True if running as the alternative JIT.
   bool IsExcludeMethod; ///< True if method is to be excluded.

--- a/include/Reader/options.h
+++ b/include/Reader/options.h
@@ -54,5 +54,6 @@ struct Options {
   bool DoInsertStatepoints; ///< True if the environment calls for statepoints.
   bool DoTailCallOpt;       ///< Tail call optimization.
   bool LogGcInfo;           ///< Generate GCInfo Translation logs
+  bool DoSIMDIntrinsic;     ///< True if SIMD intrinsic is on.
 };
 #endif // OPTIONS_H

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -252,6 +252,20 @@ enum ReaderExceptionType {
   Reader_GlobalVerificationException, ///< Verifier global check failed
 };
 
+enum ReaderSIMDIntrinsic {
+  UNDEF,
+  CTOR,
+  ADD,
+  SUB,
+  MUL,
+  DIV,
+  ABS,
+  SQRT,
+  EQ,
+  NEQ,
+  GETCOUNTOP
+};
+
 /// Common base class for reader exceptions
 class ReaderException {
 public:
@@ -328,7 +342,7 @@ public:
   /// \brief Return begin iterator for iterating from bottom to top of stack.
   iterator begin() { return Stack.begin(); }
 
-  /// \brief Return begin iterator for iterating from bottom to top of stack.
+  /// \brief Return end iterator for iterating from bottom to top of stack.
   iterator end() { return Stack.end(); }
 
 #if defined(_DEBUG)
@@ -1568,6 +1582,14 @@ public:
   /// \returns true if tail call opt is enabled.
   virtual bool doTailCallOpt() = 0;
 
+  /// \brief Check options to as to whether to use SIMD intrinsic.
+  ///
+  /// Derived class will provide an implementation that is correct for the
+  /// client.
+  ///
+  /// \returns true if simd intrinsic opt is enabled.
+  virtual bool doSimdIntrinsicOpt() = 0;
+
 private:
   /// \brief Determine if a call instruction is a candidate to be a tail call.
   ///
@@ -2500,6 +2522,11 @@ public:
   void setMethodAttribs(CORINFO_METHOD_HANDLE Handle,
                         CorInfoMethodRuntimeFlags Flag);
 
+  virtual std::string appendClassNameAsString(CORINFO_CLASS_HANDLE Class,
+                                              bool IncludeNamespace,
+                                              bool FullInst,
+                                              bool IncludeAssembly) = 0;
+
   bool checkMethodModifier(CORINFO_METHOD_HANDLE Method, LPCSTR Modifier,
                            bool IsOptional);
   mdToken getMethodDefFromMethod(CORINFO_METHOD_HANDLE Handle);
@@ -3276,6 +3303,107 @@ public:
 #endif
 
   static bool rdrIsMethodVirtual(uint32_t MethodAttribs);
+
+  /// \brief Return Method name for non helper and non native Methods.
+  ///
+  /// \param method  Method handle for the target Method.
+  /// \param classNamePtr out param, Module name.
+  /// \param JitInfo The JIT interface for this method
+  /// \returns Method name.
+  const char *getMethodName(CORINFO_METHOD_HANDLE Method,
+                            const char **ClassNamePtr, ICorJitInfo *JitInfo);
+
+  /// \brief Return true if we process this Class with SIMD intrinsics.
+  ///
+  /// \param Class The class handle for the call target method's class.
+  /// \returns  result, that represents true if HW acceleration
+  /// enabled for this class, false otherwise.
+  virtual IRNode *generateIsHardwareAccelerated(CORINFO_CLASS_HANDLE Class) = 0;
+
+  /// \brief Return result of binary or unary operation on SIMD Vector Types.
+  /// \brief It gets arguments from stack.
+  ///
+  /// \param OperationCode code to be done.
+  /// \returns an IRNode representing the result of the intrinsic
+  /// or nullptr if the intrinsic is not supported.
+
+  IRNode *generateSIMDBinOp(ReaderSIMDIntrinsic OperationCode);
+  IRNode *generateSIMDUnOp(ReaderSIMDIntrinsic OperationCode);
+
+  /// \brief Return IRNode* Result of BinOp.
+  ///
+  /// \param Vector1 the first argument for BinOp.
+  /// \param Vector2 the second argument for BinOp.
+  /// \returns an IRNode representing the result of BinOp
+  /// or nullptr if BinOp is not supported.
+
+  virtual IRNode *vectorAdd(IRNode *Vector1, IRNode *Vector2) = 0;
+  virtual IRNode *vectorSub(IRNode *Vector1, IRNode *Vector2) = 0;
+  virtual IRNode *vectorMul(IRNode *Vector1, IRNode *Vector2) = 0;
+  virtual IRNode *vectorDiv(IRNode *Vector1, IRNode *Vector2) = 0;
+
+  virtual IRNode *vectorEqual(IRNode *Vector1, IRNode *Vector2) = 0;
+  virtual IRNode *vectorNotEqual(IRNode *Vector1, IRNode *Vector2) = 0;
+
+  /// \brief Return IRNode* Result of UnOp.
+  ///
+  /// \param Vector  argument for UnOp.
+  /// \returns an IRNode representing the result of UnOp
+  /// or nullptr if UnOp is not supported.
+  virtual IRNode *vectorAbs(IRNode *Vector) = 0;
+  virtual IRNode *vectorSqrt(IRNode *Vector) = 0;
+
+  /// \brief Return result of ctor operation on SIMD Vector Types.
+  ///
+  /// \param ArgsCount Number of arguments on stack for call.
+  /// \param Class The class handle for the call target method's class.
+  /// \param Opcode Operation Opcode to distinguish newobj from ctor.
+  /// \returns an IRNode representing the result of ctor
+  /// or nullptr if ctor is not supported.
+  IRNode *generateSMIDCtor(CORINFO_CLASS_HANDLE Class, int ArgsCount,
+                           ReaderBaseNS::CallOpcode Opcode);
+
+  /// \brief Return IRNode* Result of ctor.
+  ///
+  /// \param Class The class handle for the call target method's class.
+  /// \param This in not null for ctor, null for newobj.
+  /// \param Args, args for ctor.
+  /// \returns an IRNode representing the result of ctor
+  /// or nullptr if ctor is not supported.
+  virtual IRNode *vectorCtor(CORINFO_CLASS_HANDLE Class, IRNode *This,
+                             std::vector<IRNode *> Args) = 0;
+
+  /// \brief Return length of Generic Vector.
+  ///
+  /// \param Class The class handle for the call target method's class.
+  /// \returns an IRNode representing the length of Class
+  /// or nullptr if getCount or Class is not supported.
+  virtual IRNode *vectorGetCount(CORINFO_CLASS_HANDLE Class) = 0;
+
+  /// \brief Return IRNode* The result of the intrinsic or nullptr, if it is
+  /// unnsupported.
+  ///
+  /// \param Class The class handle for the call target method's class.
+  /// \param  Method handle for the target Method.
+  /// \param  SigInfo info for the target Method.
+  /// \returns an IRNode representing the result of the intrinsic
+  /// \or nullptr if the intrinsic is not supported.
+  IRNode *generateSIMDIntrinsicCall(CORINFO_CLASS_HANDLE Class,
+                                    CORINFO_METHOD_HANDLE Method,
+                                    CORINFO_SIG_INFO *SigInfo,
+                                    ReaderBaseNS::CallOpcode Opcode);
+
+  /// \brief Check LLVM::VectorType.
+  ///
+  /// \param Arg The target for checking.
+  /// \returns true if Arg is supported vector type.
+  virtual bool checkVectorType(IRNode *Arg) = 0;
+
+  /// \brief Return length of Vector or 0 if it is not Vector.
+  ///
+  /// \param Class The class handle for the call target method's class.
+  /// \returns number of elements in vector.
+  virtual int getElementCountOfSIMDType(CORINFO_CLASS_HANDLE Class) = 0;
 
 private:
   ///////////////////////////////////////////////////////////////////////

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1455,6 +1455,10 @@ private:
   /// Provides client specific Options look up.
   bool doTailCallOpt() override;
 
+  /// \brief Override of doSimdIntrinsicOpt method
+  /// Provides client specific Options look up.
+  bool doSimdIntrinsicOpt() override;
+
   /// If isZeroInitLocals() returns true, zero intitialize all locals;
   /// otherwise, zero initialize all gc pointers and structs with gc pointers.
   void zeroInitLocals();
@@ -1600,6 +1604,37 @@ private:
                                           uint64_t ValueHandle, llvm::Type *Ty,
                                           llvm::StringRef Name,
                                           bool IsConstant);
+  std::string appendClassNameAsString(CORINFO_CLASS_HANDLE Class,
+                                      bool IncludeNamespace, bool FullInst,
+                                      bool IncludeAssembly);
+
+  IRNode *vectorAdd(IRNode *Vector1, IRNode *Vector2) override;
+  IRNode *vectorSub(IRNode *Vector1, IRNode *Vector2) override;
+  IRNode *vectorMul(IRNode *Vector1, IRNode *Vector2) override;
+  IRNode *vectorDiv(IRNode *Vector1, IRNode *Vector2) override;
+  IRNode *vectorEqual(IRNode *Vector1, IRNode *Vector2) override;
+  IRNode *vectorNotEqual(IRNode *Vector1, IRNode *Vector2) override;
+  IRNode *vectorAbs(IRNode *Vector) override;
+  IRNode *vectorSqrt(IRNode *Vector) override;
+
+  bool checkVectorType(IRNode *Arg) override;
+
+  bool checkVectorSignature(std::vector<IRNode *> Args,
+                            std::vector<llvm::Type *> Types);
+  IRNode *vectorCtor(CORINFO_CLASS_HANDLE Class, IRNode *This,
+                     std::vector<IRNode *> Args) override;
+  IRNode *vectorCtorFromOne(int VectorSize, IRNode *This,
+                            std::vector<IRNode *> Args);
+  IRNode *vectorCtorFromFloats(int VectorSize, IRNode *This,
+                               std::vector<IRNode *> Args);
+
+  IRNode *vectorGetCount(CORINFO_CLASS_HANDLE Class) override;
+
+  llvm::Type *getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE Class,
+                                           int &VectorLength, bool &IsGeneric);
+  IRNode *generateIsHardwareAccelerated(CORINFO_CLASS_HANDLE Class) override;
+
+  int getElementCountOfSIMDType(CORINFO_CLASS_HANDLE Class) override;
 
 private:
   LLILCJitContext *JitContext;
@@ -1685,6 +1720,15 @@ private:
     llvm::DICompileUnit *TheCU;
     llvm::DIScope *FunctionScope;
   } LLILCDebugInfo;
+
+  static llvm::Type *Vector2Ty;
+  static llvm::Type *Vector3Ty;
+  static llvm::Type *Vector4Ty;
+  static llvm::Type *FloatTy;
+  static llvm::Type *FloatPtrTy;
+  static llvm::Type *Vector2PtrTy;
+  static llvm::Type *Vector3PtrTy;
+  static llvm::Type *Vector4PtrTy;
 };
 
 #endif // MSIL_READER_IR_H

--- a/lib/Jit/jitoptions.cpp
+++ b/lib/Jit/jitoptions.cpp
@@ -70,6 +70,8 @@ JitOptions::JitOptions(LLILCJitContext &Context) {
   // Set whether to insert statepoints.
   DoInsertStatepoints = queryDoInsertStatepoints(Context);
 
+  DoSIMDIntrinsic = queryDoSIMDIntrinsic(Context);
+
   // Set whether to do tail call opt.
   DoTailCallOpt = queryDoTailCallOpt(Context);
 
@@ -241,6 +243,13 @@ bool JitOptions::queryLogGcInfo(LLILCJitContext &Context) {
   char16_t *LogGcInfoStr =
       getStringConfigValue(Context.JitInfo, UTF16("JitGCInfoLogging"));
   return (LogGcInfoStr != nullptr);
+}
+
+// Determine if SIMD intrinsics should be used.
+bool JitOptions::queryDoSIMDIntrinsic(LLILCJitContext &Context) {
+  char16_t *StatePointStr =
+      getStringConfigValue(Context.JitInfo, UTF16("SIMDINTRINSIC"));
+  return (StatePointStr != nullptr);
 }
 
 OptLevel JitOptions::queryOptLevel(LLILCJitContext &Context) {

--- a/lib/Reader/abi.cpp
+++ b/lib/Reader/abi.cpp
@@ -74,7 +74,7 @@ ABIArgInfo X86_64_Win64::classify(const ABIType ABITy, const DataLayout &DL,
                                   bool IsManagedCallingConv) {
   Type *Ty = ABITy.getType();
 
-  if (Ty->isAggregateType()) {
+  if (Ty->isAggregateType() || Ty->isVectorTy()) {
     // If the aggregate's size in bytes is a power of 2 that is less than or
     // equal to 8, it can be passed directly once coerced to an
     // appropriately-sized

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -317,6 +317,16 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   EntryBlock = BasicBlock::Create(LLVMContext, "entry", Function);
 
   LLVMBuilder = new IRBuilder<>(LLVMContext);
+  llvm::LLVMContext &Context = LLVMBuilder->getContext();
+  FloatTy = llvm::Type::getFloatTy(Context);
+  FloatPtrTy = llvm::Type::getFloatPtrTy(Context);
+  Vector2Ty = llvm::VectorType::get(FloatTy, 2);
+  Vector3Ty = llvm::VectorType::get(FloatTy, 3);
+  Vector4Ty = llvm::VectorType::get(FloatTy, 4);
+  Vector2PtrTy = llvm::PointerType::get(Vector2Ty, 0);
+  Vector3PtrTy = llvm::PointerType::get(Vector3Ty, 0);
+  Vector4PtrTy = llvm::PointerType::get(Vector4Ty, 0);
+
   DBuilder = new DIBuilder(*JitContext->CurrentModule);
   LLILCDebugInfo.TheCU = DBuilder->createCompileUnit(dwarf::DW_LANG_C_plus_plus,
                                                      Function->getName().str(),
@@ -1076,6 +1086,10 @@ llvm::DIType *GenIR::convertType(Type *Ty) {
   return nullptr;
 }
 
+bool GenIR::doSimdIntrinsicOpt() {
+  return JitContext->Options->DoSIMDIntrinsic;
+}
+
 #pragma endregion
 
 #pragma region DIAGNOSTICS
@@ -1324,7 +1338,24 @@ GenIR::getType(CorInfoType CorType, CORINFO_CLASS_HANDLE ClassHandle,
 Type *
 GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool GetAggregateFields,
                     std::list<CORINFO_CLASS_HANDLE> *DeferredDetailAggregates) {
-
+  if (doSimdIntrinsicOpt() &&
+      JitContext->JitInfo->isInSIMDModule(ClassHandle)) {
+    std::string ClassName =
+        appendClassNameAsString(ClassHandle, true, false, false);
+    if (ClassName.compare(0, 22, "System.Numerics.Vector") == 0 &&
+        ClassName.length() == 23) {
+      switch (ClassName[22]) {
+      case '2':
+        return Vector2Ty;
+      case '3':
+        return Vector3Ty;
+      case '4':
+        return Vector4Ty;
+      default:
+        assert(UNREACHED);
+      }
+    }
+  }
   Type *Result = nullptr;
   if (DeferredDetailAggregates == nullptr) {
     // Keep track of any aggregates that we deferred examining in detail, so we
@@ -1358,6 +1389,42 @@ GenIR::getClassType(CORINFO_CLASS_HANDLE ClassHandle, bool GetAggregateFields,
   }
 
   return Result;
+}
+
+std::string GenIR::appendClassNameAsString(CORINFO_CLASS_HANDLE Class,
+                                           bool IncludeNamespace, bool FullInst,
+                                           bool IncludeAssembly) {
+  int NameSize = 0;
+  NameSize = appendClassName(nullptr, &NameSize, Class, IncludeNamespace,
+                             FullInst, IncludeAssembly);
+  std::string ResultString;
+  if (NameSize > 0) {
+    // Add one for terminating null.
+    int32_t BufferLength = NameSize + 1;
+    int32_t BufferRemaining = BufferLength;
+    char16_t *WideCharBuffer = new char16_t[BufferLength];
+    char16_t *BufferPtrToChange = WideCharBuffer;
+    appendClassName(&BufferPtrToChange, &BufferRemaining, Class,
+                    IncludeNamespace, FullInst, IncludeAssembly);
+    ASSERT(BufferRemaining == 1);
+
+    // Note that this is a worst-case estimate.
+    size_t UTF8Size = (NameSize * UNI_MAX_UTF8_BYTES_PER_CODE_POINT) + 1;
+    UTF8 *ClassName = new UTF8[UTF8Size];
+    UTF8 *UTF8Start = ClassName;
+    const UTF16 *UTF16Start = (UTF16 *)WideCharBuffer;
+    ConversionResult Result =
+        ConvertUTF16toUTF8(&UTF16Start, &UTF16Start[NameSize + 1], &UTF8Start,
+                           &UTF8Start[UTF8Size], strictConversion);
+    if (Result == conversionOK) {
+      ASSERT((size_t)(&WideCharBuffer[BufferLength] -
+                      (const char16_t *)UTF16Start) == 0);
+      ResultString = (char *)ClassName;
+    }
+    delete[] ClassName;
+    delete[] WideCharBuffer;
+  }
+  return ResultString;
 }
 
 // Map this class handle into an LLVM type.
@@ -1448,10 +1515,22 @@ Type *GenIR::getClassTypeWorker(
     }
 
     // Fetch the name of this type for use in dumps.
-    char *ClassName = getClassNameWithNamespace(ClassHandle);
-    if (ClassName != nullptr) {
-      StructTy->setName((char *)ClassName);
-      delete[] ClassName;
+
+    // Note some constructed types like arrays may not have names.
+
+    const bool IncludeNamespace = true;
+    const bool FullInst = false;
+    const bool IncludeAssembly = false;
+    // We are using appendClassName instead of getClassName because
+    // getClassName omits namespaces from some types (e.g., nested classes).
+    // We may still get the same name for two different structs because
+    // two classes with the same fully-qualified names may live in different
+    // assemblies. In that case StructType->setName will append a unique suffix
+    // to the conflicting name.
+    std::string Name = appendClassNameAsString(ClassHandle, IncludeNamespace,
+                                               FullInst, IncludeAssembly);
+    if (Name.length()) {
+      StructTy->setName(Name.c_str());
     }
   }
 
@@ -2037,6 +2116,9 @@ bool GenIR::isValidStackType(IRNode *Node) {
   case Type::TypeID::DoubleTyID:
     IsValid = true;
     break;
+  case Type::TypeID::VectorTyID:
+    IsValid = true;
+    break;
 
   default:
     ASSERT(UNREACHED);
@@ -2200,6 +2282,9 @@ IRNode *GenIR::convertToStackType(IRNode *Node, CorInfoType CorType) {
   case Type::TypeID::DoubleTyID:
     // Already a valid stack type.
     break;
+  case Type::TypeID::VectorTyID:
+    // Already a valid stack type.
+    break;
 
   case Type::TypeID::StructTyID:
   default:
@@ -2292,6 +2377,9 @@ IRNode *GenIR::convertFromStackType(IRNode *Node, CorInfoType CorType,
     }
     break;
   }
+  case Type::TypeID::VectorTyID:
+    Result = (IRNode *)Node;
+    break;
 
   case Type::TypeID::StructTyID:
   // We don't allow structs on the stack. They are represented by pointers.
@@ -3589,7 +3677,21 @@ IRNode *GenIR::loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Obj,
   int32_t AccessFlags = ObjIsThis ? CORINFO_ACCESS_THIS : CORINFO_ACCESS_ANY;
   AccessFlags |= CORINFO_ACCESS_GET;
   CORINFO_FIELD_INFO FieldInfo;
+
   getFieldInfo(ResolvedToken, (CORINFO_ACCESS_FLAGS)AccessFlags, &FieldInfo);
+  if (doSimdIntrinsicOpt()) {
+    Type *ObjType = Obj->getType();
+    auto &Context = LLVMBuilder->getContext();
+
+    if (ObjType->isVectorTy()) {
+      int32_t ElementSize =
+          ObjType->getVectorElementType()->getScalarSizeInBits();
+      int32_t IndexInVector = FieldInfo.offset * 8 / ElementSize;
+      IRNode *Index =
+          (IRNode *)ConstantInt::get(Type::getInt32Ty(Context), IndexInVector);
+      return (IRNode *)LLVMBuilder->CreateExtractElement(Obj, Index);
+    }
+  }
 
   // LoadStaticField and GetFieldAddress already generate
   // checkFieldAuthorization calls, so
@@ -3736,6 +3838,17 @@ void GenIR::storeField(CORINFO_RESOLVED_TOKEN *FieldToken, IRNode *ValueToStore,
   AccessFlags |= CORINFO_ACCESS_SET;
   CORINFO_FIELD_INFO FieldInfo;
   getFieldInfo(FieldToken, (CORINFO_ACCESS_FLAGS)AccessFlags, &FieldInfo);
+  Type *ObjType = Object->getType();
+  if (doSimdIntrinsicOpt() && ObjType->isVectorTy()) {
+    auto &Context = LLVMBuilder->getContext();
+    int32_t ElementSize =
+        ObjType->getVectorElementType()->getScalarSizeInBits();
+    int32_t IndexInVector = FieldInfo.offset * 8 / ElementSize;
+    IRNode *Index =
+        (IRNode *)ConstantInt::get(Type::getInt32Ty(Context), IndexInVector);
+    LLVMBuilder->CreateInsertElement(Object, ValueToStore, Index);
+    return;
+  }
   CORINFO_FIELD_HANDLE FieldHandle = FieldToken->hField;
 
   // It's legal to use STFLD to store into a static field. In that case,
@@ -3816,8 +3929,16 @@ void GenIR::storeIndirectArg(const CallArgType &ValueArgType,
                              llvm::Value *ValueToStore, llvm::Value *Address,
                              bool IsVolatile) {
   assert(isManagedPointerType(cast<PointerType>(Address->getType())));
-  assert(ValueToStore->getType()->isPointerTy() &&
-         ValueToStore->getType()->getPointerElementType()->isStructTy());
+
+  Type *ValueToStoreType = ValueToStore->getType();
+  if (ValueToStoreType->isVectorTy()) {
+    assert(!ValueToStoreType->getVectorElementType()->isPointerTy());
+    makeStoreNonNull(ValueToStore, Address, IsVolatile);
+    return;
+  }
+
+  assert(ValueToStoreType->isPointerTy() &&
+         ValueToStoreType->getPointerElementType()->isStructTy());
   assert(doesValueRepresentStruct(ValueToStore));
 
   CORINFO_CLASS_HANDLE ArgClass = ValueArgType.Class;
@@ -3972,11 +4093,13 @@ IRNode *GenIR::addressOfValue(IRNode *Leaf) {
   switch (LeafTy->getTypeID()) {
   case Type::TypeID::IntegerTyID:
   case Type::TypeID::FloatTyID:
-  case Type::TypeID::DoubleTyID: {
+  case Type::TypeID::DoubleTyID:
+  case Type::TypeID::VectorTyID: {
     Instruction *Alloc = createTemporary(LeafTy);
     LLVMBuilder->CreateStore(Leaf, Alloc);
     return (IRNode *)Alloc;
   }
+
   case Type::TypeID::PointerTyID: {
     assert(doesValueRepresentStruct(Leaf));
 
@@ -5630,8 +5753,8 @@ IRNode *GenIR::unbox(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Object,
     IRNode *UnboxedNullable =
         (IRNode *)createTemporary(NullableType, "UnboxedNullable");
     const bool MayThrow = true;
-    IRNode *Result = callHelper(HelperId, MayThrow, nullptr, UnboxedNullable,
-                                ClassHandleArgument, Object);
+    callHelper(HelperId, MayThrow, nullptr, UnboxedNullable,
+               ClassHandleArgument, Object);
     if (AndLoad) {
       setValueRepresentsStruct(UnboxedNullable);
     }
@@ -7517,5 +7640,412 @@ void VerificationState::print() {
   }
 }
 #endif
+
+#pragma endregion
+
+#pragma region SIMD_INTRISNICS
+
+//===----------------------------------------------------------------------===//
+//
+// SIMD Intrinsics
+//
+//===----------------------------------------------------------------------===//
+
+Type *GenIR::FloatTy;
+Type *GenIR::FloatPtrTy;
+Type *GenIR::Vector2Ty;
+Type *GenIR::Vector3Ty;
+Type *GenIR::Vector4Ty;
+Type *GenIR::Vector2PtrTy;
+Type *GenIR::Vector3PtrTy;
+Type *GenIR::Vector4PtrTy;
+
+// BinOperations
+
+IRNode *GenIR::vectorAdd(IRNode *Vector1, IRNode *Vector2) {
+  assert(((Value *)Vector1)
+             ->getType()
+             ->getVectorElementType()
+             ->isFloatingPointTy());
+  assert(((Value *)Vector2)->getType() == ((Value *)Vector1)->getType());
+  return (IRNode *)LLVMBuilder->CreateFAdd(Vector1, Vector2);
+}
+
+IRNode *GenIR::vectorSub(IRNode *Vector1, IRNode *Vector2) {
+  assert(((Value *)Vector1)
+             ->getType()
+             ->getVectorElementType()
+             ->isFloatingPointTy());
+  assert(((Value *)Vector2)->getType() == ((Value *)Vector1)->getType());
+  return (IRNode *)LLVMBuilder->CreateFSub(Vector1, Vector2);
+}
+
+IRNode *GenIR::vectorMul(IRNode *Vector1, IRNode *Vector2) {
+  assert(((Value *)Vector1)
+             ->getType()
+             ->getVectorElementType()
+             ->isFloatingPointTy());
+  assert(((Value *)Vector2)->getType() == ((Value *)Vector1)->getType());
+  return (IRNode *)LLVMBuilder->CreateFMul(Vector1, Vector2);
+}
+
+IRNode *GenIR::vectorDiv(IRNode *Vector1, IRNode *Vector2) {
+  assert(((Value *)Vector1)
+             ->getType()
+             ->getVectorElementType()
+             ->isFloatingPointTy());
+  assert(((Value *)Vector2)->getType() == ((Value *)Vector1)->getType());
+  return (IRNode *)LLVMBuilder->CreateFDiv(Vector1, Vector2);
+}
+
+IRNode *GenIR::vectorEqual(IRNode *Vector1, IRNode *Vector2) {
+  assert(((Value *)Vector1)
+             ->getType()
+             ->getVectorElementType()
+             ->isFloatingPointTy());
+  assert(((Value *)Vector2)->getType() == ((Value *)Vector1)->getType());
+  return (IRNode *)LLVMBuilder->CreateFCmpOEQ(Vector1, Vector2);
+}
+
+IRNode *GenIR::vectorNotEqual(IRNode *Vector1, IRNode *Vector2) {
+  assert(((Value *)Vector1)
+             ->getType()
+             ->getVectorElementType()
+             ->isFloatingPointTy());
+  assert(((Value *)Vector2)->getType() == ((Value *)Vector1)->getType());
+  return (IRNode *)LLVMBuilder->CreateFCmpONE(Vector1, Vector2);
+}
+
+IRNode *GenIR::vectorAbs(IRNode *Vector) {
+  assert(((Value *)Vector)
+             ->getType()
+             ->getVectorElementType()
+             ->isFloatingPointTy());
+  std::vector<Type *> ArgTypes;
+  ArgTypes.push_back(Vector->getType());
+  llvm::Function *Func = Intrinsic::getDeclaration(JitContext->CurrentModule,
+                                                   Intrinsic::fabs, ArgTypes);
+  return (IRNode *)LLVMBuilder->CreateCall(Func, Vector);
+}
+
+IRNode *GenIR::vectorSqrt(IRNode *Vector) {
+  assert(((Value *)Vector)
+             ->getType()
+             ->getVectorElementType()
+             ->isFloatingPointTy());
+  std::vector<Type *> ArgTypes;
+  ArgTypes.push_back(Vector->getType());
+  llvm::Function *Func = Intrinsic::getDeclaration(JitContext->CurrentModule,
+                                                   Intrinsic::sqrt, ArgTypes);
+  return (IRNode *)LLVMBuilder->CreateCall(Func, Vector);
+}
+
+IRNode *GenIR::generateIsHardwareAccelerated(CORINFO_CLASS_HANDLE Class) {
+  int Length = 0;
+  bool IsGeneric = 0;
+  getBaseTypeAndSizeOfSIMDType(Class, Length, IsGeneric);
+  int Result = 0;
+  if (Length && !IsGeneric) {
+    Result = 1;
+  }
+  return (IRNode *)ConstantInt::get(Type::getInt32Ty(LLVMBuilder->getContext()),
+                                    Result);
+}
+
+bool GenIR::checkVectorSignature(std::vector<IRNode *> Args,
+                                 std::vector<Type *> Types) {
+  assert(Args.size() == Types.size());
+  for (int Counter = 0; Counter < Args.size(); ++Counter) {
+    assert(Args[Counter]);
+    if (Args[Counter]->getType() != Types[Counter]) {
+      assert(UNREACHED);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+IRNode *GenIR::vectorCtorFromOne(int VectorSize, IRNode *Vector,
+                                 std::vector<IRNode *> Args) {
+  assert(Args.size() == 1);
+  for (int Counter = 0; Counter < VectorSize; ++Counter) {
+    Vector =
+        (IRNode *)LLVMBuilder->CreateInsertElement(Vector, Args[0], Counter);
+  }
+  return Vector;
+}
+
+IRNode *GenIR::vectorCtorFromFloats(int VectorSize, IRNode *Vector,
+                                    std::vector<IRNode *> Args) {
+  assert(Args.size() == VectorSize);
+  std::vector<Type *> Types;
+  for (int Counter = 0; Counter < VectorSize; ++Counter) {
+    Types.push_back(FloatTy);
+  }
+  if (checkVectorSignature(Args, Types)) {
+    for (int Counter = 0; Counter < VectorSize; ++Counter) {
+      Vector = (IRNode *)LLVMBuilder->CreateInsertElement(Vector, Args[Counter],
+                                                          Counter);
+    }
+    return Vector;
+  }
+  return 0;
+}
+
+IRNode *GenIR::vectorCtor(CORINFO_CLASS_HANDLE Class, IRNode *This,
+                          std::vector<IRNode *> Args) {
+  int VectorSize = 0;
+  bool IsGeneric = false;
+  Type *ElementType =
+      getBaseTypeAndSizeOfSIMDType(Class, VectorSize, IsGeneric);
+  if (VectorSize == 0) { // For example Vector<bool>.
+    return 0;
+  }
+  Type *VectorType = llvm::VectorType::get(ElementType, VectorSize);
+  IRNode *Vector = (IRNode *)UndefValue::get(VectorType);
+
+  IRNode *Return = 0;
+  if (!IsGeneric) {
+    if (Args.size() == 1) {
+      if (Args[0]->getType() == ElementType) {
+        Return = vectorCtorFromOne(VectorSize, Vector, Args);
+      } else {
+        return 0;
+      }
+    } else if (Args.size() == VectorSize) {
+      Return = vectorCtorFromFloats(VectorSize, Vector, Args);
+    } else {
+      std::vector<Type *> Types;
+      std::vector<IRNode *> ExtractedArgs;
+      llvm::LLVMContext &Context = *JitContext->LLVMContext;
+      Type *IntTy = Type::getInt32Ty(Context);
+      IRNode *Index0 = (IRNode *)ConstantInt::get(IntTy, 0);
+      IRNode *Index1 = (IRNode *)ConstantInt::get(IntTy, 1);
+      IRNode *Index2 = (IRNode *)ConstantInt::get(IntTy, 2);
+#pragma region non - generic ctors
+      switch (VectorSize) {
+      case 3:
+        assert(Args.size() == 2);
+        Types.push_back(Vector2Ty);
+        Types.push_back(FloatTy);
+        if (checkVectorSignature(Args, Types)) {
+          IRNode *Vector2 = Args[0];
+          ExtractedArgs.push_back(
+              (IRNode *)LLVMBuilder->CreateExtractElement(Vector2, Index0));
+          ExtractedArgs.push_back(
+              (IRNode *)LLVMBuilder->CreateExtractElement(Vector2, Index1));
+          ExtractedArgs.push_back(Args[1]);
+        }
+        break;
+
+      case 4:
+        if (Args.size() == 2) {
+          Types.push_back(Vector3Ty);
+          Types.push_back(FloatTy);
+          if (checkVectorSignature(Args, Types)) {
+            IRNode *Vector3 = Args[0];
+            ExtractedArgs.push_back(
+                (IRNode *)LLVMBuilder->CreateExtractElement(Vector3, Index0));
+            ExtractedArgs.push_back(
+                (IRNode *)LLVMBuilder->CreateExtractElement(Vector3, Index1));
+            ExtractedArgs.push_back(
+                (IRNode *)LLVMBuilder->CreateExtractElement(Vector3, Index2));
+            ExtractedArgs.push_back(Args[1]);
+          }
+        } else {
+          assert(Args.size() == 3);
+          Types.push_back(Vector2Ty);
+          Types.push_back(FloatTy);
+          Types.push_back(FloatTy);
+          if (checkVectorSignature(Args, Types)) {
+            IRNode *Vector2 = Args[0];
+            ExtractedArgs.push_back(
+                (IRNode *)LLVMBuilder->CreateExtractElement(Vector2, Index0));
+            ExtractedArgs.push_back(
+                (IRNode *)LLVMBuilder->CreateExtractElement(Vector2, Index1));
+            ExtractedArgs.push_back(Args[1]);
+            ExtractedArgs.push_back(Args[2]);
+          }
+        }
+        break;
+
+      default:
+        assert(UNREACHED);
+      }
+      if (ExtractedArgs.size()) {
+        for (int Counter = 0; Counter < VectorSize; ++Counter) {
+          Vector = (IRNode *)LLVMBuilder->CreateInsertElement(
+              Vector, ExtractedArgs[Counter], Counter);
+        }
+        Return = Vector;
+      }
+    }
+  }
+  if (Return) {
+    if (This) {
+      return (IRNode *)LLVMBuilder->CreateStore(
+          Return, This); // TODO sandreenko: is volatile?
+    } else {
+      return Return;
+    }
+  }
+  return 0;
+}
+
+bool GenIR::checkVectorType(IRNode *Arg) {
+  assert(Arg);
+  return Arg->getType()->isVectorTy();
+}
+
+llvm::Type *GenIR::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE Class,
+                                                int &VectorLength,
+                                                bool &IsGeneric) {
+  VectorLength = 0;
+  IsGeneric = false;
+  // TODO t-seand : issue #720, check thread safety.
+  static CORINFO_CLASS_HANDLE SIMDFloatHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDDoubleHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDIntHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDUShortHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDUByteHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDShortHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDByteHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDLongHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDUIntHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDULongHandle = 0;
+  static CORINFO_CLASS_HANDLE SIMDVector2Handle = 0;
+  static CORINFO_CLASS_HANDLE SIMDVector3Handle = 0;
+  static CORINFO_CLASS_HANDLE SIMDVector4Handle = 0;
+  static CORINFO_CLASS_HANDLE SIMDVectorHandle = 0;
+
+  LLVMContext &Context = *JitContext->LLVMContext;
+
+  if (Class == SIMDFloatHandle) {
+    IsGeneric = true;
+    VectorLength = 4;
+    return llvm::Type::getFloatTy(Context);
+  } else if (Class == SIMDDoubleHandle) {
+    IsGeneric = true;
+    VectorLength = 2;
+    return llvm::Type::getDoubleTy(Context);
+  } else if (Class == SIMDIntHandle) {
+    IsGeneric = true;
+    VectorLength = 4;
+    return llvm::Type::getInt32Ty(Context);
+  } else if (Class == SIMDUShortHandle) {
+    IsGeneric = true;
+    VectorLength = 8;
+    return llvm::Type::getInt16Ty(Context);
+  } else if (Class == SIMDUByteHandle) {
+    IsGeneric = true;
+    VectorLength = 16;
+    return llvm::Type::getInt8Ty(Context);
+  } else if (Class == SIMDShortHandle) {
+    IsGeneric = true;
+    VectorLength = 8;
+    return llvm::Type::getInt16Ty(Context);
+  } else if (Class == SIMDByteHandle) {
+    IsGeneric = true;
+    VectorLength = 16;
+    return llvm::Type::getInt8Ty(Context);
+  } else if (Class == SIMDLongHandle) {
+    IsGeneric = true;
+    VectorLength = 2;
+    return llvm::Type::getInt64Ty(Context);
+  } else if (Class == SIMDUIntHandle) {
+    IsGeneric = true;
+    VectorLength = 4;
+    return llvm::Type::getInt32Ty(Context);
+  } else if (Class == SIMDULongHandle) {
+    IsGeneric = true;
+    VectorLength = 2;
+    return llvm::Type::getInt64Ty(Context);
+  } else if (Class == SIMDVector2Handle) {
+    VectorLength = 2;
+    return llvm::Type::getFloatTy(Context);
+  } else if (Class == SIMDVector3Handle) {
+    VectorLength = 3;
+    return llvm::Type::getFloatTy(Context);
+  } else if (Class == SIMDVector4Handle) {
+    VectorLength = 4;
+    return llvm::Type::getFloatTy(Context);
+  }
+
+  // Doesn't match with any of the cached type handles.
+  // Obtain base type by parsing fully qualified class name.
+
+  std::string ClassName = appendClassNameAsString(Class, TRUE, FALSE, FALSE);
+  if (ClassName.compare(0, 22, "System.Numerics.Vector") == 0) {
+    if (ClassName.compare(22, 3, "`1[") == 0) {
+      IsGeneric = true;
+      if (ClassName.compare(25, 13, "System.Single") == 0) {
+        SIMDFloatHandle = Class;
+        VectorLength = 4;
+        return llvm::Type::getFloatTy(Context);
+      } else if (ClassName.compare(25, 12, "System.Int32") == 0) {
+        SIMDIntHandle = Class;
+        VectorLength = 4;
+        return llvm::Type::getInt32Ty(Context);
+      } else if (ClassName.compare(25, 13, "System.UInt16") == 0) {
+        SIMDUShortHandle = Class;
+        VectorLength = 8;
+        return llvm::Type::getInt16Ty(Context);
+      } else if (ClassName.compare(25, 11, "System.Byte") == 0) {
+        SIMDUByteHandle = Class;
+        VectorLength = 16;
+        return llvm::Type::getInt8Ty(Context);
+      } else if (ClassName.compare(25, 13, "System.Double") == 0) {
+        SIMDDoubleHandle = Class;
+        VectorLength = 2;
+        return llvm::Type::getDoubleTy(Context);
+      } else if (ClassName.compare(25, 12, "System.Int64") == 0) {
+        SIMDLongHandle = Class;
+        VectorLength = 2;
+        return llvm::Type::getInt64Ty(Context);
+      } else if (ClassName.compare(25, 12, "System.Int16") == 0) {
+        SIMDShortHandle = Class;
+        VectorLength = 8;
+        return llvm::Type::getInt16Ty(Context);
+      } else if (ClassName.compare(25, 12, "System.SByte") == 0) {
+        SIMDByteHandle = Class;
+        VectorLength = 16;
+        return llvm::Type::getInt8Ty(Context);
+      } else if (ClassName.compare(25, 13, "System.UInt32") == 0) {
+        SIMDUIntHandle = Class;
+        VectorLength = 4;
+        return llvm::Type::getInt32Ty(Context);
+      } else if (ClassName.compare(25, 13, "System.UInt64") == 0) {
+        SIMDULongHandle = Class;
+        VectorLength = 2;
+        return llvm::Type::getInt64Ty(Context);
+      }
+    } else if (ClassName.compare(22, 2, "2") == 0) {
+      SIMDVector2Handle = Class;
+      VectorLength = 2;
+      return llvm::Type::getFloatTy(Context);
+    } else if (ClassName.compare(22, 2, "3") == 0) {
+      SIMDVector3Handle = Class;
+      VectorLength = 3;
+      return llvm::Type::getFloatTy(Context);
+    } else if (ClassName.compare(22, 2, "4") == 0) {
+      SIMDVector4Handle = Class;
+      VectorLength = 4;
+      return llvm::Type::getFloatTy(Context);
+    }
+  }
+  return 0;
+}
+
+int GenIR::getElementCountOfSIMDType(CORINFO_CLASS_HANDLE Class) {
+  int Length = 0;
+  bool IsGeneric = false;
+  getBaseTypeAndSizeOfSIMDType(Class, Length, IsGeneric);
+  return Length;
+}
+
+IRNode *GenIR::vectorGetCount(CORINFO_CLASS_HANDLE Class) {
+  return (IRNode *)ConstantInt::get(Type::getInt32Ty(LLVMBuilder->getContext()),
+                                    getElementCountOfSIMDType(Class));
+}
 
 #pragma endregion


### PR DESCRIPTION
Support System.Numerics.Vector with fixed size.
Represent Vectors like LLVM::<float * VectorSize>.
Change getfield and storfield behavior to avoid memcopy and use Vector LLVM specific assessors.
Support binary, unary, ctors operations.