### PR TITLE
GcInfo: Fix Offsets for NGEN

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -312,9 +312,11 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
                << ", size = " << *NativeSizeOfCode
                << " method = " << Context.MethodName << '\n';
       }
+
+      assert(*NativeEntry >= MM.getHotCodeBlock());
       GcInfoAllocator GcInfoAllocator;
-      GCInfo GcInfo(&Context, MM.getStackMapSection(), MM.getHotCodeBlock(),
-                    &GcInfoAllocator);
+      GCInfo GcInfo(&Context, MM.getStackMapSection(), &GcInfoAllocator,
+                    *NativeEntry - MM.getHotCodeBlock());
       GcInfo.emitGCInfo();
 
       // Dump out any enabled timing info.


### PR DESCRIPTION
GcInfoEncoder needs to find the distance (offset) of the
Function entry point to the start of the code section.
For this, it calculated the diffrence between the HotCodeBlock
and the function address reported in __llvm_stackmaps.

However, in an Ngen/AOT build, the FunctionEntry address
recorded in LLVM's StackMap are post-relocation offsets.
Therefore, it cannot be compared to the Start of the CodeBlock
allocated during compilation.

This change fixes this bug by using non-relocated code-block
address for both function-entry and code-block-start.

Fixes #743