### PR TITLE
GCTables: Report StackBasePointer.

### DIFF
--- a/include/GcInfo/GcInfo.h
+++ b/include/GcInfo/GcInfo.h
@@ -43,9 +43,13 @@ public:
   ~GCInfo();
 
 private:
-  void encodeHeader();
-  void encodeLiveness();
+  void emitGCInfo(const llvm::Function &F);
+  void encodeHeader(const llvm::Function &F);
+  void encodeLiveness(const llvm::Function &F);
   void emitEncoding();
+
+  bool shouldEmitGCInfo(const llvm::Function &F);
+  bool isStackBaseFramePointer(const llvm::Function &F);
 
   const LLILCJitContext *JitContext;
   const uint8_t *LLVMStackMapData;

--- a/include/GcInfo/GcInfo.h
+++ b/include/GcInfo/GcInfo.h
@@ -39,6 +39,8 @@ public:
   /// Emit GC Info to the EE using GcInfoEncoder.
   void emitGCInfo();
 
+  static bool isGCFunction(const llvm::Function &F);
+
   /// Destructor -- delete allocated memory
   ~GCInfo();
 

--- a/include/GcInfo/Target.h
+++ b/include/GcInfo/Target.h
@@ -17,10 +17,19 @@
 #define GCINFO_TARGET_H
 
 #include "global.h"
+#include "corinfo.h"
 
 #if (defined(_TARGET_X86_) || defined(_TARGET_X64_) || defined(_TARGET_AMD64_))
 
-// Define DWARF encodings for registers
+// Identify the frame-pointer register number
+
+#if defined(_TARGET_X86_)
+#define REGNUM_FPBASE ICorDebugInfo::RegNum::REGNUM_EBP
+#else
+#define REGNUM_FPBASE ICorDebugInfo::RegNum::REGNUM_RBP
+#endif // defined(_TARGET_X86_)
+
+// Define encodings for DWARF registers
 // Size variants (ex: AL,AH,AX,EAX,RAX) all get the same Dwarf register number
 
 #define DW_RAX 0

--- a/lib/GcInfo/GcInfo.cpp
+++ b/lib/GcInfo/GcInfo.cpp
@@ -37,11 +37,10 @@ GCInfo::GCInfo(LLILCJitContext *JitCtx, uint8_t *StackMapData,
 #endif // defined(PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED)
 }
 
