### PR TITLE
Support for ngen-ing of methods with switches and floating point instructions.

### DIFF
--- a/include/Jit/EEObjectLinkingLayer.h
+++ b/include/Jit/EEObjectLinkingLayer.h
@@ -1,0 +1,195 @@
+//===------------ include/Jit/EEObjectLinkingLayer.h ------------*- C++ -*-===//
+//
+// LLILC
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Declaration of the object linking layer.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef EE_OBJECTLINKINGLAYER_H
+#define EE_OBJECTLINKINGLAYER_H
+
+#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+
+namespace llvm {
+namespace orc {
+
+/// @brief Bare bones object linking layer.
+///
+///   This class is intended to be used as the base layer for a JIT. It allows
+/// object files to be loaded into memory, linked, and the addresses of their
+/// symbols queried. All objects added to this layer can see each other's
+/// symbols.
+template <typename NotifyLoadedFtor = DoNothingOnNotifyLoaded>
+class EEObjectLinkingLayer : public ObjectLinkingLayerBase {
+private:
+  template <typename MemoryManagerPtrT, typename SymbolResolverPtrT>
+  class ConcreteLinkedObjectSet : public LinkedObjectSet {
+  public:
+    ConcreteLinkedObjectSet(MemoryManagerPtrT MemMgr,
+                            SymbolResolverPtrT Resolver)
+        : LinkedObjectSet(*MemMgr, *Resolver), MemMgr(std::move(MemMgr)),
+          Resolver(std::move(Resolver)) {}
+
+    void Finalize() override {
+      State = Finalizing;
+      RTDyld->registerEHFrames();
+      MemMgr->finalizeMemory();
+      OwnedBuffers.clear();
+      State = Finalized;
+    }
+
+  private:
+    MemoryManagerPtrT MemMgr;
+    SymbolResolverPtrT Resolver;
+  };
+
+  template <typename MemoryManagerPtrT, typename SymbolResolverPtrT>
+  std::unique_ptr<LinkedObjectSet>
+  createLinkedObjectSet(MemoryManagerPtrT MemMgr, SymbolResolverPtrT Resolver) {
+    typedef ConcreteLinkedObjectSet<MemoryManagerPtrT, SymbolResolverPtrT> LOS;
+    return llvm::make_unique<LOS>(std::move(MemMgr), std::move(Resolver));
+  }
+
+public:
+  /// @brief LoadedObjectInfo list. Contains a list of owning pointers to
+  ///        RuntimeDyld::LoadedObjectInfo instances.
+  typedef std::vector<std::unique_ptr<RuntimeDyld::LoadedObjectInfo>>
+      LoadedObjInfoList;
+
+  /// @brief Functor for receiving finalization notifications.
+  typedef std::function<void(ObjSetHandleT)> NotifyFinalizedFtor;
+
+  /// @brief Construct an EEObjectLinkingLayer with the given NotifyLoaded,
+  ///        and NotifyFinalized functors.
+  EEObjectLinkingLayer(
+      NotifyLoadedFtor NotifyLoaded = NotifyLoadedFtor(),
+      NotifyFinalizedFtor NotifyFinalized = NotifyFinalizedFtor())
+      : NotifyLoaded(std::move(NotifyLoaded)),
+        NotifyFinalized(std::move(NotifyFinalized)) {}
+
+  /// @brief Add a set of objects (or archives) that will be treated as a unit
+  ///        for the purposes of symbol lookup and memory management.
+  ///
+  /// @return A pair containing (1) A handle that can be used to free the memory
+  ///         allocated for the objects, and (2) a LoadedObjInfoList containing
+  ///         one LoadedObjInfo instance for each object at the corresponding
+  ///         index in the Objects list.
+  ///
+  ///   This version of this method allows the client to pass in an
+  /// RTDyldMemoryManager instance that will be used to allocate memory and look
+  /// up external symbol addresses for the given objects.
+  template <typename ObjSetT, typename MemoryManagerPtrT,
+            typename SymbolResolverPtrT>
+  ObjSetHandleT addObjectSet(const ObjSetT &Objects, MemoryManagerPtrT MemMgr,
+                             SymbolResolverPtrT Resolver) {
+    ObjSetHandleT Handle = LinkedObjSetList.insert(
+        LinkedObjSetList.end(),
+        createLinkedObjectSet(std::move(MemMgr), std::move(Resolver)));
+
+    LinkedObjectSet &LOS = **Handle;
+    LoadedObjInfoList LoadedObjInfos;
+
+    for (auto &Obj : Objects)
+      LoadedObjInfos.push_back(LOS.addObject(*Obj));
+
+    NotifyLoaded(Handle, Objects, LoadedObjInfos);
+
+    return Handle;
+  }
+
+  /// @brief Remove the set of objects associated with handle H.
+  ///
+  ///   All memory allocated for the objects will be freed, and the sections and
+  /// symbols they provided will no longer be available. No attempt is made to
+  /// re-emit the missing symbols, and any use of these symbols (directly or
+  /// indirectly) will result in undefined behavior. If dependence tracking is
+  /// required to detect or resolve such issues it should be added at a higher
+  /// layer.
+  void removeObjectSet(ObjSetHandleT H) {
+    // How do we invalidate the symbols in H?
+    LinkedObjSetList.erase(H);
+  }
+
+  /// @brief Search for the given named symbol.
+  /// @param Name The name of the symbol to search for.
+  /// @param ExportedSymbolsOnly If true, search only for exported symbols.
+  /// @return A handle for the given named symbol, if it exists.
+  JITSymbol findSymbol(StringRef Name, bool ExportedSymbolsOnly) {
+    for (auto I = LinkedObjSetList.begin(), E = LinkedObjSetList.end(); I != E;
+         ++I)
+      if (auto Symbol = findSymbolIn(I, Name, ExportedSymbolsOnly))
+        return Symbol;
+
+    return nullptr;
+  }
+
+  /// @brief Search for the given named symbol in the context of the set of
+  ///        loaded objects represented by the handle H.
+  /// @param H The handle for the object set to search in.
+  /// @param Name The name of the symbol to search for.
+  /// @param ExportedSymbolsOnly If true, search only for exported symbols.
+  /// @return A handle for the given named symbol, if it is found in the
+  ///         given object set.
+  JITSymbol findSymbolIn(ObjSetHandleT H, StringRef Name,
+                         bool ExportedSymbolsOnly) {
+    if (auto Sym = (*H)->getSymbol(Name)) {
+      if (Sym.isExported() || !ExportedSymbolsOnly) {
+        auto Addr = Sym.getAddress();
+        auto Flags = Sym.getFlags();
+        if (!(*H)->NeedsFinalization()) {
+          // If this instance has already been finalized then we can just return
+          // the address.
+          return JITSymbol(Addr, Flags);
+        } else {
+          // If this instance needs finalization return a functor that will do
+          // it. The functor still needs to double-check whether finalization is
+          // required, in case someone else finalizes this set before the
+          // functor is called.
+          auto GetAddress = [this, Addr, H]() {
+            if ((*H)->NeedsFinalization()) {
+              (*H)->Finalize();
+              if (NotifyFinalized)
+                NotifyFinalized(H);
+            }
+            return Addr;
+          };
+          return JITSymbol(std::move(GetAddress), Flags);
+        }
+      }
+    }
+    return nullptr;
+  }
+
+  /// @brief Map section addresses for the objects associated with the handle H.
+  void mapSectionAddress(ObjSetHandleT H, const void *LocalAddress,
+                         TargetAddress TargetAddr) {
+    (*H)->mapSectionAddress(LocalAddress, TargetAddr);
+  }
+
+  /// @brief Immediately emit and finalize the object set represented by the
+  ///        given handle.
+  /// @param H Handle for object set to emit/finalize.
+  void emitAndFinalize(ObjSetHandleT H) {
+    (*H)->Finalize();
+    if (NotifyFinalized)
+      NotifyFinalized(H);
+  }
+
+private:
+  LinkedObjectSetListT LinkedObjSetList;
+  NotifyLoadedFtor NotifyLoaded;
+  NotifyFinalizedFtor NotifyFinalized;
+};
+
+} // End namespace orc.
+} // End namespace llvm
+
+#endif // EE_OBJECTLINKINGLAYER_H

