### PR TITLE
Resolve issue #638 and update exclusion.targets

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -1540,9 +1540,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b32613\b32613.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08672\b08672.cmd" >
-             <Issue>638</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25813\b25813.cmd" >
              <Issue>13</Issue>
         </ExcludeList>


### PR DESCRIPTION
Closes #638.

The test that was failing with issue #638 no longer fails.
Remote it from the exclusion.targets.