### PR TITLE
Update LLILC ORC Compiler

### DIFF
--- a/include/Jit/compiler.h
+++ b/include/Jit/compiler.h
@@ -43,7 +43,6 @@ public:
     if (TM.addPassesToEmitMC(PM, Ctx, ObjStream))
       llvm_unreachable("Target does not support MC emission.");
     PM.run(M);
-    ObjStream.flush();
     std::unique_ptr<MemoryBuffer> ObjBuffer(
         new ObjectMemoryBuffer(std::move(ObjBufferSV)));
     ErrorOr<std::unique_ptr<object::ObjectFile>> Obj =


### PR DESCRIPTION
ORC Compiler functor was using a API that had been deleted in LLVM.  Call is no longer needed and so is removed.