--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -23,7 +23,6 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/ThreadLocal.h"
-#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
 #include "llvm/ExecutionEngine/Orc/NullResolver.h"
 #include "llvm/Config/config.h"

--- a/lib/Jit/EEMemoryManager.cpp
+++ b/lib/Jit/EEMemoryManager.cpp
@@ -55,11 +55,21 @@ uint8_t *EEMemoryManager::allocateDataSection(uintptr_t Size,
   assert(IsReadOnly);
 
   // Pad for alignment needs.
-  unsigned int Offset = ((uint64_t)ReadOnlyDataUnallocated) % Alignment;
+  unsigned int Offset = 0;
+  if ((this->Context->Flags & CORJIT_FLG_PREJIT) != 0) {
+    // In ngen scenario ReadOnlyDataBlock will have a 16 bytes alignment in the
+    // image but the memory block we get may not have a 16 bytes alignment. We
+    // calculate alignment padding based on the image alignment of
+    // ReadOnlyDataBlock.
+    assert(Alignment <= 16);
+    Offset = ((uint64_t)ReadOnlyDataUnallocated - (uint64_t)ReadOnlyDataBlock) %
+             Alignment;
+  } else {
+    Offset = ((uint64_t)ReadOnlyDataUnallocated) % Alignment;
+  }
   if (Offset > 0) {
     ReadOnlyDataUnallocated += Alignment - Offset;
   }
-  assert((((uint64_t)ReadOnlyDataUnallocated) % Alignment) == 0);
 
   // There are multiple read-only sections, so we need to keep
   // track of the current allocation point in the read-only memory region.
@@ -104,16 +114,16 @@ void EEMemoryManager::reserveAllocationSpace(uintptr_t CodeSize,
   // So this gives the dynamic loader room to copy the RO sections, and later
   // the EE will copy from there to the place it really keeps unwind data.
 
-  // RODataBlock we get back is either 8 bytes or pointer-size aligned. If the
-  // first section we place in that block is 16 bytes aligned (e.g., for a
-  // constant pool), we may need to add padding. Overallocate by 16 bytes to
-  // account for that.
-  uintptr_t ReadOnlyDataSize = DataSizeRO + 16;
+  uintptr_t ReadOnlyDataSize = DataSizeRO;
   uint32_t ExceptionCount = 0;
 
-  // Remap alignment to the EE notion of alignment
+  // Remap alignment to the EE notion of alignment.
+  // Conservatively request 16 bytes alignment for RODataBlock since one of the
+  // .rdata sections may be 16 bytes aligned (e.g., a floating-point constant
+  // pool.)
   CorJitAllocMemFlag Flag =
-      CorJitAllocMemFlag::CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN;
+      CorJitAllocMemFlag::CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN |
+      CorJitAllocMemFlag::CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN;
 
   // We allow the amount of RW data to be nonzero to work around the fact that
   // MCJIT will not report a size of zero for any section, even if that

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2920,16 +2920,10 @@ IRNode *GenIR::loadConstantI(size_t Constant) {
 }
 
 IRNode *GenIR::loadConstantR4(float Value) {
-  if ((JitContext->Flags & CORJIT_FLG_PREJIT) != 0) {
-    throw NotYetImplementedException("ldc.r4 in ngen");
-  }
   return (IRNode *)ConstantFP::get(*JitContext->LLVMContext, APFloat(Value));
 }
 
 IRNode *GenIR::loadConstantR8(double Value) {
-  if ((JitContext->Flags & CORJIT_FLG_PREJIT) != 0) {
-    throw NotYetImplementedException("ldc.r8 in ngen");
-  }
   return (IRNode *)ConstantFP::get(*JitContext->LLVMContext, APFloat(Value));
 }
 
@@ -5354,14 +5348,6 @@ IRNode *GenIR::conv(ReaderBaseNS::ConvOpcode Opcode, IRNode *Source) {
       {CorInfoType::CORINFO_TYPE_DOUBLE, false, true}       // CONV_R_UN
   };
 
-  if ((JitContext->Flags & CORJIT_FLG_PREJIT) != 0) {
-    if ((Opcode == ReaderBaseNS::ConvOpcode::ConvR4) ||
-        (Opcode == ReaderBaseNS::ConvOpcode::ConvR8) ||
-        (Opcode == ReaderBaseNS::ConvOpcode::ConvRUn)) {
-      throw NotYetImplementedException("conv.r4, conv.r8, or conv.run in ngen");
-    }
-  }
-
   ConvertInfo Info = Map[Opcode];
 
   Type *TargetTy = getType(Info.CorType, nullptr);
@@ -5798,13 +5784,6 @@ bool GenIR::memoryBarrier() {
 }
 
 void GenIR::switchOpcode(IRNode *Opr) {
-
-  const uint32_t JitFlags = JitContext->Flags;
-
-  if ((JitFlags & CORJIT_FLG_PREJIT) != 0) {
-    throw NotYetImplementedException("switch in ngen");
-  }
-
   // We split the block right after the switch during the flow-graph build.
   // The terminator is switch instruction itself.
   // Now condition operand is updated.


### PR DESCRIPTION
Process all relocations in ObjectLoadListener::recordRelocations.
Fix an issue with read-only section alignment: make sure Constant
pools have a 16 bytes alignment.

Create a copy of ObjectLinkingLayer (EEObjectLinkingLayer) so that
we can suppress relocation resolutiotion by LLVM. Lang Hames is
likely to re-design ObjectLinkingLayer in the future to allow more
control over relocations. When that happens we should be able to get rid
of our copy.

Closes #699.
Closes #700.