### PR TITLE
Make float to int conversion more determined.

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -940,9 +940,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\isinst_catch.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b05617\b05617.cmd" >
-             <Issue>808</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b84909\b84909.cmd" >
              <Issue>13</Issue>
         </ExcludeList>


### PR DESCRIPTION
The ECMA-335 spec says that for unchecked floating point to
integer conversion, that if there is overflow then the result
is unspecified. However for compatibility with other jits
we make the result more deterministic. If the target
bit size is less than 64 we first convert to i64 where overflow
is less likely. Then we truncate to the target bit size.

Closes #808 and allows test
\JIT\Regression\CLR-x86-JIT\V1-M10\b05617\b05617.cmd
to pass.