### PR TITLE
Exclude a test in INSERTSTATEPOINTS run.

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -2697,6 +2697,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68361\b68361.cmd" >
              <Issue>735</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b268908\b268908.cmd" >
+             <Issue>735</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\113574\113574.cmd" >
              <Issue>737</Issue>
         </ExcludeList>


### PR DESCRIPTION
Another test run with statepoints inserted hit failure noted in Issue #735.
This cause the nightly testing to fail:
http://dotnet-ci.cloudapp.net/job/dotnet_llilc_insert_statepoints_nightly/95/console

So, exclude the test until #735 is fixed.