### PR TITLE
Handle cases where the finally lexically precedes the try.

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1655,6 +1655,16 @@ private:
 
   int getElementCountOfSIMDType(CORINFO_CLASS_HANDLE Class) override;
 
+  /// Create the IR for a finally dispatch.
+  ///
+  /// Creates an alloca for the selector variable, and then a load and switch
+  /// on the selector value. The load and switch are not inserted into any
+  /// block. Sets the region's switch to the switch.
+  ///
+  /// \param FinallyRegion         Finally region needing dispatch IR.
+  /// \returns                     Dispatch switch instruction.
+  llvm::SwitchInst *createFinallyDispatch(EHRegion *FinallyRegion);
+
 private:
   LLILCJitContext *JitContext;
   ABIInfo *TheABIInfo;

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -998,7 +998,7 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b85477\b85477.cmd" >
-             <Issue>644</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b13452\b13452.cmd" >
              <Issue>13</Issue>


### PR DESCRIPTION
Closes #644.

Create the finally dispatch IR a bit more flexibly -- either when the reader first sees the endfinally, or first sees a leave.  Otherwise we risk leaving the finally IR dangling outside of any basic block.

The test case now fails because of EH, so reclassify as blocked by issue #13.