### PR TITLE
Fix assert in box codegen.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -3196,11 +3196,11 @@ public:
 
   /// Converts the operand to an argument type understood by the boxing helper
   ///
-  /// \param Opr Operand
-  /// \param CorType CorInfoType of the operand.
-  /// \returns Converted operand
+  /// \param Opr      Operand to pass to the boxing helper.
+  /// \param DestSize Size of the box type in bytes.
+  /// \returns        Converted operand
   virtual IRNode *convertToBoxHelperArgumentType(IRNode *Opr,
-                                                 CorInfoType CorType) = 0;
+                                                 uint32_t DestSize) = 0;
 
   virtual IRNode *genNullCheck(IRNode *Node) = 0;
 

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -794,7 +794,7 @@ public:
   void callMonitorHelper(bool IsEnter);
 
   IRNode *convertToBoxHelperArgumentType(IRNode *Opr,
-                                         CorInfoType CorType) override;
+                                         uint32_t DestSize) override;
 
   IRNode *makeBoxDstOperand(CORINFO_CLASS_HANDLE Class) override;
 

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -3648,10 +3648,10 @@ IRNode *ReaderBase::box(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg2,
     return Arg2;
   }
 
-  // Ensure that operand from operand stack has type that is
+  // Ensure that operand from operand stack has size that is
   // compatible with box destination, then get the (possibly
   // converted) operand's address.
-  Arg2 = convertToBoxHelperArgumentType(Arg2, getClassType(Class));
+  Arg2 = convertToBoxHelperArgumentType(Arg2, getClassSize(Class));
 
   Dst = makeBoxDstOperand(Class);
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -5279,8 +5279,7 @@ IRNode *GenIR::genCall(ReaderCallTargetData *CallTargetInfo, bool MayThrow,
   }
 }
 
-IRNode *GenIR::convertToBoxHelperArgumentType(IRNode *Opr,
-                                              CorInfoType DestType) {
+IRNode *GenIR::convertToBoxHelperArgumentType(IRNode *Opr, uint32_t DestSize) {
   Type *Ty = Opr->getType();
   switch (Ty->getTypeID()) {
   case Type::TypeID::IntegerTyID: {
@@ -5289,9 +5288,9 @@ IRNode *GenIR::convertToBoxHelperArgumentType(IRNode *Opr,
     ASSERT((Ty->getIntegerBitWidth() == 32) ||
            (Ty->getIntegerBitWidth() == 64));
 
-    // If Size were smaller than DestinationSize the boxing helper would grab
-    // data from outside the smaller datatype.
-    ASSERT(size(DestType) <= Ty->getIntegerBitWidth());
+    // If the operand size is smaller than DestSize the boxing helper will grab
+    // data from outside the smaller operand.
+    ASSERT(DestSize <= Ty->getIntegerBitWidth());
     break;
   }
   // If the data type is a float64 and we want to box it to a
@@ -5301,7 +5300,7 @@ IRNode *GenIR::convertToBoxHelperArgumentType(IRNode *Opr,
   // destroy the value.
   case Type::TypeID::FloatTyID:
   case Type::TypeID::DoubleTyID:
-    if (Ty->getPrimitiveSizeInBits() > size(DestType)) {
+    if (Ty->getPrimitiveSizeInBits() > DestSize) {
       Opr = (IRNode *)LLVMBuilder->CreateFPCast(Opr, Ty);
     }
     break;

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -742,9 +742,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_sub_ovf_u1.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_b473131\b473131_struct.cmd" >
-             <Issue>643</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_add_ovf_i8.cmd" >
              <Issue>13</Issue>
         </ExcludeList>


### PR DESCRIPTION
Closes #643.

When boxing, pass the size instead of the CorType into the argument helper, so if the box type is a value type we have the size available.

Enable the test that was failing with the assert.