### PR TITLE
Precise GC: Add NYIs for functions with missing info

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -580,6 +580,11 @@ void GenIR::insertIRToKeepGenericContextAlive() {
 
   // TODO: we must convey the offset of this local to the runtime
   // via the GC encoding.
+  // https://github.com/dotnet/llilc/issues/766
+
+  if (JitContext->Options->DoInsertStatepoints) {
+    throw NotYetImplementedException("NYI: Generic Context reporting");
+  }
 }
 
 void GenIR::insertIRForSecurityObject() {
@@ -616,6 +621,11 @@ void GenIR::insertIRForSecurityObject() {
 
   // TODO: we must convey the offset of the security object to the runtime
   // via the GC encoding.
+  // https://github.com/dotnet/llilc/issues/767
+
+  if (JitContext->Options->DoInsertStatepoints) {
+    throw NotYetImplementedException("NYI: Security Object Reporting");
+  }
 }
 
 void GenIR::callMonitorHelper(bool IsEnter) {


### PR DESCRIPTION
GcInfo encoder doesn't yet report certain data in the
GCInfo headers.

1) Generic Context slot: #766
2) Security Object Slot: #767
3) GSCookie slot: #768

This change adds exclusions for functions containing (1) and (2)
when compiling for Precise GC.

There is no exclusion for (3) because stack protection checks are
yet to be implemented in LLILC #353