### PR TITLE
Clone finally bodies

### DIFF
--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1911,6 +1911,24 @@ private:
   ///          outlined.
   llvm::Function *getCurrentFilter();
 
+  /// Copy the IR in each finally so that the exceptional path does not share
+  /// code with the non-exceptional path.
+  void cloneFinallyBodies();
+
+  /// Copy the IR in the given finally so that the exceptional path does not
+  /// share code with the non-exceptional path.
+  ///
+  /// \param FinallyRegion  The region whose IR is to be cloned.
+  void cloneFinallyBody(EHRegion *FinallyRegion);
+
+  /// Remove the unwind edge from the given terminator, indicating that if it
+  /// faults it will unwind to this function's caller rather than a handler in
+  /// this function.  The terminator will be replaced with a new terminator
+  /// that doesn't have the edge.
+  ///
+  /// \param Terminator  The terminator that is to be replaced.
+  void removeUnwindDest(llvm::TerminatorInst *Terminator);
+
   /// Record that the given address needs to escape by call to
   /// @llvm.localescape, and return the index that may be used to recover it by
   /// call to @llvm.localrecover.  May be called multiple times for the same

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -605,53 +605,18 @@ public:
 
   void fgEnterRegion(EHRegion *Region) override;
 
-  /// Make a landing pad suitable as an unwind label for code in the given try
-  /// region.
+  /// Make an EH pad suitable as an unwind label for code in the try region
+  /// protected by the given handler, and any dispatch code needed after the
+  /// EH pad to transfer control to the handler code.
   ///
-  /// \param TryRegion         Protected region we need to build a landing pad
-  ///                          for.
-  /// \param OuterLandingPad   Outer region's LandingPad (where to branch to
-  ///                          when propagating an exception).
-  /// \returns A new \p LandingPadInst in a populated landing-pad block.
-  llvm::LandingPadInst *createLandingPad(EHRegion *TryRegion,
-                                         llvm::LandingPadInst *OuterLandingPad);
-
-  /// Generate a single catch clause for a protected region.
-  ///
-  /// \param CatchRegion   Handler that needs a clause and dispatch code
-  /// \param LandingPad    \p LandingPadInst under construction
-  /// \param FauxException \p Value representing the caught exception in the
-  ///                      dispatch code
-  /// \param Selector      \p Value representing the exception selector in the
-  ///                      dispatch code
-  void genCatchDispatch(EHRegion *CatchRegion, llvm::LandingPadInst *LandingPad,
-                        llvm::Value *FauxException, llvm::Value *Selector);
-
-  /// Generate landingpad code for a single filter.
-  ///
-  /// \param FilterRegion   Filter that needs a clause and dispatch code
-  /// \param LandingPad     \p LandingPadInst under construction
-  /// \param FauxException  \p Value representing the caught exception in the
-  ///                       dispatch code
-  /// \param Selector       \p Value representing the exception selector in the
-  ///                       dispatch code
-  void genFilterDispatch(EHRegion *FilterRegion,
-                         llvm::LandingPadInst *LandingPad,
-                         llvm::Value *FauxException, llvm::Value *Selector);
-
-  /// Helper for generating catch/filter dispatch.
-  ///
-  /// \param HandlerRegion  Handler that needs a clause and dispatch code
-  /// \param DoEnter        \p Value dictating whether to dispatch to the
-  ///                       handler
-  /// \param EnterBlockName Name for the BasicBlock that will enter the handler
-  /// \param ExceptionType  \p Type of the formal for the exception object
-  /// \param FauxException  \p Value representing the caught exception in the
-  ///                       dispatch code
-  void genHandlerDispatch(EHRegion *HandlerRegion, llvm::Value *DoEnter,
-                          const llvm::Twine &EnterBlockName,
-                          llvm::Type *ExceptionType,
-                          llvm::Value *FauxException);
+  /// \param Handler           Catch/Finally/Fault/Filter region we need to
+  ///                          build an EH pad for.
+  /// \param EndPad [in/out]   CatchEndPad/CleanupEndPad that should be the
+  ///                          unwind target of code in the handler body.
+  /// \param NextPad           Next outer (or successor catch) EH region.
+  /// \returns A new CatchPad/CleanupPad in a populated EH pad block.
+  llvm::Instruction *createEHPad(EHRegion *Handler, llvm::Instruction *&EndPad,
+                                 llvm::Instruction *NextPad);
 
   IRNode *fgNodeFindStartLabel(FlowGraphNode *Block) override;
 


### PR DESCRIPTION
Note: this is a PR for code to go into the EH branch.

The main reader passes generate IR for finally handlers that reflects the
right semantics, but is ill-formed because the `cleanuppad` at the entry
of a finally doesn't dominate its uses at the exits from that finally
(because there is a side-entry for the non-exceptional paths through the
finally).

Add a post-pass (in `readerPostVisit`) that makes a separate clone for the
non-exception version of each finally handler, leaving the `cleanuppad`
def and uses well-formed on the exception-only path.

The long-term plan is to add a `cleanupcall` operator to LLVM that the
non-exceptional paths can use to target the `cleanuppad` directly (and
perform finally cloning as a subsequent optimization in many cases, but
without the need to introduce potentially-explosive cloning for
correctness).  That work is being deferred to simplify/speed-up the
initial WinEH bring-up.

Closes #835.