### PR TITLE
Map BasicBlocks to EHRegion nodes

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -956,6 +956,15 @@ bool rgnGetIsLive(EHRegion *EhRegion);
 void rgnSetIsLive(EHRegion *EhRegion, bool Live);
 void rgnSetParent(EHRegion *EhRegion, EHRegion *Parent);
 EHRegion *rgnGetParent(EHRegion *EhRegion);
+/// \brief Determine if this region is lexically outside its parent in the tree
+///
+/// Handler regions are children of the \p try regions they protect in the
+/// region tree, but lexically they come after (not inside) the protected
+/// region.  This routine identifies them.
+///
+/// \param Region   The child region to check against its parent
+/// \returns True iff this region is lexically outside its parent
+bool rgnIsOutsideParent(EHRegion *Region);
 void rgnSetChildList(EHRegion *EhRegion, EHRegionList *Children);
 EHRegionList *rgnGetChildList(EHRegion *EhRegion);
 bool rgnGetHasNonLocalFlow(EHRegion *EhRegion);
@@ -998,23 +1007,6 @@ EHRegion *getFinallyRegion(EHRegion *TryRegion);
 /// \name Client Flow Graph interface
 ///
 ///@{
-
-/// \brief Determine the EH region for this flow graph node
-///
-/// One the EH regions have been created, each flow graph node should have an
-/// innermost containing EH region. This method returns that region.
-///
-/// \param FgNode   The FlowGraphNode of interest.
-/// \returns        Associated EH region.
-EHRegion *fgNodeGetRegion(FlowGraphNode *FgNode);
-
-/// \brief Establish the EH region for this flow graph node
-///
-/// Sets up the association between a FlowGraphNode and and EH Region.
-///
-/// \param FgNode   The FlowGraphNode of interest.
-/// \param EhRegion The EH region to associate.
-void fgNodeSetRegion(FlowGraphNode *FgNode, EHRegion *EhRegion);
 
 /// \brief Obtain a list of the successor edges of a FlowGraphNode
 ///
@@ -1332,6 +1324,7 @@ public:
   // The reader's operand stack. Public because of inlining and debug prints
   ReaderStack *ReaderOperandStack;
 
+  // Used in both first and second pass
   // Public for debug printing
   EHRegion *CurrentRegion;
 
@@ -1684,14 +1677,12 @@ protected:
   ///          that includes \p Offset, if such a region exists; else nullptr.
   EHRegion *getInnerEnclosingRegion(EHRegion *OuterRegion, uint32_t Offset);
 
-private:
-  /// \brief Perform special processing for blocks that start EH regions.
+  /// Process first entry to a region during 1st-pass flow-graph construction
   ///
-  /// Uses the \p CurrentFgNode to determine which block to process. Ensures
-  /// the operand stack and debugger info is in the proper state for blocks
-  /// that start EH regions.
-  void setupBlockForEH();
+  /// \param Region   \p EHRegion being entered
+  virtual void fgEnterRegion(EHRegion *Region) = 0;
 
+private:
   /// \brief Check if this offset is the start of an MSIL instruction.
   ///
   /// Helper used to check whether branch targets and similar are referring
@@ -1960,6 +1951,20 @@ private:
 
   void rgnCreateRegionTree(void);
   void rgnPushRegionChild(EHRegion *Parent, EHRegion *Child);
