### PR TITLE
Add workaround for debug locals with Statepoints

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -588,7 +588,10 @@ void ObjectLoadListener::getDebugInfoForObject(
       Context->JitInfo->setBoundaries(MethodHandle, NumDebugRanges, OM);
     }
 
-    getDebugInfoForLocals(DwarfContext, Addr, Size);
+    // TODO: Remove this opt-out when #776 is fixed
+    if (!Context->Options->DoInsertStatepoints) {
+      getDebugInfoForLocals(DwarfContext, Addr, Size);
+    }
   }
 }
 


### PR DESCRIPTION
When we are inserting statepoints, there are multiple functions in a
module. This workaround will not send debug info to the EE when we
insert statepoints until we have an actual fix to identify multiple
function in a module.