### PR TITLE
Mark @gc.SafepointPoll() as NoUnwind

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -979,6 +979,13 @@ void GenIR::createSafepointPoll() {
 
   assert(SafepointPoll->empty());
 
+  // Safepoint Poll function itself is never expected to be called
+  // at runtime, so we can save generating unwind information for it.
+  //
+  // PlaceSafepoints phase inlines the contents of @gc.SafepointPoll()
+  // at all gc-polling locations.
+  SafepointPoll->addFnAttr(Attribute::NoUnwind);
+
   BasicBlock *EntryBlock =
       BasicBlock::Create(*LLVMContext, "entry", SafepointPoll);
 


### PR DESCRIPTION
@gc.SafepointPoll() function is never expected to be called
at runtime, so we can save generating unwind information for it.
PlaceSafepoints phase inlines the contents of @gc.SafepointPoll()
at all gc-polling locations.

EEMemoryManager::registerEHFrames() is written with the assumption
that there's only one function per module. This assumption is not
true when ruin with COMPLUS_InsertStatepoints=1 because of the
addition of the @gc.SafepointPoll() function. This resulted in
reporting incorrect UnwindInfo to the runtime.

This limitation needs to be fixed for FunctLets (an orthogonal issue).
But can be circumvented for the SafepointPoll function by marking it
with the NoUnwind qattribute.

This change also adds a check in the EEMemoryManager to check that
UnwindInfo is actually generated for one function in the module.

Fixes #734 