### PR TITLE
Reclassify failures with exclusion issue 487.

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -107,13 +107,10 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\Inline_Handler.cmd" >
-             <Issue>487</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\Inline_Vars.cmd" >
-             <Issue>487</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\InlineThrow.cmd" >
-             <Issue>487</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\GenToGen01.cmd" >
              <Issue>13</Issue>


### PR DESCRIPTION
Closes #487.

One test passes, the other two require eh and so are excluded via issue #13.