+
+  /// \brief Process a region transition during 1st-pass flow-graph construction
+  ///
+  /// Does any processing necessary for entering the new region and computes
+  /// the new current region and the MSIL offset where the next region
+  /// transition will occur (in a forward lexical walk).
+  ///
+  /// \param OldRegion   The region that was current before reaching \p Offset
+  /// \param Offset      The new MSIL offset reached in the lexical walk
+  /// \param NextOffset [out] The MSIL offset where the next region transition
+  ///                         after this one will occur (in the lexical walk)
+  /// \returns The innermost \p EHRegion enclosing \p Offset
+  EHRegion *fgSwitchRegion(EHRegion *OldRegion, uint32_t Offset,
+                           uint32_t *NextOffset);
 
 public:
   EHRegion *rgnMakeRegion(ReaderBaseNS::RegionKind Type, EHRegion *Parent,
@@ -2672,6 +2677,10 @@ public:
   virtual uint32_t fgNodeGetEndMSILOffset(FlowGraphNode *Fg) = 0;
   virtual void fgNodeSetEndMSILOffset(FlowGraphNode *FgNode,
                                       uint32_t Offset) = 0;
+  virtual EHRegion *fgNodeGetRegion(FlowGraphNode *FgNode) = 0;
+  virtual void fgNodeSetRegion(FlowGraphNode *FgNode, EHRegion *EhRegion) = 0;
+  virtual void fgNodeChangeRegion(FlowGraphNode *FgNode,
+                                  EHRegion *EhRegion) = 0;
 
   /// \brief Checks whether this node has been visited by an algorithm
   /// traversing the flow graph.
@@ -3093,11 +3102,9 @@ public:
   /// \param PreviousNode  The new node will follow \p PreviousNode in the
   ///                      node list if specified (may be nullptr, in which case
   ///                      the new node will simply be appended)
-  /// \param Region        EHRegion to apply to the new node
   /// \returns The new FlowGraphNode
   virtual FlowGraphNode *makeFlowGraphNode(uint32_t TargetOffset,
-                                           FlowGraphNode *PreviousNode,
-                                           EHRegion *Region) = 0;
+                                           FlowGraphNode *PreviousNode) = 0;
   virtual void markAsEHLabel(IRNode *LabelNode) = 0;
   virtual IRNode *makeTryEndNode(void) = 0;
   virtual IRNode *makeRegionStartNode(ReaderBaseNS::RegionKind RegionType) = 0;

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -1789,66 +1789,6 @@ void ReaderBase::rgnCreateRegionTree(void) {
   EhRegionTree = RegionTreeRoot;
 }
 
