### PR TITLE
Implement llilc support for ReadyToRun.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ endif()
 
 add_definitions( -D_GNU_SOURCE )
 add_definitions( -DFEATURE_CORECLR )
+add_definitions( -DFEATURE_READYTORUN_COMPILER )
 
 if (UNIX)
   link_directories("${WITH_CORECLR_ABS}")

--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -735,6 +735,12 @@ public:
   /// \returns      Specified client IR, or nullptr if none.
   IRNode *getTypeContextNode();
 
+  /// Get the client IR for the type context when compiling in ReadyToRun mode.
+  /// \param Token Method or class token.
+  /// \param CompileHandle Method or class handle.
+  /// \returns      Specified client IR.
+  IRNode *getReadyToRunTypeContextNode(mdToken Token, void *CompileHandle);
+
   /// \brief Modify the \p this parameter as necessary at the call site.
   ///
   /// Certain calls may require indirection or boxing to obtain the proper
@@ -2311,14 +2317,25 @@ private:
   void rdrMakeCallTargetNode(ReaderCallTargetData *CallTargetData,
                              IRNode **ThisPointer);
 
-  IRNode *rdrMakeLdFtnTargetNode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
-                                 CORINFO_CALL_INFO *CallInfo);
-
   IRNode *rdrGetDirectCallTarget(ReaderCallTargetData *CallTargetData);
 
+  /// \brief Generate IR for getting the target of a direct call. "Direct call"
+  /// can either be a true direct call if the runtime allows, or it can be an
+  /// indirect call through the method descriptor.
+  ///
+  /// \param Method            Method handle.
+  /// \param MethodToken       Method token.
+  /// \param CodePointerLookup Info to get the address to call in ReadyToRun
+  ///                          mode.
+  /// \param NeedsNullCheck    True iff 'this' pointer is not guaranteed to be
+  ///                          non-null.
+  /// \param CanMakeDirectCall True iff a true direct call can be generated.
+  ///
+  /// \returns An \p IRNode that represents the target of the direct call.
   IRNode *rdrGetDirectCallTarget(CORINFO_METHOD_HANDLE Method,
-                                 mdToken MethodToken, bool NeedsNullCheck,
-                                 bool CanMakeDirectCall);
+                                 mdToken MethodToken,
+                                 CORINFO_LOOKUP CodePointerLookup,
+                                 bool NeedsNullCheck, bool CanMakeDirectCall);
   IRNode *
   rdrGetCodePointerLookupCallTarget(ReaderCallTargetData *CallTargetData);
 
@@ -2367,6 +2384,9 @@ public:
   IRNode *rdrCallGetStaticBase(CORINFO_CLASS_HANDLE Class, mdToken ClassToken,
                                CorInfoHelpFunc HelperId, bool NoCtor,
                                bool CanMoveUp, IRNode *Dst);
+
+  IRNode *rdrMakeLdFtnTargetNode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
+                                 CORINFO_CALL_INFO *CallInfo);
 
 public:
   // //////////////////////////////////////////////////////////////////////////
@@ -2810,6 +2830,9 @@ public:
   virtual IRNode *loadVirtFunc(IRNode *Arg1,
                                CORINFO_RESOLVED_TOKEN *ResolvedToken,
                                CORINFO_CALL_INFO *CallInfo) = 0;
