### PR TITLE
Run verifier before unreachable code removal.

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -3184,6 +3184,7 @@ public:
 
   virtual IRNode *fgMakeSwitch(IRNode *DefaultLabel, IRNode *Node) = 0;
   virtual IRNode *fgMakeThrow(IRNode *Node) = 0;
+  virtual IRNode *fgMakeReturn(IRNode *Node) = 0;
   virtual IRNode *fgAddCaseToCaseList(IRNode *SwitchNode, IRNode *LabelNode,
                                       uint32_t Element) = 0;
   virtual void insertEHAnnotationNode(IRNode *InsertionPointNode,

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -616,6 +616,7 @@ public:
 
   IRNode *fgMakeSwitch(IRNode *DefaultLabel, IRNode *Insert) override;
 
+  IRNode *fgMakeReturn(IRNode *Insert) override;
   IRNode *fgMakeThrow(IRNode *Insert) override;
   IRNode *fgAddCaseToCaseList(IRNode *SwitchNode, IRNode *LabelNode,
                               unsigned Element) override;

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -3061,6 +3061,8 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
 
     case ReaderBaseNS::CEE_RET:
       verifyReturnFlow(CurrentOffset);
+      BlockNode = fgNodeGetStartIRNode(Block);
+      fgMakeReturn(BlockNode);
       fgNodeSetEndMSILOffset(Block, NextOffset);
       if (NextOffset < ILInputSize) {
         Block = makeFlowGraphNode(NextOffset, Block);


### PR DESCRIPTION
Running the verifier before unreachable code removal would have caught
some of the bugs we had (e.g., #785).

Changes to pass the verifier:
* Add unreachable instruction in place of return during flow graph building.
   Remove the unreachable when processing return instruction in the second pass.
* Type dummy switch selector as int32 so that there is no mismatch with types
   of case values.
* Move DBuilder finalization to readerPostVisit to avoid invalid MDNodes.

Closes #849.