### PR TITLE
Fix PHI update logic.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1412,12 +1412,13 @@ private:
                                unsigned int NumReservedValues,
                                const llvm::Twine &NameStr);
 
-  /// Add a new operand to the PHI instruction. The type of the new operand may
-  /// or may not equal to the type of the PHI instruction. Adjust the types as
-  /// necessary.
+  /// Update all undef placeholders corresponding to the new operand in the
+  /// PHI instruction. The type of the new operand may or may not equal the type
+  /// of the PHI instruction. Adjust the types as necessary.
   ///
   /// \param PHI PHI instruction.
   /// \param NewOperand Operand to add to the PHI instruction.
+  /// \param NewBlock Basic block corresponding to NewOperand.
   void addPHIOperand(llvm::PHINode *PHI, llvm::Value *NewOperand,
                      llvm::BasicBlock *NewBlock);
 


### PR DESCRIPTION
If a block terminator is
br i1 %6, label %7, label %7
and the operand stack is not empty,
we'll create a PHI instruction in the successor block with an undef operand:
; <label>:7                                       ; preds = %2, %2
  %8 = phi i32 [ %3, %2 ], [ undef, %2 ]
...
; <label>:9                                       ; preds = %7
  %10 = add i32 %8, 3

We never update the undef in this case.

llvm::removeUnreachableBlocks calls llvm::constantFoldTerminator
and optimizes the br instruction above so that the above code becomes

br label %5

; <label>:5                                       ; preds = %4
  %6 = add i32 undef, 3

which is a problem. This was causing 6 of our tests to fail.

The fix is to update all PHI operands corresponding to a predecessor,
not just one.

Closes #785.