### PR TITLE
﻿Remove SafepointPoll from the Module after Safepoint placement.

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -81,6 +81,7 @@ public:
   llvm::LLVMContext *LLVMContext; ///< LLVM context for types and similar.
   llvm::Module *CurrentModule;    ///< Module holding LLVM IR.
   llvm::TargetMachine *TM;        ///< Target characteristics
+  llvm::Function *SafepointPoll;  /// < The Safepoint Poll helper
   bool HasLoadedBitCode;          ///< Flag for side-loaded LLVM IR.
   llvm::StringMap<uint64_t> NameToHandleMap; ///< Map from global variable names
                                              ///< to the corresponding CLR

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -988,6 +988,8 @@ void GenIR::createSafepointPoll() {
 
   CallInst::Create(Target, "", EntryBlock);
   ReturnInst::Create(*LLVMContext, EntryBlock);
+
+  JitContext->SafepointPoll = SafepointPoll;
 }
 
 bool GenIR::doTailCallOpt() { return JitContext->Options->DoTailCallOpt; }


### PR DESCRIPTION
This change removes the SafepointPoll function from the module
once the Safepoint placement and rewriting Phases are run.
There will be no references to this function after the
PlaceSafepoints phase is run -- since this phase inlines the contents
of the function SafepointPoll() at all polling locations.

This change will improve throughput, since machine lowering sees
one less function in every module. We'll get this optimization for free
once we turn on the LLVM inliner via Inliner::removeDeadFunctions().