### PR TITLE
Update ModuleDataLayout from TargetMachine

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -250,6 +250,9 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
         CodeModel::JITDefault, OptLevel);
     Context.TM = TM;
 
+    // Set target machine datalayout on the method module.
+    Context.CurrentModule->setDataLayout(TM->createDataLayout());
+
     // Construct the jitting layers.
     EEMemoryManager MM(&Context);
     ObjectLoadListener Listener(&Context);


### PR DESCRIPTION
Set DataLayout on newly created module so that there's agreement between the TargetMachine and the Module.  This check is forthcoming in the LLVM merge.

@erozenfeld @adiaaida 