### PR TITLE
Disable type caching across methods in ReadyToRun mode.

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -545,6 +545,19 @@ void GenIR::readerPostPass(bool IsImportOnly) {
     }
   }
 
+  // Crossgen in ReadyToRun mode records structs that method compilation
+  // depends on via getClassSize calls. Therefore, we shouldn't cache type info
+  // across methods.
+  if (JitContext->Flags & CORJIT_FLG_READYTORUN) {
+    // Clearing the cache is only safe if we're at the "top-level" context.
+    // We shouldn't have re-entrant jit requests in a prejit scenario.
+    assert(JitContext->Next == nullptr);
+    ClassTypeMap->clear();
+    ArrayTypeMap->clear();
+    ReverseClassTypeMap->clear();
+    BoxedTypeMap->clear();
+  }
+
   // Cleanup the memory we've been using.
   DBuilder->finalize();
   delete DBuilder;

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -2275,9 +2275,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_i1.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\readytorun\mainv2.cmd" >
-             <Issue>833</Issue>
-        </ExcludeList>
     </ItemGroup>
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(COMPLUS_INSERTSTATEPOINTS)' != ''">	
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\113574\113574.cmd" >


### PR DESCRIPTION
ReadyToRun mainv2 test has a series of subtests. One of them is TestGrowingStruct.
The scenario is that an app is ReadyToRun-compiled against a version of a struct in a lib.
Then two new fields are added to the struct and the lib is ReadyToRun recompiled.
Then we attempt to run the app without recompiling. What should happen in this case
is that the runtime should detect that the struct layout has changed and the pre-compiled
code for the method in the app is invalid and the method should be JIT-ed.

The reason that wasn't always happening was because we have per-thread caching of types.
Crossgen records structs that the JIT calls getClassSize for and that allows the runtime to do
the detection described above. In this case more than one method needed the info about
that struct but crossgen recorded just the method that happened to call getClassSize on it first.
So if a method was compiled on the same thread as TestGrowingStruct before it and called getClassSize,
crossgen wouldn't record the TestGrowingStruct's dependency on the struct layout.

The fix is not to do type caching across methods in ReadyToRun mode.

Closes #833.