-void GCInfo::encodeHeader() {
+void GCInfo::encodeHeader(const Function &F) {
 #if !defined(NDEBUG)
   if (EmitLogs) {
-    dbgs() << "GcTable for Function: " << JitContext->MethodName << "\n"
-           << "  Size: " << JitContext->HotCodeSize << "\n";
+    dbgs() << "GcTable for Function: " << F.getName() << "\n";
   }
 #endif // !NDEBUG
 
@@ -50,15 +49,41 @@ void GCInfo::encodeHeader() {
   // JitContext->HotCodeSize is the size of the allocated code block.
   // It is not the actual length of the current function's code.
   Encoder.SetCodeLength(JitContext->HotCodeSize);
+#if !defined(NDEBUG)
+  if (EmitLogs) {
+    dbgs() << "  Size: " << JitContext->HotCodeSize << "\n";
+  }
+#endif // !NDEBUG
+
+  if (isStackBaseFramePointer(F)) {
+    Encoder.SetStackBaseRegister(REGNUM_FPBASE);
+#if !defined(NDEBUG)
+    if (EmitLogs) {
+      dbgs() << "  StackBaseRegister: FP\n";
+    }
+#endif // !NDEBUG
+  } else {
+#if !defined(NDEBUG)
+    if (EmitLogs) {
+      dbgs() << "  StackBaseRegister: SP\n";
+    }
+#endif // !NDEBUG
+  }
 
 #if defined(FIXED_STACK_PARAMETER_SCRATCH_AREA)
   // TODO: Set size of outgoing/scratch area accurately
   // https://github.com/dotnet/llilc/issues/681
-  Encoder.SetSizeOfStackOutgoingAndScratchArea(0);
+  const unsigned ScratchAreaSize = 0;
+  Encoder.SetSizeOfStackOutgoingAndScratchArea(ScratchAreaSize);
+#if !defined(NDEBUG)
+  if (EmitLogs) {
+    dbgs() << "  Scratch Area Size: " << ScratchAreaSize << "\n";
+  }
+#endif // !NDEBUG
 #endif // defined(FIXED_STACK_PARAMETER_SCRATCH_AREA)
 }
 
-void GCInfo::encodeLiveness() {
+void GCInfo::encodeLiveness(const Function &F) {
   if (LLVMStackMapData == nullptr) {
     return;
   }
@@ -73,6 +98,9 @@ void GCInfo::encodeLiveness() {
 #endif
   StackMapParserType StackMapParser(StackMapContentsArray);
 
+  // TODO: Once StackMap v2 is implemented, remove this assertion about
+  // one function per module, and emit the GcInfo for the records
+  // corresponding to the Function 'F'
   assert(StackMapParser.getNumFunctions() == 1 &&
          "Expect only one function with GcInfo in the module");
 
@@ -239,6 +267,11 @@ void GCInfo::encodeLiveness() {
       }
     }
 
+    // __LLVM_Stackmap reports the liveness of pointers wrt SP even for
+    // certain methods which have a FP. So, we cannot
+    // assert((SpBase == GC_FRAMEREG_REL) ?
+    //          isStackBaseFramePointer(F) : !isStackBaseFramePointer(F));
+
     for (GcSlotId SlotID = 0; SlotID < NumSlots; SlotID++) {
       if (!OldLiveSet[SlotID] && NewLiveSet[SlotID]) {
 #if !defined(NDEBUG)
@@ -297,8 +330,40 @@ GCInfo::~GCInfo() {
 #endif // defined(PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED)
 }
 
-void GCInfo::emitGCInfo() {
-  encodeHeader();
-  encodeLiveness();
+void GCInfo::emitGCInfo(const Function &F) {
+  encodeHeader(F);
+  encodeLiveness(F);
   emitEncoding();
+}
+
+void GCInfo::emitGCInfo() {
+  const Module::FunctionListType &FunctionList =
+      JitContext->CurrentModule->getFunctionList();
+  Module::const_iterator Iterator = FunctionList.begin();
+  Module::const_iterator End = FunctionList.end();
+
+  for (; Iterator != End; ++Iterator) {
+    const Function &F = *Iterator;
+    if (shouldEmitGCInfo(F)) {
+      emitGCInfo(F);
+    }
+  }
+}
+
+bool GCInfo::shouldEmitGCInfo(const Function &F) {
+  if (F.isDeclaration()) {
+    return false;
+  }
+
+  if (!F.hasGC()) {
+    return false;
+  }
+
+  const StringRef CoreCLRName("coreclr");
+  return (CoreCLRName == F.getGC());
+}
+
+bool GCInfo::isStackBaseFramePointer(const llvm::Function &F) {
+  Attribute Attribute = F.getFnAttribute("no-frame-pointer-elim");
+  return (Attribute.getValueAsString() == "true");
 }

--- a/lib/GcInfo/GcInfo.cpp
+++ b/lib/GcInfo/GcInfo.cpp
@@ -351,10 +351,10 @@ void GCInfo::emitGCInfo() {
 }
 
 bool GCInfo::shouldEmitGCInfo(const Function &F) {
-  if (F.isDeclaration()) {
-    return false;
-  }
+  return !F.isDeclaration() && isGCFunction(F);
+}
 
+bool GCInfo::isGCFunction(const llvm::Function &F) {
   if (!F.hasGC()) {
     return false;
   }

--- a/lib/Reader/CMakeLists.txt
+++ b/lib/Reader/CMakeLists.txt
@@ -2,12 +2,17 @@ get_filename_component(LLILC_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../include 
 
 include_directories(${LLILC_INCLUDES}/clr
                     ${LLILC_INCLUDES}/Pal
+                    ${LLILC_INCLUDES}/GcInfo                    
                     ${LLILC_INCLUDES}/Reader
                     ${LLILC_INCLUDES}/Jit)
+
+set(LLILCJIT_LINK_LIBRARIES GcInfo)
 
 if( WIN32 )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc")
 endif()
+
+add_definitions(-DSTANDALONE_BUILD)
 
 add_llilcjit_library(LLILCReader
   abi.cpp

--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -598,9 +598,7 @@ Function *ABIMethodSignature::createFunction(GenIR &Reader, Module &M) {
     F->setAttributes(AttributeSet::get(Context, Attrs));
   }
 
-  if (Reader.JitContext->Options->DoInsertStatepoints) {
-    F->setGC("coreclr");
-  }
+  F->setGC("coreclr");
 
   return F;
 }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -15,6 +15,7 @@
 
 #include "earlyincludes.h"
 #include "readerir.h"
+#include "GcInfo.h"
 #include "imeta.h"
 #include "newvstate.h"
 #include "llvm/ADT/Triple.h"
@@ -649,7 +650,8 @@ void GenIR::insertIRForUnmanagedCallFrame() {
 
   // Mark this function as requiring a frame pointer and as using GC.
   Function->addFnAttr("no-frame-pointer-elim", "true");
-  Function->setGC("coreclr");
+
+  assert(GCInfo::isGCFunction(*Function));
 
   // The call frame data structure is modeled as an opaque blob of bytes.
   Type *CallFrameTy = ArrayType::get(Int8Ty, CallFrameInfo.size);


### PR DESCRIPTION
CoreCLR requires that we identify whether a method's frame is
FP or SP based. This is inaddition to reporting the reference pointers
for the slots representing liveness. So, this change reports the
StackBasePointer in the GcTable header.

To facilitate the above, the GcInfo encoding functions are
restructured to be per-function routines.

Fixes #758.