-//
-// setupBlockForEH
-//
-// Called from ReaderBase::readBytesForFlowGraphNode to ensure that
-// only exception object is on operand stack on entry to funclet.
-//
-// If GenIR needs a callback whenever a new region is entered, then
-// this is the place to put it.
-//
-// (1) If we are entering a catch, except, or filter region for the first time,
-//     we assert that the stack is empty and push a GenIR'd ExceptionObject.
-// (2) Set a debug sequence point at the start of the an catch/filter/except.
-//
-// This is required since the stack is not empty at these points.
-void ReaderBase::setupBlockForEH() {
-  FlowGraphNode *Fg = CurrentFgNode;
-
-  if (CurrentRegion != nullptr) {
-    rgnSetIsLive(CurrentRegion, true);
-
-    if (isRegionStartBlock(Fg)) {
-      ReaderBaseNS::RegionKind RegionKind = rgnGetRegionType(CurrentRegion);
-      switch (RegionKind) {
-      case ReaderBaseNS::RGN_MCatch:
-      case ReaderBaseNS::RGN_MExcept:
-      case ReaderBaseNS::RGN_Filter:
-
-        // SEQUENCE POINTS: ensure sequence point at eh region start
-        if (needSequencePoints()) {
-          setSequencePoint(fgNodeGetStartMSILOffset(Fg),
-                           ICorDebugInfo::SOURCE_TYPE_INVALID);
-        }
-
-        // If we are currently entering a handler, we must reset the evaluation
-        // stack so that the only item on the stack is the exception object.
-        IRNode *ExceptionObject;
-
-        // Note, for example, that web prop might have dumped something here.
-        // It wouldn't get used anyway so clearing it is no harm.
-        ReaderOperandStack->clearStack();
-
-        // Make the exception object and push it onto the empty stack.
-        ExceptionObject = makeExceptionObject();
-        ReaderOperandStack->push(ExceptionObject);
-        break;
-
-      case ReaderBaseNS::RGN_Try:
-        // Entering a try region, the evaluation stack is required to be empty.
-        if (!ReaderOperandStack->empty()) {
-          BADCODE(MVER_E_TRY_N_EMPTY_STACK);
-        }
-        break;
-      default:
-        // reached
-        break;
-      }
-    }
-  }
-}
-
 void ReaderBase::fgFixRecursiveEdges(FlowGraphNode *HeadBlock) {
   // As a special case, localloc is incompatible with the recursive
   // tail call optimization, and any branches that we initially set up
@@ -1929,8 +1869,7 @@ FlowGraphNodeOffsetList *ReaderBase::fgAddNodeMSILOffset(
   NewElement->setOffset(TargetOffset);
 
   if (*Node == nullptr) {
-    *Node = makeFlowGraphNode(TargetOffset, nullptr,
-                              fgGetRegionFromMSILOffset(TargetOffset));
+    *Node = makeFlowGraphNode(TargetOffset, nullptr);
   }
   NewElement->setNode(*Node);
 
@@ -2212,7 +2151,7 @@ FlowGraphNode *ReaderBase::fgSplitBlock(FlowGraphNode *Block,
   fgNodeSetEndMSILOffset(NewBlock, OldEndOffset);
 
   // Set the EH region
-  fgNodeSetRegion(NewBlock, fgGetRegionFromMSILOffset(CurrentOffset));
+  fgNodeSetRegion(NewBlock, fgNodeGetRegion(Block));
 
   // Init operand stack to nullptr.
   fgNodeSetOperandStack(NewBlock, nullptr);
@@ -2415,18 +2354,6 @@ void ReaderBase::fgInsertEndRegionExceptionNode(
 
       // Insert the EH tuple
       insertEHAnnotationNode(InsertionPointNode, Node);
-
-      // TODO: Rewrite in an appropriate common way.
-
-      // Split the block if necessary.
-      if ((Offset != End) || fgIsExceptRegionStartNode(irNodeGetNext(Node))) {
-        Block = fgSplitBlock(Block, Offset, irNodeGetNext(Node));
-
-        // When two regions begin/End at the same offset this block my have the
-        // wrong region assigned to it. We have to correct for that by
-        // assigning the region of the Ending IR Node to this block.
-        fgNodeSetRegion(Block, irNodeGetRegion(irNodeGetNext(Node)));
-      }
 
       // No need to keep processing blocks!
       break;
@@ -2792,6 +2719,84 @@ EHRegion *getFinallyRegion(EHRegion *TryRegion) {
   return nullptr;
 }
 
+EHRegion *ReaderBase::fgSwitchRegion(EHRegion *OldRegion, uint32_t Offset,
+                                     uint32_t *NextOffset) {
+  uint32_t TransitionOffset = rgnGetEndMSILOffset(OldRegion);
+  if (Offset >= TransitionOffset) {
+    // Exit this region; recursively check parent (may need to exit to ancestor
+    // and/or may need to enter sibling/cousin).
+    assert(Offset == TransitionOffset && "over-stepped region end");
+    EHRegion *ParentRegion = rgnGetParent(OldRegion);
+    if (rgnIsOutsideParent(OldRegion)) {
+      // We want the enclosing ancestor, not the immediate parent.
+      ParentRegion = rgnGetParent(ParentRegion);
+    }
+    return fgSwitchRegion(ParentRegion, Offset, NextOffset);
+  }
+
+  for (EHRegionList *ChildNode = rgnGetChildList(OldRegion); ChildNode;
+       ChildNode = rgnListGetNext(ChildNode)) {
+    EHRegion *ChildRegion = rgnListGetRgn(ChildNode);
+
+    uint32_t ChildStartOffset = rgnGetStartMSILOffset(ChildRegion);
+    if (Offset < ChildStartOffset) {
+      // Haven't reached this child yet; consider it a potential next
+      // transition
+
+      if (ChildStartOffset < TransitionOffset) {
+        TransitionOffset = ChildStartOffset;
+      }
+
+      continue;
+    }
+
+    uint32_t ChildEndOffset = rgnGetEndMSILOffset(ChildRegion);
+
+    if (Offset < ChildEndOffset) {
+      // Enter this region; recursively check it (may need to enter descendant)
+      fgEnterRegion(ChildRegion);
+      return fgSwitchRegion(ChildRegion, Offset, NextOffset);
+    }
+
+    if (rgnGetRegionType(ChildRegion) == ReaderBaseNS::RegionKind::RGN_Try) {
+      // A handler region for the try is a child of it in the tree but follows
+      // it in the IR, so we explicitly have to check for grandchildren in this
+      // case (the current offset falls in the grandchild's range but not the
+      // child's range).
+      for (EHRegionList *GrandchildNode = rgnGetChildList(ChildRegion);
+           GrandchildNode; GrandchildNode = rgnListGetNext(GrandchildNode)) {
+
+        EHRegion *Grandchild = rgnListGetRgn(GrandchildNode);
+
+        uint32_t GrandchildStartOffset = rgnGetStartMSILOffset(Grandchild);
+        if (Offset < GrandchildStartOffset) {
+          // Haven't reached this child yet; consider it a potential next
+          // transition
+
+          if (GrandchildStartOffset < TransitionOffset) {
+            TransitionOffset = GrandchildStartOffset;
+          }
+
+          continue;
+        }
+
+        uint32_t GrandchildEndOffset = rgnGetEndMSILOffset(Grandchild);
+
+        if (Offset < GrandchildEndOffset) {
+          // Recursively check this region (it may need to enter a descendant).
+          // Don't call fgEnterRegion here, since we already processed the
+          // region entry for this try when we visited it the first time.
+          return fgSwitchRegion(Grandchild, Offset, NextOffset);
+        }
+      }
+    }
+  }
+
+  // Not exiting OldRegion or entering child; just report the transition offset
+  *NextOffset = TransitionOffset;
+  return OldRegion;
+}
+
 #define CHECKTARGET(TargetOffset, BufSize)                                     \
   {                                                                            \
     if ((TargetOffset) < 0 || (TargetOffset) >= (BufSize))                     \
@@ -2810,6 +2815,7 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
   IRNode *BranchNode, *BlockNode, *TheExitLabel;
   FlowGraphNode *GraphNode;
   uint32_t CurrentOffset, BranchOffset, TargetOffset, NextOffset, NumCases;
+  uint32_t NextRegionTransitionOffset;
   bool IsShortInstr, IsConditional, IsTailCall, IsReadOnly, PreviousWasPrefix;
   bool LoadFtnToken;
   mdToken TokenConstrained;
@@ -2846,10 +2852,25 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
   LoadFtnToken = false;
   BranchesToVerify = nullptr;
   HasLocAlloc = false;
-  NextOffset = CurrentOffset = 0;
+  NextRegionTransitionOffset = NextOffset = CurrentOffset = 0;
 
   // Keep going through the buffer of bytecodes until we get to the end.
   while (CurrentOffset < ILInputSize) {
+    if ((EhRegionTree != nullptr) &&
+        (CurrentOffset == NextRegionTransitionOffset)) {
+
+      CurrentRegion = fgSwitchRegion(CurrentRegion, CurrentOffset,
+                                     &NextRegionTransitionOffset);
+
+      if (fgNodeGetStartMSILOffset(Block) != CurrentOffset) {
+        // Split the block so we can maintain a many-to-one block-to-region
+        // mapping.
+        Block = fgSplitBlock(Block, CurrentOffset, nullptr);
+      }
+      // Update the region on the current block (it will have inherited the
+      // previous block's region when it was split off from it).
+      fgNodeChangeRegion(Block, CurrentRegion);
+    }
     uint8_t *Operand;
     NextOffset = parseILOpcode(ILInput, CurrentOffset, ILInputSize, this,
                                &Opcode, &Operand);
@@ -3033,7 +3054,7 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
     case ReaderBaseNS::CEE_JMP:
       fgNodeSetEndMSILOffset(Block, NextOffset);
       if (NextOffset < ILInputSize) {
-        Block = makeFlowGraphNode(NextOffset, Block, nullptr);
+        Block = makeFlowGraphNode(NextOffset, Block);
       }
       break;
 
@@ -3041,7 +3062,7 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
       verifyReturnFlow(CurrentOffset);
       fgNodeSetEndMSILOffset(Block, NextOffset);
       if (NextOffset < ILInputSize) {
-        Block = makeFlowGraphNode(NextOffset, Block, nullptr);
+        Block = makeFlowGraphNode(NextOffset, Block);
       }
       break;
 
@@ -3348,8 +3369,9 @@ FlowGraphNode *ReaderBase::fgBuildBasicBlocksFromBytes(uint8_t *Buffer,
   FlowGraphNode *Block;
 
   // Initialize head block to root region.
+  CurrentRegion = EhRegionTree;
   Block = fgGetHeadBlock();
-  fgNodeSetRegion(Block, fgGetRegionFromMSILOffset(0));
+  fgNodeSetRegion(Block, CurrentRegion);
 
   // PRE-PHASE
   Block = fgPrePhase(Block);
@@ -7750,10 +7772,6 @@ void ReaderBase::readBytesForFlowGraphNode(FlowGraphNode *Fg,
            isOffsetInstrStart(TheParam.CurrentOffset));
 
   beginFlowGraphNode(Fg, TheParam.CurrentOffset, IsVerifyOnly);
-
-  if (!IsVerifyOnly) {
-    setupBlockForEH();
-  }
 
   PAL_TRY(ReadBytesForFlowGraphNodeHelperParam *, Param, &TheParam) {
     Param->This->readBytesForFlowGraphNodeHelper(Param);


### PR DESCRIPTION
Create a Block -> Region map in the first pass by paying attention to
region boundaries as we advance through the IL, and maintain it as new
blocks are added in the second pass by preserving it when splitting blocks
and such.

Expand the EHRegion struct to include fields that will be useful for
building EH flow.

Remove the setupBlockForEH method that is now superfluous.

Add a stub EnterRegion method to GenIR; this is where landing/EH pads will
be generated as the EH implementation comes online.