### PR TITLE
Add link to clang-format.exe to ccformat

### DIFF
--- a/utils/ccformat.py
+++ b/utils/ccformat.py
@@ -179,6 +179,8 @@ def runFormat(args):
 
   if returncode == -1:
     print("There were formatting errors. Rerun with --fix")
+    print("Up-to-date clang-format.exe can be found at",
+          "http://dotnet-ci.cloudapp.net/view/dotnet_llilc/job/dotnet_llilc_code_formatter_drop/")
   return returncode
 
 def main(argv):


### PR DESCRIPTION
If formatting fails, we would like to have a link to the
clang-format.exe that is being used in the lab so users can easily find
what their code will be tested against.