### PR TITLE
Implement translation of jmp msil instruction.

### DIFF
--- a/include/Reader/abisignature.h
+++ b/include/Reader/abisignature.h
@@ -92,12 +92,13 @@ public:
   /// \param Args             The arguments to the call.
   /// \param IndirectionCell  The indirection cell argument for the call, if
   ///                         any.
+  /// \param IsJmp            True iff this is a call for a jmp instruction.
   /// \param CallNode [out]   The call instruction.
   ///
   /// \returns The result of the call to the target.
   llvm::Value *emitCall(GenIR &Reader, llvm::Value *Target, bool MayThrow,
                         llvm::ArrayRef<llvm::Value *> Args,
-                        llvm::Value *IndirectionCell,
+                        llvm::Value *IndirectionCell, bool IsJmp,
                         llvm::Value **CallNode) const;
 };
 

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -343,10 +343,7 @@ public:
 
   IRNode *getStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken) override;
 
-  void jmp(ReaderBaseNS::CallOpcode Opcode, mdToken Token, bool HasThis,
-           bool HasVarArg) override {
-    throw NotYetImplementedException("jmp");
-  };
+  void jmp(ReaderBaseNS::CallOpcode Opcode, mdToken Token) override;
 
   virtual uint32_t updateLeaveOffset(uint32_t LeaveOffset, uint32_t NextOffset,
                                      FlowGraphNode *LeaveBlock,


### PR DESCRIPTION
jmp is implemented as a call marked with musttail followed by a ret.

If the caller has a secret parameter we need to pass it to the jmp call
because the signature and the calling convention of the caller and
the musttail call must match. To accommodate that a parallel
LLVM change modifies CLR_SecretParameter calling convention
to make the secret parameter the first pointer-sized parameter
(still passed in R10) rather than a parameter passed with a
"CLR_SecretParameter" attribute.

All indirect parameters are passed as they come to the caller, without
copying them to the current frame.

Indirect result parameter is typed as a managed pointer in a jmp call
because we type indirect result parameter for the caller as a
managed pointer.

Closes #192.