### PR TITLE
LLVM merge fixes

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -586,8 +586,9 @@ void ObjectLoadListener::recordRelocations(
         continue;
       }
 
-      section_iterator SymbolSection(Obj.section_end());
-      Symbol->getSection(SymbolSection);
+      ErrorOr<section_iterator> SymbolSectionOrErr = Symbol->getSection();
+      assert(!SymbolSectionOrErr.getError());
+      object::section_iterator SymbolSection = *SymbolSectionOrErr;
       const bool IsExtern = SymbolSection == Obj.section_end();
       uint64_t RelType = I->getType();
       uint64_t Offset = I->getOffset();

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -7347,12 +7347,13 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
         fgNodeSetOperandStack(SuccessorBlock, SuccessorStack);
         CreatePHIs = true;
       }
-      
+
       // We need to be very careful about reasoning about or iterating through
       // instructions in empty blocks or blocks with no terminators.
       Instruction *TermInst = SuccessorBlock->getTerminator();
       const bool SuccessorDegenerate = (TermInst == nullptr);
-      Instruction *CurrentInst = SuccessorBlock->empty() ? nullptr : SuccessorBlock->begin();
+      Instruction *CurrentInst =
+          SuccessorBlock->empty() ? nullptr : SuccessorBlock->begin();
       PHINode *Phi = nullptr;
       for (IRNode *Current : *ReaderOperandStack) {
         Value *CurrentValue = (Value *)Current;
@@ -7391,11 +7392,11 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
 
       // The number of PHI instructions should match the number of values on the
       // stack, so if we're not creating PHIs, try and verify that the next
-      // instruction is not a PHI. 
+      // instruction is not a PHI.
       //
       // Note when SuccessorBlock is degenerate we can't be sure CurrentInst is
       // valid, so we can't do this check.
-      assert(CreatePHIs|| SuccessorDegenerate || !isa<PHINode>(CurrentInst));
+      assert(CreatePHIs || SuccessorDegenerate || !isa<PHINode>(CurrentInst));
     }
     SuccessorList = fgEdgeListGetNextSuccessorActual(SuccessorList);
   }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -2695,6 +2695,7 @@ FlowGraphNode *GenIR::fgSplitBlock(FlowGraphNode *Block, IRNode *Node) {
       BranchInst::Create(NewBlock, TheBasicBlock);
     }
   } else {
+    assert(TheBasicBlock != nullptr);
     if (TheBasicBlock->getTerminator() != nullptr) {
       NewBlock = TheBasicBlock->splitBasicBlock(Inst);
     } else {
@@ -7346,8 +7347,12 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
         fgNodeSetOperandStack(SuccessorBlock, SuccessorStack);
         CreatePHIs = true;
       }
-
-      Instruction *CurrentInst = SuccessorBlock->begin();
+      
+      // We need to be very careful about reasoning about or iterating through
+      // instructions in empty blocks or blocks with no terminators.
+      Instruction *TermInst = SuccessorBlock->getTerminator();
+      const bool SuccessorDegenerate = (TermInst == nullptr);
+      Instruction *CurrentInst = SuccessorBlock->empty() ? nullptr : SuccessorBlock->begin();
       PHINode *Phi = nullptr;
       for (IRNode *Current : *ReaderOperandStack) {
         Value *CurrentValue = (Value *)Current;
@@ -7372,7 +7377,9 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
                 fgEdgeListGetNextPredecessorActual(PredecessorList);
           }
         } else {
-          // PHI instructions should have been inserted already
+          // PHI instructions should have been inserted already.
+          assert(CurrentInst != nullptr);
+          assert(isa<PHINode>(CurrentInst));
           Phi = cast<PHINode>(CurrentInst);
           CurrentInst = CurrentInst->getNextNode();
         }
@@ -7383,8 +7390,12 @@ void GenIR::maintainOperandStack(FlowGraphNode *CurrentBlock) {
       }
 
       // The number of PHI instructions should match the number of values on the
-      // stack.
-      ASSERT(CreatePHIs || !isa<PHINode>(CurrentInst));
+      // stack, so if we're not creating PHIs, try and verify that the next
+      // instruction is not a PHI. 
+      //
+      // Note when SuccessorBlock is degenerate we can't be sure CurrentInst is
+      // valid, so we can't do this check.
+      assert(CreatePHIs|| SuccessorDegenerate || !isa<PHINode>(CurrentInst));
     }
     SuccessorList = fgEdgeListGetNextSuccessorActual(SuccessorList);
   }


### PR DESCRIPTION
Update to the changed section API.  Done to match the LLVM merge.  Also includes work around for degenerate block uninitialized data.