### PR TITLE
InsertStatepoints: Add exclusion for a test that times out.

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -2281,7 +2281,10 @@
     </ItemGroup>
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(COMPLUS_INSERTSTATEPOINTS)' != ''">	
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\113574\113574.cmd" >
-             <Issue>737</Issue>
+             <Issue>CoreCLR\1541</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68361\b68361.cmd" >
+             <Issue>CoreCLR\1541</Issue>
         </ExcludeList>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Two tests time out because some loops take longer to run
with gc-probes inserted within loops.

We need to add an option to the CoreCLR test framework to
specify timeout factor (dotnet/coreclr#1541).

This change adds exclusion for the failing tests until the
above issue is fixed -- so that InsertStaetpoints job is green.