### PR TITLE
Resolve issue #635

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -602,7 +602,7 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_468598\Test_HndIndex_10_Reordered.cmd" >
-             <Issue>635</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41002\b41002.cmd" >
              <Issue>13</Issue>
@@ -665,7 +665,7 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\verif\sniff\fg\ver_fg_13.cmd" >
-             <Issue>635</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b49104\b49104.cmd" >
              <Issue>13</Issue>
@@ -749,7 +749,7 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\ceeillegal.cmd" >
-             <Issue>635</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26332\b26332.cmd" >
              <Issue>13</Issue>
@@ -764,7 +764,7 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_468598\Test_HndIndex_10_Plain.cmd" >
-             <Issue>635</Issue>
+             <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26748\b26748.cmd" >
              <Issue>13</Issue>


### PR DESCRIPTION
Closes #635.

All four of the tests excluded for issue #635 throw
exceptions as part of their normal execution.
So change the issue number for these to #13
until LLILC implements catching exceptions.