### PR TITLE
Change getDataLayout to createDataLayout

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1062,8 +1062,8 @@ llvm::DIType *GenIR::convertType(Type *Ty) {
   }
 
   if (Ty->isPointerTy()) {
-    uint64_t Size = JitContext->TM->getDataLayout()->getPointerTypeSize(Ty);
-    uint64_t Align = JitContext->TM->getDataLayout()->getPrefTypeAlignment(Ty);
+    uint64_t Size = JitContext->TM->createDataLayout().getPointerTypeSize(Ty);
+    uint64_t Align = JitContext->TM->createDataLayout().getPrefTypeAlignment(Ty);
     llvm::DIType *DbgTy = DBuilder->createPointerType(
         convertType(Ty->getPointerElementType()), Size, Align);
 


### PR DESCRIPTION
The call to getting a DataLayout object changed in LLVM. Update LLILC to
use the new call.