### PR TITLE
Allow int32 to int64 comparisons in branches

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -319,6 +319,21 @@ public:
   IRNode *ckFinite(IRNode *Arg1) override {
     throw NotYetImplementedException("ckFinite");
   };
+
+  /// \brief Modify comparison arguments, if needed, to have equal types.
+  ///
+  /// LLVM comparisons require that the operands have the same type
+  /// whereas MSIL operands may have different type, subject to
+  /// the conditions in the ECMA spec, partition III, table 4,
+  /// except we relax these conditions somewhat by allowing comparison
+  /// of int64 with int32 or native int. Promote the arguments
+  /// as needed to achieve type equality.
+  ///
+  /// \param [in,out] Arg1 Pointer to first argument.
+  /// \param [in,out] Arg2 Pointer to second argument.
+  /// \returns True if the comparison is a floating comparison.
+  bool prepareArgsForCompare(IRNode *&Arg1, IRNode *&Arg2);
+
   IRNode *cmp(ReaderBaseNS::CmpOpcode Opode, IRNode *Arg1,
               IRNode *Arg2) override;
   void condBranch(ReaderBaseNS::CondBranchOpcode Opcode, IRNode *Arg1,

--- a/lib/Reader/GenIRStubs.cpp
+++ b/lib/Reader/GenIRStubs.cpp
@@ -17,6 +17,11 @@
 #include "earlyincludes.h"
 #include "reader.h"
 #include <cstdarg>
+#include <cstdio>
+
+#ifdef _MSC_VER
+#define vsnprintf _vsnprintf
+#endif
 
 // Get the special block-start placekeeping node
 IRNode *fgNodeGetStartIRNode(FlowGraphNode *FgNode) { return (IRNode *)FgNode; }
@@ -507,8 +512,13 @@ void ReaderBase::verGlobalError(const char *Message) { return; }
 int _cdecl dbPrint(const char *Format, ...) {
   va_list Args;
   va_start(Args, Format);
-  int NumChars = vfprintf(stderr, Format, Args);
+  const int BufferSize = 200;
+  char Buffer[BufferSize];
+  int NumChars = vsnprintf(Buffer, BufferSize, Format, Args);
   va_end(Args);
+  if (NumChars > 0) {
+    llvm::dbgs() << Buffer;
+  }
   return NumChars;
 }
 

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -662,7 +662,7 @@
              <Issue>633</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91223\b91223.cmd" >
-             <Issue>637</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b77304\b77304.cmd" >
              <Issue>637</Issue>

--- a/test/llilc_run.py
+++ b/test/llilc_run.py
@@ -60,8 +60,8 @@ def UnquoteArg(arg):
 
 def log(*objs):
     '''Print log message to both stdout and stderr'''
-    print("llilc-run: ", *objs)
-    print("llilc-run: ", *objs, file=sys.stderr)
+    print("llilc_run\stdout: ", *objs)
+    print("llilc_run\stderr: ", *objs, file=sys.stderr)
     
 def RunCommand(command):
     ''' Run a command and return its exit code, optionally echoing it.'''


### PR DESCRIPTION
LLILC was already allowing int32 to int64 comparisons
for the opcodes that produce a boolean result.
But the code that adjusted comparison arguments was
only partly duplicated for branch comparisons.

This change factors out the common code that
adjusts comparison arguments so that boolean result
comparison and branch comparison are treated consistently.

With this change test
JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91223,
which was failing with an assertion failure is now
able to compile the ILGEN_0x9c0b37ec.Method_0xa1f09b04
method. The test still fails later, because the tests
correct execution throws an overflow exception which
LLILC is not yet prepared to catch.

This change also includes two other small changes:

The MSIL dumps were being written directly to stderr
rather than going through dbgs() and I've observed
that this output does not appear when called from
the debugger. To fix this I've changed the
dbprint method to first format the message into a
string and then output that string to dbgs().
Currently we only use dbPrint to write MSIL
dumps. I allowed a buffer size of 200 characters,
but also used the safe string formatting method (vsnprintf).

In the llilc_run.py file, when verbose output is being
produced I modified the log function so that output to
stdout and stderr were tagged to avoid confusion,
as when they have the save destination the duplication
can be confusing.

Resolves #637. 