### PR TITLE
Fix #789 and #797

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1252,8 +1252,9 @@ private:
 
   /// Get the type of the result of the merge of two values from operand stacks
   /// of a block's predecessors. The allowed combinations are nativeint and
-  // int32 (resulting in nativeint), float and double (resulting in double),
-  /// and GC pointers (resulting in the closest common supertype).
+  /// int32 (resulting in whichever was first), float and double
+  /// (resulting in double), and GC pointers (resulting in the closest common
+  /// supertype).
   ///
   /// \param Ty1 Type of the first value.
   /// \param Ty1 Type of the second value.

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -696,11 +696,11 @@ void ObjectLoadListener::getDebugInfoForLocals(
     if (SubprogramDIE->getAttributeValue(CU.get(), dwarf::DW_AT_low_pc,
                                          FormValue)) {
       Optional<uint64_t> FormAddress = FormValue.getAsAddress(CU.get());
-      
+
       // If the Form address doesn't match the address for the function passed
       // do not collect debug for locals since they do not go with the current
       // function being processed
-      if (FormAddress.getValue() != Addr){
+      if (FormAddress.getValue() != Addr) {
         return;
       }
     }

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -2287,40 +2287,10 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relnegIndexRngChkElim.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_fld.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_flow.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_vfld.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgptr.cmd" >
              <Issue>637</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_fld.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_vfld.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_fld.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_flow.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_vfld.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relptr.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_fld.cmd" >
-             <Issue>637</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_vfld.cmd" >
              <Issue>637</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b49435\b49435.cmd" >


### PR DESCRIPTION
Closes #789. Closes #797.

For #789, when merging stack states, if the types being merged
are int32 and native int, keeps the first type in order to
conform to the ECMA standard. This fixed 8 tests.

For #797, if a switch has a selector whose type is not i32,
fix up the types of the case values to match. This fixed
two tests.