### PR TITLE
Fix various memory leaks in the jit

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -1445,7 +1445,6 @@ protected:
   uint32_t CurrentBranchDepth;
 
   // EH Info
-  CORINFO_EH_CLAUSE *EhClauseInfo; // raw eh clause info
   EHRegion *EhRegionTree;
   EHRegionList *AllRegionList;
 

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -119,7 +119,7 @@ private:
   ///
   /// \param DwarfContext Dwarf Context to extract debug info from
   /// \param Size Size of the function we are gathering info from
-  void getDebugInfoForLocals(DWARFContextInMemory *DwarfContext, uint64_t Addr,
+  void getDebugInfoForLocals(DWARFContextInMemory &DwarfContext, uint64_t Addr,
                              uint64_t Size);
 
   /// \brief Convert DWARF register number to CLR register number
@@ -515,7 +515,7 @@ void ObjectLoadListener::getDebugInfoForObject(
 
   // TODO: This extracts DWARF information from the object file, but we will
   // want to also be able to eventually extract WinCodeView information as well
-  DWARFContextInMemory *DwarfContext = new DWARFContextInMemory(DebugObj);
+  DWARFContextInMemory DwarfContext(DebugObj);
 
   // Use symbol info to iterate functions in the object.
   // TODO: This may have to change when we have funclets
@@ -544,8 +544,7 @@ void ObjectLoadListener::getDebugInfoForObject(
     unsigned NumDebugRanges = 0;
     ICorDebugInfo::OffsetMapping *OM;
 
-    DILineInfoTable Lines =
-        DwarfContext->getLineInfoForAddressRange(Addr, Size);
+    DILineInfoTable Lines = DwarfContext.getLineInfoForAddressRange(Addr, Size);
 
     DILineInfoTable::iterator Begin = Lines.begin();
     DILineInfoTable::iterator End = Lines.end();
@@ -691,8 +690,8 @@ void ObjectLoadListener::getRelocationTypeAndAddend(uint8_t *FixupAddress,
 }
 
 void ObjectLoadListener::getDebugInfoForLocals(
-    DWARFContextInMemory *DwarfContext, uint64_t Addr, uint64_t Size) {
-  for (const auto &CU : DwarfContext->compile_units()) {
+    DWARFContextInMemory &DwarfContext, uint64_t Addr, uint64_t Size) {
+  for (const auto &CU : DwarfContext.compile_units()) {
     const DWARFDebugInfoEntryMinimal *UnitDIE = CU->getUnitDIE(false);
     const DWARFDebugInfoEntryMinimal *SubprogramDIE = getSubprogramDIE(UnitDIE);
 

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -46,22 +46,13 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\fieldExprUnchecked1.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeArray.cmd" >
-             <Issue>794</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeArray1.cmd" >
-             <Issue>794</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\hugeexpr1.cmd" >
              <Issue>794</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeField1.cmd" >
              <Issue>794</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeField2.cmd" >
-             <Issue>794</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\hugeSimpleExpr1.cmd" >
              <Issue>794</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\471729\test.cmd" >


### PR DESCRIPTION
This is the initial step in fixing jit-related memory leaks. It partially addresses #794. Using the debug CRT (which entails various hacks too ugly to commit) this set of changes gets rid most of the direct leaks from the jit. Most simple methods now leak ~2K when jitted, down from ~50K. We can also now process the various huge cases that blocked us.

I plan to subsequently rework most of this to use automatic reclamation.

Free up EH region and related info when done reading. Make sure we track the all region list to enable this (the code was set up to do this at one time, but when we went to LLVM naming conventions we introduced a local shadow). Streamline processing of raw eh clauses a bit.

Free up "initial" reader stacks when done reading.

Free up node offset array and related when done reading.

Free up final "working" reader stack when done reading.

Free up the canonical exit offset buffer (if heap allocated) when done readong.

Free up "working" stacks when switching before reading IL for a block.

Free up node worklist after computing initial reachability set.

Free up runtime GC info after examining it.

Stack allocate some debug generation objects so they are cleaned up automatically. Explicitly delete others.

Also, reduce the default stack size. Since we won't be inlining in-reader, and most stacks are small, use 4 as the default size. This saves about 300MB of allocation on `HugeArray`.

Remove exclusions for three tests that now pass. The other three cases also generate correct code but fail at runtime because the generated code requires a huge stack frame (4.7MB in the case of `HugeArray`).