### PR TITLE
Tolerate integers in mkrefany.

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -703,9 +703,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31784\b31784.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\refanytype1.cmd" >
-             <Issue>641</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59952\b59952.cmd" >
              <Issue>13</Issue>
         </ExcludeList>


### PR DESCRIPTION
Closes #641.

Ecma-335 III.4.19 says the argument to `mkrefany` must be type `&` or `native int`, but it appears traditional that arbitrary ints are allowed. Tolerate this.

Enabled the one blocked test that now passes.