+  virtual IRNode *
+  getReadyToRunVirtFuncPtr(IRNode *Arg1, CORINFO_RESOLVED_TOKEN *ResolvedToken,
+                           CORINFO_CALL_INFO *CallInfo) = 0;
   virtual IRNode *loadPrimitiveType(IRNode *Address, CorInfoType CorType,
                                     ReaderAlignType Alignment, bool IsVolatile,
                                     bool IsInterfConst,
@@ -3190,7 +3213,23 @@ public:
 
   virtual bool canMakeDirectCall(ReaderCallTargetData *CallTargetData) = 0;
 
-  // Generate call to helper
+  /// \brief Generate call to a helper.
+  ///
+  /// \param HelperID        Helper ID.
+  /// \param MayThrow        True iff this helper may throw.
+  /// \param Dst             Destination node.
+  /// \param Arg1            First helper argument.
+  /// \param Arg2            Second helper argument.
+  /// \param Arg3            Third helper argument.
+  /// \param Arg4            Fourth helper argument.
+  /// \param Alignment       Memory alignment for helpers that care about it.
+  /// \param IsVolatile      True iff the operation performed by the helper is
+  ///                        volatile.
+  /// \param NoCtor          True if the operation definitely will NOT invoke
+  ///                        the static constructor.
+  /// \param CanMoveUp       True iff the call may be moved up out of loops.
+  ///
+  /// \returns An \p IRNode that represents the result of the helper call.
   virtual IRNode *callHelper(CorInfoHelpFunc HelperID, bool MayThrow,
                              IRNode *Dst, IRNode *Arg1 = nullptr,
                              IRNode *Arg2 = nullptr, IRNode *Arg3 = nullptr,
@@ -3198,6 +3237,57 @@ public:
                              ReaderAlignType Alignment = Reader_AlignUnknown,
                              bool IsVolatile = false, bool NoCtor = false,
                              bool CanMoveUp = false) = 0;
+
+  /// \brief Generate call to a helper.
+  ///
+  /// \param HelperID        Helper ID.
+  /// \param HelperAddress   Address of the helper.
+  /// \param MayThrow        True iff this helper may throw.
+  /// \param Dst             Destination node.
+  /// \param Arg1            First helper argument.
+  /// \param Arg2            Second helper argument.
+  /// \param Arg3            Third helper argument.
+  /// \param Arg4            Fourth helper argument.
+  /// \param Alignment       Memory alignment for helpers that care about it.
+  /// \param IsVolatile      True iff the operation performed by the helper is
+  ///                        volatile.
+  /// \param NoCtor          True if the operation definitely will NOT invoke
+  ///                        the static constructor.
+  /// \param CanMoveUp       True iff the call may be moved up out of loops.
+  ///
+  /// \returns An \p IRNode that represents the result of the helper call.
+  virtual IRNode *callHelper(CorInfoHelpFunc HelperID, IRNode *HelperAddress,
+                             bool MayThrow, IRNode *Dst, IRNode *Arg1 = nullptr,
+                             IRNode *Arg2 = nullptr, IRNode *Arg3 = nullptr,
+                             IRNode *Arg4 = nullptr,
+                             ReaderAlignType Alignment = Reader_AlignUnknown,
+                             bool IsVolatile = false, bool NoCtor = false,
+                             bool CanMoveUp = false) = 0;
+
+  /// \brief Generate call to a ReadyToRun helper.
+  ///
+  /// \param HelperID        Helper ID.
+  /// \param MayThrow        True iff this helper may throw.
+  /// \param Dst             Destination node.
+  /// \param ResolvedToken   Token corresponding to the helper.
+  /// \param Arg1            First helper argument.
+  /// \param Arg2            Second helper argument.
+  /// \param Arg3            Third helper argument.
+  /// \param Arg4            Fourth helper argument.
+  /// \param Alignment       Memory alignment for helpers that care about it.
+  /// \param IsVolatile      True iff the operation performed by the helper is
+  ///                        volatile.
+  /// \param NoCtor          True if the operation definitely will NOT invoke
+  ///                        the static constructor.
+  /// \param CanMoveUp       True iff the call may be moved up out of loops.
+  ///
+  /// \returns An \p IRNode that represents the result of the helper call.
+  virtual IRNode *callReadyToRunHelper(
+      CorInfoHelpFunc HelperID, bool MayThrow, IRNode *Dst,
+      CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1 = nullptr,
+      IRNode *Arg2 = nullptr, IRNode *Arg3 = nullptr, IRNode *Arg4 = nullptr,
+      ReaderAlignType Alignment = Reader_AlignUnknown, bool IsVolatile = false,
+      bool NoCtor = false, bool CanMoveUp = false) = 0;
 
   // Generate special generics helper that might need to insert flow
   virtual IRNode *callRuntimeHandleHelper(CorInfoHelpFunc Helper, IRNode *Arg1,
@@ -3234,6 +3324,18 @@ public:
                                      CORINFO_RESOLVED_TOKEN *ResolvedToken,
                                      CORINFO_FIELD_INFO *FieldInfo) = 0;
 
+  /// \brief Convert handle into an \p IRNode.
+  ///
+  /// \param Token           Token corresponding to the handle.
+  /// \param EmbedHandle     Handle to convert.
+  /// \param RealHandle      Optional compile-time handle.
+  /// \param IsIndirect      True iff the handle represents an indirection.
+  /// \param IsReadonly      True iff the handle represent a read-only value.
+  /// \param IsRelocatable   True iff the handle is relocatable.
+  /// \param IsCallTarget    True iff the handle represents a call target.
+  /// \param IsFrozenObject  True iff the handle represents a frozen object.
+  ///
+  /// \returns An \p IRNode corresponding to the handle.
   virtual IRNode *handleToIRNode(mdToken Token, void *EmbedHandle,
                                  void *RealHandle, bool IsIndirect,
                                  bool IsReadOnly, bool IsRelocatable,
@@ -3297,6 +3399,18 @@ public:
   // Used to expand multidimensional array access intrinsics
   virtual bool arrayGet(CORINFO_SIG_INFO *Sig, IRNode **RetVal) = 0;
   virtual bool arraySet(CORINFO_SIG_INFO *Sig) = 0;
+
+  /// \brief Copy struct pointed to by Src to Dst address. The struct may have
+  //  GC pointers so copying may involve write barriers.
+  ///
+  /// \param Class Struct's class handle.
+  /// \param Dst Destination address.
+  /// \param Src Source address.
+  /// \param Alignment.
+  /// \returns The class handle that corresponds to the type of the node.
+  virtual void copyStruct(CORINFO_CLASS_HANDLE Class, IRNode *Dst, IRNode *Src,
+                          ReaderAlignType Alignment, bool IsVolatile,
+                          bool IsUnchecked) = 0;
 
 #if !defined(NDEBUG)
   virtual void dbDumpFunction(void) = 0;

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -424,6 +424,10 @@ public:
   IRNode *loadVirtFunc(IRNode *Arg1, CORINFO_RESOLVED_TOKEN *ResolvedToken,
                        CORINFO_CALL_INFO *CallInfo) override;
 
+  IRNode *getReadyToRunVirtFuncPtr(IRNode *Arg1,
+                                   CORINFO_RESOLVED_TOKEN *ResolvedToken,
+                                   CORINFO_CALL_INFO *CallInfo) override;
+
   IRNode *loadPrimitiveType(IRNode *Addr, CorInfoType CorInfoType,
                             ReaderAlignType Alignment, bool IsVolatile,
                             bool IsInterfConst,
@@ -770,7 +774,40 @@ public:
                      bool IsVolatile = false, bool NoCtor = false,
                      bool CanMoveUp = false) override;
 
-  // Generate call to helper
+  IRNode *callHelper(CorInfoHelpFunc HelperID, IRNode *HelperAddress,
+                     bool MayThrow, IRNode *Dst, IRNode *Arg1 = nullptr,
+                     IRNode *Arg2 = nullptr, IRNode *Arg3 = nullptr,
+                     IRNode *Arg4 = nullptr,
+                     ReaderAlignType Alignment = Reader_AlignUnknown,
+                     bool IsVolatile = false, bool NoCtor = false,
+                     bool CanMoveUp = false) override;
+
+  IRNode *callReadyToRunHelper(CorInfoHelpFunc HelperID, bool MayThrow,
+                               IRNode *Dst,
+                               CORINFO_RESOLVED_TOKEN *pResolvedToken,
+                               IRNode *Arg1 = nullptr, IRNode *Arg2 = nullptr,
+                               IRNode *Arg3 = nullptr, IRNode *Arg4 = nullptr,
+                               ReaderAlignType Alignment = Reader_AlignUnknown,
+                               bool IsVolatile = false, bool NoCtor = false,
+                               bool CanMoveUp = false) override;
+
+  /// \brief Generate call to a helper.
+  ///
+  /// \param HelperID        Helper ID.
+  /// \param MayThrow        True iff this helper may throw.
+  /// \param ReturnType      Return type.
+  /// \param Arg1            First helper argument.
+  /// \param Arg2            Second helper argument.
+  /// \param Arg3            Third helper argument.
+  /// \param Arg4            Fourth helper argument.
+  /// \param Alignment       Memory alignment for helpers that care about it.
+  /// \param IsVolatile      True iff the operation performed by the helper is
+  ///                        volatile.
+  /// \param NoCtor          True if the operation definitely will NOT invoke
+  ///                        the static constructor.
+  /// \param CanMoveUp       True iff the call may be moved up out of loops.
+  ///
+  /// \returns An \p CallSite corresponding to the helper call.
   llvm::CallSite callHelperImpl(CorInfoHelpFunc HelperID, bool MayThrow,
                                 llvm::Type *ReturnType, IRNode *Arg1 = nullptr,
                                 IRNode *Arg2 = nullptr, IRNode *Arg3 = nullptr,
@@ -778,6 +815,57 @@ public:
                                 ReaderAlignType Alignment = Reader_AlignUnknown,
                                 bool IsVolatile = false, bool NoCtor = false,
                                 bool CanMoveUp = false);
+
+  /// \brief Generate call to a helper.
+  ///
+  /// \param HelperID        Helper ID.
+  /// \param HelperAddress   Address of the helper.
+  /// \param MayThrow        True iff this helper may throw.
+  /// \param ReturnType      Return type.
+  /// \param Arg1            First helper argument.
+  /// \param Arg2            Second helper argument.
+  /// \param Arg3            Third helper argument.
+  /// \param Arg4            Fourth helper argument.
+  /// \param Alignment       Memory alignment for helpers that care about it.
+  /// \param IsVolatile      True iff the operation performed by the helper is
+  ///                        volatile.
+  /// \param NoCtor          True if the operation definitely will NOT invoke
+  ///                        the static constructor.
+  /// \param CanMoveUp       True iff the call may be moved up out of loops.
+  ///
+  /// \returns An \p CallSite corresponding to the helper call.
+  llvm::CallSite callHelperImpl(CorInfoHelpFunc HelperID, IRNode *HelperAddress,
+                                bool MayThrow, llvm::Type *ReturnType,
+                                IRNode *Arg1 = nullptr, IRNode *Arg2 = nullptr,
+                                IRNode *Arg3 = nullptr, IRNode *Arg4 = nullptr,
+                                ReaderAlignType Alignment = Reader_AlignUnknown,
+                                bool IsVolatile = false, bool NoCtor = false,
+                                bool CanMoveUp = false);
+
+  /// \brief Generate call to a ReadyToRun helper.
+  ///
+  /// \param HelperID        Helper ID.
+  /// \param MayThrow        True iff this helper may throw.
+  /// \param ReturnType      Return type.
+  /// \param ResolvedToken   Token corresponding to the helper.
+  /// \param Arg1            First helper argument.
+  /// \param Arg2            Second helper argument.
+  /// \param Arg3            Third helper argument.
+  /// \param Arg4            Fourth helper argument.
+  /// \param Alignment       Memory alignment for helpers that care about it.
+  /// \param IsVolatile      True iff the operation performed by the helper is
+  ///                        volatile.
+  /// \param NoCtor          True if the operation definitely will NOT invoke
+  ///                        the static constructor.
+  /// \param CanMoveUp       True iff the call may be moved up out of loops.
+  ///
+  /// \returns An \p CallSite corresponding to the helper call.
+  llvm::CallSite callReadyToRunHelperImpl(
+      CorInfoHelpFunc HelperID, bool MayThrow, llvm::Type *ReturnType,
+      CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg1 = nullptr,
+      IRNode *Arg2 = nullptr, IRNode *Arg3 = nullptr, IRNode *Arg4 = nullptr,
+      ReaderAlignType Alignment = Reader_AlignUnknown, bool IsVolatile = false,
+      bool NoCtor = false, bool CanMoveUp = false);
 
   /// Generate special generics helper that might need to insert flow. The
   /// helper is called if NullCheckArg is null at compile-time or if it
@@ -818,10 +906,37 @@ public:
 
   IRNode *getHelperCallAddress(CorInfoHelpFunc HelperId) override;
 
+  /// \brief Get address of a ReadyToRun helper.
+  ///
+  /// \param HelperID        Helper ID.
+  /// \param ResolvedToken   Token corresponding to the helper.
+  ///
+  /// \returns An \p IRNode corresponding to the helper address.
+  IRNode *getReadyToRunHelperCallAddress(CorInfoHelpFunc HelperID,
+                                         CORINFO_RESOLVED_TOKEN *ResolvedToken);
+
   IRNode *handleToIRNode(mdToken Token, void *EmbedHandle, void *RealHandle,
                          bool IsIndirect, bool IsReadOnly, bool IsRelocatable,
                          bool IsCallTarget,
                          bool IsFrozenObject = false) override;
+
+  /// \brief Convert handle into an \p IRNode.
+  ///
+  /// \param HandleName      Name to use for the GlobalVariable corresponding
+  ///                        to a relocatable handle.
+  /// \param EmbedHandle     Handle to convert.
+  /// \param RealHandle      Optional compile-time handle.
+  /// \param IsIndirect      True iff the handle represents an indirection.
+  /// \param IsReadonly      True iff the handle represent a read-only value.
+  /// \param IsRelocatable   True iff the handle is relocatable.
+  /// \param IsCallTarget    True iff the handle represents a call target.
+  /// \param IsFrozenObject  True iff the handle represents a frozen object.
+  ///
+  /// \returns An \p IRNode corresponding to the handle.
+  IRNode *handleToIRNode(const std::string &HandleName, void *EmbedHandle,
+                         void *RealHandle, bool IsIndirect, bool IsReadOnly,
+                         bool IsRelocatable, bool IsCallTarget,
+                         bool IsFrozenObject = false);
 
   /// Generate a name for the given token, handle, context and scope. The names
   /// generated by this method are used for GlobalVariables corresponding to the
@@ -1495,15 +1610,21 @@ private:
   void zeroInitBlock(llvm::Value *Address, llvm::Value *Size);
 
   /// Copy an instance of a struct from SourceAddress to DestinationAddress.
+  /// Copying is done without write barriers.
   ///
   /// \param StructTy Type of the struct.
   /// \param DestinationAddress Address to copy to.
   /// \param SourceAddress Address to copy from.
   /// \param IsVolatile true iff copy is volatile.
   /// \param Alignment Alignment of the copy.
-  void copyStruct(llvm::Type *StructTy, llvm::Value *DestinationAddress,
-                  llvm::Value *SourceAddress, bool IsVolatile,
-                  ReaderAlignType Alignment = Reader_AlignNatural);
+  void copyStructNoBarrier(llvm::Type *StructTy,
+                           llvm::Value *DestinationAddress,
+                           llvm::Value *SourceAddress, bool IsVolatile,
+                           ReaderAlignType Alignment = Reader_AlignNatural);
+
+  void copyStruct(CORINFO_CLASS_HANDLE Class, IRNode *Dst, IRNode *Src,
+                  ReaderAlignType Alignment, bool IsVolatile,
+                  bool IsUnchecked) override;
 
   /// Check if this value represents a struct.
   ///

--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -418,7 +418,7 @@ Value *ABICallSignature::emitCall(GenIR &Reader, Value *Target, bool MayThrow,
           ArgumentTypes[I] = ArgType;
           Temp = Reader.createTemporary(ArgStructTy);
           const bool IsVolatile = false;
-          Reader.copyStruct(ArgStructTy, Temp, Arg, IsVolatile);
+          Reader.copyStructNoBarrier(ArgStructTy, Temp, Arg, IsVolatile);
         } else {
           ArgumentTypes[I] = ArgType->getPointerTo();
           Temp = Reader.createTemporary(ArgType);

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -615,7 +615,7 @@ GCLayout *ReaderBase::getClassGCLayout(CORINFO_CLASS_HANDLE Class) {
   const uint32_t ClassSize = JitInfo->getClassSize(Class);
   const uint32_t GcLayoutSize = ((ClassSize + PointerSize - 1) / PointerSize);
 
-  // Our internal data strcutures prepend the number of GC pointers
+  // Our internal data structures prepend the number of GC pointers
   // before the struct.  Therefore we add the size of the
   // GCLAYOUT_STRUCT to our computed size above.
   GCLayout *GCLayoutInfo =
@@ -785,6 +785,14 @@ ReaderBase::getFieldInClass(CORINFO_CLASS_HANDLE Class, uint32_t Ordinal) {
 void ReaderBase::getFieldInfo(CORINFO_RESOLVED_TOKEN *ResolvedToken,
                               CORINFO_ACCESS_FLAGS AccessFlags,
                               CORINFO_FIELD_INFO *FieldInfo) {
+  if (Flags & CORJIT_FLG_READYTORUN) {
+    // CORINFO_ACCESS_ATYPICAL_CALLSITE means that we can't guarantee
+    // that we'll be able to generate call [rel32] form of the helper call so
+    // crossgen shouldn't try to disassemble the call instruction.
+    AccessFlags =
+        (CORINFO_ACCESS_FLAGS)(AccessFlags | CORINFO_ACCESS_ATYPICAL_CALLSITE);
+  }
+
   JitInfo->getFieldInfo(ResolvedToken, getCurrentMethodHandle(), AccessFlags,
                         FieldInfo);
 }
@@ -1095,6 +1103,14 @@ void ReaderBase::getCallInfo(CORINFO_RESOLVED_TOKEN *ResolvedToken,
   Flags = (CORINFO_CALLINFO_FLAGS)(Flags | CORINFO_CALLINFO_SECURITYCHECKS);
   if (VerificationNeeded)
     Flags = (CORINFO_CALLINFO_FLAGS)(Flags | CORINFO_CALLINFO_VERIFICATION);
+
+  if (this->Flags & CORJIT_FLG_READYTORUN) {
+    // CORINFO_ACCESS_ATYPICAL_CALLSITE means that we can't guarantee
+    // that we'll be able to generate call [rel32] form so crossgen shouldn't
+    // try to disassemble the call instruction.
+    Flags =
+        (CORINFO_CALLINFO_FLAGS)(Flags | CORINFO_CALLINFO_ATYPICAL_CALLSITE);
+  }
 
   JitInfo->getCallInfo(ResolvedToken, ConstrainedResolvedToken, Caller, Flags,
                        Result);
@@ -3672,7 +3688,11 @@ IRNode *ReaderBase::box(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Arg2,
 // CastClass - Generate a simple helper call for the cast class.
 IRNode *ReaderBase::castClass(CORINFO_RESOLVED_TOKEN *ResolvedToken,
                               IRNode *ObjRefNode) {
-  CorInfoHelpFunc HelperId = JitInfo->getCastingHelper(ResolvedToken, true);
+  const bool IsThrowing = true;
+  CorInfoHelpFunc HelperId =
+      (Flags & CORJIT_FLG_READYTORUN)
+          ? CORINFO_HELP_READYTORUN_CHKCAST
+          : JitInfo->getCastingHelper(ResolvedToken, IsThrowing);
 
   return castOp(ResolvedToken, ObjRefNode, HelperId);
 }
@@ -3680,7 +3700,11 @@ IRNode *ReaderBase::castClass(CORINFO_RESOLVED_TOKEN *ResolvedToken,
 // IsInst - Default reader processing of CEE_ISINST.
 IRNode *ReaderBase::isInst(CORINFO_RESOLVED_TOKEN *ResolvedToken,
                            IRNode *ObjRefNode) {
-  CorInfoHelpFunc HelperId = JitInfo->getCastingHelper(ResolvedToken, false);
+  const bool IsThrowing = false;
+  CorInfoHelpFunc HelperId =
+      (Flags & CORJIT_FLG_READYTORUN)
+          ? CORINFO_HELP_READYTORUN_ISINSTANCEOF
+          : JitInfo->getCastingHelper(ResolvedToken, IsThrowing);
 
   return castOp(ResolvedToken, ObjRefNode, HelperId);
 }
@@ -3914,6 +3938,17 @@ void ReaderBase::insertClassConstructor() {
 
     // Record that this block initialized the class.
     domInfoRecordClassInit(CurrentFgNode, Class);
+
+    if (Flags & CORJIT_FLG_READYTORUN) {
+      CORINFO_RESOLVED_TOKEN ResolvedToken;
+      memset(&ResolvedToken, 0, sizeof(ResolvedToken));
+      ResolvedToken.hClass = Class;
+      const bool MayThrow = false;
+      IRNode *Dst = nullptr;
+      callReadyToRunHelper(CORINFO_HELP_READYTORUN_STATIC_BASE, MayThrow, Dst,
+                           &ResolvedToken);
+      return;
+    }
 
     // Use the shared static base helper as it is faster than InitClass
     CorInfoHelpFunc HelperId = getSharedCCtorHelper(Class);
@@ -4174,28 +4209,7 @@ void ReaderBase::rdrCallWriteBarrierHelper(
       Class = ResolvedToken->hClass;
     }
 
-    if (classHasGCPointers(Class)) {
-      // We are able to speed up perf with shared methods
-      // by using the representative class handle (getClassHandle(Token))
-      // rather than the exact class handle (genericTokenToNode(Token)).
-      //
-      // For the purposes of the write barrier helper, the gclayout should
-      // be the same for both representative and exact class handles.
-      bool IsIndirect;
-      void *ClassHandle = embedClassHandle(Class, &IsIndirect);
-
-      IRNode *ClassHandleNode =
-          handleToIRNode(ResolvedToken->token, ClassHandle, Class, IsIndirect,
-                         IsIndirect, true, false);
-
-      const bool MayThrow = true;
-      callHelper(CORINFO_HELP_ASSIGN_STRUCT, MayThrow, nullptr, Dst, Src,
-                 ClassHandleNode, nullptr, Alignment, IsVolatile);
-    } else {
-      // If the class doesn't have a gc layout then use a memcopy
-      IRNode *Size = loadConstantI4(getClassSize(Class));
-      cpBlk(Size, Src, Dst, Alignment, IsVolatile);
-    }
+    copyStruct(Class, Dst, Src, Alignment, IsVolatile, IsUnchecked);
   }
 }
 
@@ -4306,7 +4320,8 @@ ReaderBase::rdrGetStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
           HelperId == CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE_NOCTOR ||
           HelperId == CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_DYNAMICCLASS ||
           HelperId ==
-              CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE_DYNAMICCLASS);
+              CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE_DYNAMICCLASS ||
+          HelperId == CORINFO_HELP_READYTORUN_STATIC_BASE);
 
       // If possible, use the result of a previous sharedStaticBase call.
       // This will possibly switch the HelperId to a NoCtor version
@@ -4324,9 +4339,8 @@ ReaderBase::rdrGetStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
             HelperId == CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE_DYNAMICCLASS ||
             HelperId == CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE ||
             HelperId == CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_NOCTOR ||
-            HelperId == CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_DYNAMICCLASS)
-
-        {
+            HelperId ==
+                CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_DYNAMICCLASS) {
           // Again, we happen to know that the results of these helper
           // calls should be interpreted as interior GC pointers.
           SharedStaticsBaseNode = makePtrNode(Reader_PtrGcInterior);
@@ -4352,13 +4366,31 @@ ReaderBase::rdrGetStaticFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
         // Record that this block initialized class typeRef.
         domInfoRecordClassInit(CurrentFgNode, Class);
 
-        // Call helper under rdrCallGetStaticBase uses dst operand
-        // to infer type for the call instruction.
-        // Ideally, we should pass the type, which needs refactoring.
-        // So, SharedStaticsBaseNode now becomes the defined instruction.
-        SharedStaticsBaseNode =
-            rdrCallGetStaticBase(Class, ResolvedToken->token, HelperId, NoCtor,
-                                 CanMoveUp, SharedStaticsBaseNode);
+        if (Flags & CORJIT_FLG_READYTORUN) {
+          assert(HelperId == CORINFO_HELP_READYTORUN_STATIC_BASE);
+          InfoAccessType AccessType = FieldInfo->fieldLookup.accessType;
+          void *Address = FieldInfo->fieldLookup.addr;
+          assert(Address != nullptr);
+          assert(AccessType != IAT_PPVALUE);
+          bool IsIndirect = (AccessType != IAT_VALUE);
+          const bool IsRelocatable = true;
+          const bool IsCallTarget = false;
+          void *RealHandle = nullptr;
+          IRNode *HelperAddress = handleToIRNode(
+              ResolvedToken->token, Address, RealHandle, IsIndirect, IsIndirect,
+              IsRelocatable, IsCallTarget);
+          const bool MayThrow = false;
+          SharedStaticsBaseNode = callHelper(HelperId, HelperAddress, MayThrow,
+                                             SharedStaticsBaseNode);
+        } else {
+          // Call helper under rdrCallGetStaticBase uses dst operand
+          // to infer type for the call instruction.
+          // Ideally, we should pass the type, which needs refactoring.
+          // So, SharedStaticsBaseNode now becomes the defined instruction.
+          SharedStaticsBaseNode =
+              rdrCallGetStaticBase(Class, ResolvedToken->token, HelperId,
+                                   NoCtor, CanMoveUp, SharedStaticsBaseNode);
+        }
 
         // Record (def) instruction that holds shared statics base
         domInfoRecordSharedStaticBaseDefine(CurrentFgNode, HelperId, Class,
@@ -4518,7 +4550,8 @@ IRNode *ReaderBase::rdrGetFieldAddress(CORINFO_RESOLVED_TOKEN *ResolvedToken,
 
   handleMemberAccess(FieldInfo->accessAllowed, FieldInfo->accessCalloutHelper);
 
-  if (FieldInfo->fieldAccessor != CORINFO_FIELD_INSTANCE) {
+  if ((FieldInfo->fieldAccessor != CORINFO_FIELD_INSTANCE) &&
+      (FieldInfo->fieldAccessor != CORINFO_FIELD_INSTANCE_WITH_BASE)) {
     // Need to generate a helper call to get the address.
     // the helper calls do an explicit null check
     IRNode *Arg1, *Arg2, *Dst;
@@ -5050,41 +5083,47 @@ ReaderBase::rdrCall(ReaderCallTargetData *Data, ReaderBaseNS::CallOpcode Opcode,
           }
 #endif // FEATURE_CORECLR
 
-          CORINFO_METHOD_HANDLE AlternateCtor = nullptr;
+          // TODO: In ReadyToRun mode this optimization is available for
+          // non-virtual function pointers only for now. It can be implemented
+          // via CORINFO_HELP_READYTORUN_DELEGATE_CTOR helper.
 
-          DelegateCtorArgs *CtorData =
-              (DelegateCtorArgs *)getTempMemory(sizeof(DelegateCtorArgs));
-          memset(CtorData, 0, sizeof(DelegateCtorArgs)); // zero out the struct
-          CtorData->pMethod = getCurrentMethodHandle();
+          if (!(Flags & CORJIT_FLG_READYTORUN)) {
+            CORINFO_METHOD_HANDLE AlternateCtor = nullptr;
 
-          AlternateCtor =
-              JitInfo->GetDelegateCtor(Method, Class, TargetMethod, CtorData);
+            DelegateCtorArgs *CtorData =
+                (DelegateCtorArgs *)getTempMemory(sizeof(DelegateCtorArgs));
+            memset(CtorData, 0, sizeof(DelegateCtorArgs));
+            CtorData->pMethod = getCurrentMethodHandle();
 
-          if (AlternateCtor != Method) {
-            // TODO: Ideally we would like the JIT to inline this alternate
-            // ctor method
+            AlternateCtor =
+                JitInfo->GetDelegateCtor(Method, Class, TargetMethod, CtorData);
 
-            Data->setOptimizedDelegateCtor(AlternateCtor);
+            if (AlternateCtor != Method) {
+              // TODO: Ideally we would like the JIT to inline this alternate
+              // ctor method
 
-            IRNode *ArgIR;
-            mdToken TargetMethodToken = Data->getMethodToken();
+              Data->setOptimizedDelegateCtor(AlternateCtor);
 
-            // Add the additional Args (if any)
-            if (CtorData->pArg3) {
-              ArgIR =
-                  handleToIRNode(TargetMethodToken, CtorData->pArg3,
-                                 CtorData->pArg3, false, false, true, false);
-              ReaderOperandStack->push(ArgIR);
-              if (CtorData->pArg4) {
+              IRNode *ArgIR;
+              mdToken TargetMethodToken = Data->getMethodToken();
+
+              // Add the additional Args (if any)
+              if (CtorData->pArg3) {
                 ArgIR =
-                    handleToIRNode(TargetMethodToken, CtorData->pArg4,
-                                   CtorData->pArg4, false, false, true, false);
+                    handleToIRNode(TargetMethodToken, CtorData->pArg3,
+                                   CtorData->pArg3, false, false, true, false);
                 ReaderOperandStack->push(ArgIR);
-                if (CtorData->pArg5) {
-                  ArgIR = handleToIRNode(TargetMethodToken, CtorData->pArg5,
-                                         CtorData->pArg5, false, false, true,
+                if (CtorData->pArg4) {
+                  ArgIR = handleToIRNode(TargetMethodToken, CtorData->pArg4,
+                                         CtorData->pArg4, false, false, true,
                                          false);
                   ReaderOperandStack->push(ArgIR);
+                  if (CtorData->pArg5) {
+                    ArgIR = handleToIRNode(TargetMethodToken, CtorData->pArg5,
+                                           CtorData->pArg5, false, false, true,
+                                           false);
+                    ReaderOperandStack->push(ArgIR);
+                  }
                 }
               }
             }
@@ -5397,6 +5436,7 @@ ReaderBase::rdrMakeLdFtnTargetNode(CORINFO_RESOLVED_TOKEN *ResolvedToken,
   case CORINFO_CALL:
     // Direct Call
     return rdrGetDirectCallTarget(CallInfo->hMethod, ResolvedToken->token,
+                                  CallInfo->codePointerLookup,
                                   CallInfo->nullInstanceCheck == TRUE, true);
   case CORINFO_CALL_CODE_POINTER:
     // Runtime lookup required (code sharing w/o using inst param)
@@ -5412,6 +5452,7 @@ IRNode *
 ReaderBase::rdrGetDirectCallTarget(ReaderCallTargetData *CallTargetData) {
   return rdrGetDirectCallTarget(
       CallTargetData->getMethodHandle(), CallTargetData->getMethodToken(),
+      CallTargetData->CallInfo.codePointerLookup,
       CallTargetData->NeedsNullCheck, canMakeDirectCall(CallTargetData));
 }
 
@@ -5420,25 +5461,37 @@ ReaderBase::rdrGetDirectCallTarget(ReaderCallTargetData *CallTargetData) {
 // calls through the method descriptor.
 IRNode *ReaderBase::rdrGetDirectCallTarget(CORINFO_METHOD_HANDLE Method,
                                            mdToken MethodToken,
+                                           CORINFO_LOOKUP CodePointerLookup,
                                            bool NeedsNullCheck,
                                            bool CanMakeDirectCall) {
-  CORINFO_CONST_LOOKUP AddressInfo;
-  getFunctionEntryPoint(Method, &AddressInfo, NeedsNullCheck
-                                                  ? CORINFO_ACCESS_NONNULL
-                                                  : CORINFO_ACCESS_ANY);
+  InfoAccessType AccessType;
+  void *Address;
+  if (Flags & CORJIT_FLG_READYTORUN) {
+    AccessType = CodePointerLookup.constLookup.accessType;
+    Address = CodePointerLookup.constLookup.addr;
+    assert(Address != nullptr);
+  } else {
+    CORINFO_CONST_LOOKUP AddressInfo;
+    getFunctionEntryPoint(Method, &AddressInfo, NeedsNullCheck
+                                                    ? CORINFO_ACCESS_NONNULL
+                                                    : CORINFO_ACCESS_ANY);
+    AccessType = AddressInfo.accessType;
+    Address = AddressInfo.addr;
+  }
 
   IRNode *TargetNode;
-  if ((AddressInfo.accessType == IAT_VALUE) && CanMakeDirectCall) {
-    TargetNode =
-        makeDirectCallTargetNode(Method, MethodToken, AddressInfo.addr);
+  if ((AccessType == IAT_VALUE) && CanMakeDirectCall) {
+    TargetNode = makeDirectCallTargetNode(Method, MethodToken, Address);
   } else {
-    bool IsIndirect = AddressInfo.accessType != IAT_VALUE;
-    TargetNode = handleToIRNode(MethodToken, AddressInfo.addr, 0, IsIndirect,
-                                IsIndirect, true, IsIndirect);
+    bool IsIndirect = AccessType != IAT_VALUE;
+    const bool IsReadOnly = false;
+    const bool IsRelocatable = true;
+    TargetNode = handleToIRNode(MethodToken, Address, 0, IsIndirect, IsReadOnly,
+                                IsRelocatable, IsIndirect);
 
     // TODO: call to same constant dominates this load then the load is
     // invariant
-    if (AddressInfo.accessType == IAT_PPVALUE) {
+    if (AccessType == IAT_PPVALUE) {
       TargetNode = derefAddressNonNull(TargetNode, false, true);
     }
   }
@@ -5491,31 +5544,36 @@ ReaderBase::rdrGetCodePointerLookupCallTarget(CORINFO_CALL_INFO *CallInfo,
 // return value of this helper call is then called indirectly.
 IRNode *ReaderBase::rdrGetIndirectVirtualCallTarget(
     ReaderCallTargetData *CallTargetData, IRNode **ThisPtr) {
-  IRNode *ClassHandle = CallTargetData->getClassHandleNode();
-  IRNode *MethodHandle = CallTargetData->getMethodHandleNode();
+  if (Flags & CORJIT_FLG_READYTORUN) {
+    return getReadyToRunVirtFuncPtr(*ThisPtr, &CallTargetData->ResolvedToken,
+                                    &CallTargetData->CallInfo);
+  } else {
+    IRNode *ClassHandle = CallTargetData->getClassHandleNode();
+    IRNode *MethodHandle = CallTargetData->getMethodHandleNode();
 
-  ASSERTMNR(!CallTargetData->getSigInfo()->isVarArg(),
-            "varargs + generics is not supported\n");
-  ASSERTNR(ThisPtr); // ensure we have a this pointer
-  ASSERTNR(ClassHandle);
-  ASSERTNR(MethodHandle);
+    ASSERTMNR(!CallTargetData->getSigInfo()->isVarArg(),
+              "varargs + generics is not supported\n");
+    ASSERTNR(ThisPtr); // ensure we have a this pointer
+    ASSERTNR(ClassHandle);
+    ASSERTNR(MethodHandle);
 
-  // treat as indirect call
-  CallTargetData->IsIndirect = true;
+    // treat as indirect call
+    CallTargetData->IsIndirect = true;
 
-  // We need to make a copy because the "this"
-  // pointer will be used twice:
-  //     1) to look up the virtual function
-  //     2) to call the method itself
-  IRNode *ThisPtrCopy;
-  dup(*ThisPtr, &ThisPtrCopy, ThisPtr);
+    // We need to make a copy because the "this"
+    // pointer will be used twice:
+    //     1) to look up the virtual function
+    //     2) to call the method itself
+    IRNode *ThisPtrCopy;
+    dup(*ThisPtr, &ThisPtrCopy, ThisPtr);
 
-  // Get the address of the target function by calling helper.
-  // Type it as a native int, it will be recast later.
-  IRNode *Dst = loadConstantI(0);
-  const bool MayThrow = true;
-  return callHelper(CORINFO_HELP_VIRTUAL_FUNC_PTR, MayThrow, Dst, ThisPtrCopy,
-                    ClassHandle, MethodHandle);
+    // Get the address of the target function by calling helper.
+    // Type it as a native int, it will be recast later.
+    IRNode *Dst = loadConstantI(0);
+    const bool MayThrow = true;
+    return callHelper(CORINFO_HELP_VIRTUAL_FUNC_PTR, MayThrow, Dst, ThisPtrCopy,
+                      ClassHandle, MethodHandle);
+  }
 }
 
 // Generate the target for a virtual stub dispatch call. This is the
@@ -7205,8 +7263,9 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
       resolveToken(LoadFtnToken, CORINFO_TOKENKIND_Method, &ResolvedToken);
 
       CORINFO_CALL_INFO CallInfo;
-      getCallInfo(&ResolvedToken, nullptr /*constraint*/,
-                  CORINFO_CALLINFO_LDFTN, &CallInfo);
+      CORINFO_CALLINFO_FLAGS Flags = (CORINFO_CALLINFO_FLAGS)(
+          CORINFO_CALLINFO_LDFTN | CORINFO_CALLINFO_CALLVIRT);
+      getCallInfo(&ResolvedToken, nullptr /*constraint*/, Flags, &CallInfo);
 
       verifyLoadFtn(TheVerificationState, Opcode, &ResolvedToken,
                     ILInput + CurrentOffset, &CallInfo);
@@ -8421,8 +8480,12 @@ IRNode *ReaderCallTargetData::getTypeContextNode() {
   if (SigInfo.hasTypeArg()) {
     if (((SIZE_T)CallInfo.contextHandle & CORINFO_CONTEXTFLAGS_MASK) ==
         CORINFO_CONTEXTFLAGS_METHOD) {
+      CORINFO_METHOD_HANDLE Method = (CORINFO_METHOD_HANDLE)(
+          (SIZE_T)CallInfo.contextHandle & ~CORINFO_CONTEXTFLAGS_MASK);
       // Instantiated generic method
-      if (CallInfo.exactContextNeedsRuntimeLookup) {
+      if (Reader->Flags & CORJIT_FLG_READYTORUN) {
+        return getReadyToRunTypeContextNode(mdtMethodHandle, (void *)Method);
+      } else if (CallInfo.exactContextNeedsRuntimeLookup) {
         if (Reader->getCurrentMethodHandle() != Reader->MethodBeingCompiled) {
           // The runtime passes back bogus values for runtime lookups
           // of inlinees so the inliner only allows it if the handle
@@ -8434,47 +8497,75 @@ IRNode *ReaderCallTargetData::getTypeContextNode() {
         }
       } else {
         // embed the handle passed back from getCallInfo
-        CORINFO_METHOD_HANDLE Method = (CORINFO_METHOD_HANDLE)(
-            (SIZE_T)CallInfo.contextHandle & ~CORINFO_CONTEXTFLAGS_MASK);
         Reader->methodMustBeLoadedBeforeCodeIsRun(Method);
         bool IsIndirect = false;
         void *MethodHandle = Reader->embedMethodHandle(Method, &IsIndirect);
         return Reader->handleToIRNode(mdtMethodHandle, MethodHandle, Method,
                                       IsIndirect, true, true, false);
       }
-    } else if ((getClassAttribs() & CORINFO_FLG_ARRAY) && IsReadonlyCall) {
-      // We indicate "readonly" to the Array::Address operation by
-      // using a null instParam. This effectively tells it to not do
-      // type validation.
-      return Reader->loadConstantI(0);
     } else {
-      // otherwise must be an instance method in a generic struct, a
-      // static method in a generic type, or a runtime-generated array
-      // method which all use the class handle
-      if (CallInfo.exactContextNeedsRuntimeLookup) {
-        if (Reader->getCurrentMethodHandle() != Reader->MethodBeingCompiled) {
-          // The runtime passes back invalid values for runtime lookups
-          // of inlinees so the inliner only allows it if the handle
-          // is never used
-          return Reader->loadConstantI(0);
-        } else {
-          // runtime lookup based on the class token
-          return getClassHandleNode();
-        }
+      ASSERTNR(((SIZE_T)CallInfo.contextHandle & CORINFO_CONTEXTFLAGS_MASK) ==
+               CORINFO_CONTEXTFLAGS_CLASS);
+      CORINFO_CLASS_HANDLE Class = (CORINFO_CLASS_HANDLE)(
+          (SIZE_T)CallInfo.contextHandle & ~CORINFO_CONTEXTFLAGS_MASK);
+
+      if ((getClassAttribs() & CORINFO_FLG_ARRAY) && IsReadonlyCall) {
+        // We indicate "readonly" to the Array::Address operation by
+        // using a null instParam. This effectively tells it to not do
+        // type validation.
+        return Reader->loadConstantI(0);
+      } else if (Reader->Flags & CORJIT_FLG_READYTORUN) {
+        return getReadyToRunTypeContextNode(mdtClassHandle, (void *)Class);
       } else {
-        ASSERTNR(((SIZE_T)CallInfo.contextHandle & CORINFO_CONTEXTFLAGS_MASK) ==
-                 CORINFO_CONTEXTFLAGS_CLASS);
-        CORINFO_CLASS_HANDLE Class = (CORINFO_CLASS_HANDLE)(
-            (SIZE_T)CallInfo.contextHandle & ~CORINFO_CONTEXTFLAGS_MASK);
-        Reader->classMustBeLoadedBeforeCodeIsRun(Class);
-        bool IsIndirect = false;
-        void *ClassHandle = Reader->embedClassHandle(Class, &IsIndirect);
-        return Reader->handleToIRNode(mdtClassHandle, ClassHandle, Class,
-                                      IsIndirect, true, true, false);
+        // otherwise must be an instance method in a generic struct, a
+        // static method in a generic type, or a runtime-generated array
+        // method which all use the class handle
+        if (CallInfo.exactContextNeedsRuntimeLookup) {
+          if (Reader->getCurrentMethodHandle() != Reader->MethodBeingCompiled) {
+            // The runtime passes back invalid values for runtime lookups
+            // of inlinees so the inliner only allows it if the handle
+            // is never used
+            return Reader->loadConstantI(0);
+          } else {
+            // runtime lookup based on the class token
+            return getClassHandleNode();
+          }
+        } else {
+          Reader->classMustBeLoadedBeforeCodeIsRun(Class);
+          bool IsIndirect = false;
+          void *ClassHandle = Reader->embedClassHandle(Class, &IsIndirect);
+          return Reader->handleToIRNode(mdtClassHandle, ClassHandle, Class,
+                                        IsIndirect, true, true, false);
+        }
       }
     }
   }
   return nullptr;
+}
+
+IRNode *
+ReaderCallTargetData::getReadyToRunTypeContextNode(mdToken Token,
+                                                   void *CompileHandle) {
+  InfoAccessType AccessType = CallInfo.instParamLookup.accessType;
+  void *EmbedHandle = nullptr;
+  assert(AccessType != IAT_PPVALUE);
+  bool IsIndirect;
+  if (AccessType == IAT_VALUE) {
+    EmbedHandle = CallInfo.instParamLookup.handle;
+    IsIndirect = false;
+  } else {
+    assert(AccessType == IAT_PVALUE);
+    EmbedHandle = CallInfo.instParamLookup.addr;
+    IsIndirect = true;
+  }
+  const bool IsReadOnly = true;
+  const bool IsRelocatable = true;
+  const bool IsCallTarget = false;
+  IRNode *InstParam =
+      Reader->handleToIRNode(Token, EmbedHandle, CompileHandle, IsIndirect,
+                             IsReadOnly, IsRelocatable, IsCallTarget);
+  assert(InstParam != nullptr);
+  return InstParam;
 }
 
 void ReaderCallTargetData::setOptimizedDelegateCtor(

--- a/test/LLILCTestEnv.cmd
+++ b/test/LLILCTestEnv.cmd
@@ -5,6 +5,7 @@ REM
 REM -------------------------------------------------------------------------
 
 set COMPLUS_AltJit=*
+set COMPLUS_AltJitNgen=*
 set COMPLUS_AltJitName=LLILCJit.dll
 set COMPLUS_GCCONSERVATIVE=1
 set COMPLUS_ZapDisable=1

--- a/test/llilc_run.py
+++ b/test/llilc_run.py
@@ -147,6 +147,7 @@ def main(argv):
     
     RunCommand('chcp 65001')
     os.environ["COMPlus_AltJit"]="*"
+    os.environ["COMPlus_AltJitNgen"]="*"
     os.environ["COMPlus_AltJitName"]=jit_name
     if (args.precise_gc):
         os.environ["COMPlus_InsertStatepoints"]="1"

--- a/test/llilc_runtest.py
+++ b/test/llilc_runtest.py
@@ -189,6 +189,7 @@ def main(argv):
         # Todo: Test Env is right now only for Windows. Will expand when cross platform
         with open(time_stamped_test_env_path, 'w') as test_env:
             test_env.write('set COMPlus_AltJit=*\n')
+            test_env.write('set COMPlus_AltJitNgen=*\n')
             test_env.write('set COMPlus_AltJitName=' + time_stamped_jit_name + '\n')
             if (args.precise_gc):
                 test_env.write('set COMPlus_InsertStatepoints=1\n')


### PR DESCRIPTION
These changes implement jit features for ReadyToRun compilation.
The ReadyToRun overview is located here:
https://github.com/dotnet/coreclr/blob/master/Documentation/botr/readytorun-overview.md
It's a format that provides version resiliency on top of ngen.

These changes mostly follow what's implemented in RyuJit.

Special handling is done for the following operations:

* Type context creation
* Struct copy with write barriers: CORINFO_HELP_ASSIGN_STRUCT is not available for ReadyToRun
and is not used by RyuJit at all (it's considered inefficient). I implemented inline copy expansion.
* Field access
* isinst and castclass
* Class constructor insertion
* Static field address calculation
* Direct call target computation
* Indirect virtual call target computation
* Function pointer loading
* Object creation
* Array creation

Some additional changes:

* OptLevel is set to Default for ngen and ReadyToRun compilation
regardless of whether we are compiling debug or release.
* CodeModel is set to Default instead of JITDefault for ngen
and ReadyToRun compilation. We get rel32 relocations, which matches
what RyuJit generates.

COMPLUS_AltJitNgen is now set to * for our test runs. That ensures that
the existing ReadyToRun tests will use llilc to generate ReadyToRun images.

I verified that llilc can produce ReadyToRun images of tiny Roslyn and
can use them to compile itself and the result can run.

Closes #751, #750, #749, #748, #747, #745, #746

This pull request is dependent on https://github.com/dotnet/coreclr/pull/1501 merging first.