### PR TITLE
Handle unmanaged pointer types passed to mkrefany

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -7858,14 +7858,17 @@ IRNode *GenIR::makeRefAny(CORINFO_RESOLVED_TOKEN *ResolvedToken,
   // jits have allowed arbitrary integers here too. So, tolerate this.
   Type *ExpectedObjectTy = RefAnyStructTy->getContainedType(ValueIndex);
   assert(isManagedPointerType(ExpectedObjectTy));
+  Type *ActualObjectTy = Object->getType();
   Value *CastObject;
-  if (!isManagedPointerType(Object->getType())) {
+  if (isManagedPointerType(ActualObjectTy)) {
+    CastObject = LLVMBuilder->CreatePointerCast(Object, ExpectedObjectTy);
+  } else if (isUnmanagedPointerType(ActualObjectTy)) {
+    CastObject = LLVMBuilder->CreateAddrSpaceCast(Object, ExpectedObjectTy);
+  } else {
     assert(Object->getType()->isIntegerTy());
     // Not clear what should happen on a size mismatch, so we'll just let
     // LLVM do what it thinks is reasonable.
     CastObject = LLVMBuilder->CreateIntToPtr(Object, ExpectedObjectTy);
-  } else {
-    CastObject = LLVMBuilder->CreatePointerCast(Object, ExpectedObjectTy);
   }
   Value *ValueFieldAddress =
       LLVMBuilder->CreateStructGEP(RefAnyTy, RefAny, ValueIndex);

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -313,9 +313,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\muldiv.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\format.cmd" >
-             <Issue>592</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\gcreport.cmd" >
              <Issue>13</Issue>
         </ExcludeList>


### PR DESCRIPTION
Closes #592.

Allow an unmanaged pointer as the pointer value in a mkrefany, by casting it to a managed pointer.