### PR TITLE
Translate filters to catches in reader

### DIFF
--- a/lib/Reader/abisignature.cpp
+++ b/lib/Reader/abisignature.cpp
@@ -253,7 +253,7 @@ CallSite ABICallSignature::emitUnmanagedCall(GenIR &Reader, Value *Target,
   // 1) Address of the GC mode field
   // 2) Address of the thread trap global
   // 3) Address of CORINFO_HELP_STOP_FOR_GC
-  Module *M = Reader.RootFunction->getParent();
+  Module *M = Reader.Function->getParent();
   Type *CallTypeArgs[] = {Target->getType()};
   Function *CallIntrinsic = Intrinsic::getDeclaration(
       M, Intrinsic::experimental_gc_statepoint, CallTypeArgs);

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -3019,8 +3019,16 @@ void ReaderBase::fgBuildPhase1(FlowGraphNode *Block, uint8_t *ILInput,
       break;
 
     case ReaderBaseNS::CEE_ENDFILTER:
+      // Make a branch to the handler, which will correspond to the filter
+      // returning true.
+      GraphNode = nullptr;
+      fgAddNodeMSILOffset(&GraphNode, NextOffset);
+      BlockNode = fgNodeGetStartIRNode(Block);
+      BranchNode = fgMakeBranchHelper((IRNode *)GraphNode, BlockNode,
+                                      CurrentOffset, false, false);
+      // Split the block.
       fgNodeSetEndMSILOffset(Block, NextOffset);
-      Block = makeFlowGraphNode(NextOffset, Block);
+      Block = fgSplitBlock(Block, NextOffset, nullptr);
       break;
 
     case ReaderBaseNS::CEE_ENDFINALLY: {
@@ -6869,7 +6877,6 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
       //    EXCEPTION_CONTINUE_EXECUTION (-1, not supported in CLR currently)
       Arg1 = ReaderOperandStack->pop(); // Pop the object pointer
       endFilter(Arg1);
-      clearStack();
       break;
 
     case ReaderBaseNS::CEE_ENDFINALLY:

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -3625,6 +3625,7 @@ Instruction *GenIR::createEHPad(EHRegion *Handler, Instruction *&EndPad,
     ReaderStack *EnterFilterStack = createStack();
     EnterFilterStack->push((IRNode *)&*ArgIter);
     fgNodeSetOperandStack(FilterEntry, EnterFilterStack);
+    fgNodeSetPropagatesOperandStack(FilterEntry, true);
 
     // Record the FilterFunction on the EHRegion.
     assert(Handler->FilterFunction == nullptr);
@@ -3724,6 +3725,10 @@ void GenIR::replaceFlowGraphNodeUses(FlowGraphNode *OldNode,
 
 bool fgEdgeIsNominal(FlowGraphEdgeIterator &FgEdgeIterator) {
   BasicBlock *Successor = fgEdgeIteratorGetSink(FgEdgeIterator);
+  if (Successor == &Successor->getParent()->getEntryBlock()) {
+    // This is the nominal edge to a filter function entry.
+    return true;
+  }
   Instruction *First = Successor->getFirstNonPHI();
   return (First != nullptr) && First->isEHPad();
 }


### PR DESCRIPTION
Note: this is a PR for a change to go into the EH branch.

Lowering for filters (as filters) is going to lag behind lowering for the other handler types.  This is a change to have filters masquerade as catches in the meantime -- the catch encompasses both the filter and the filter-handler, with an explicit rethrows if the `filter portion returns 0.  This is not fully "as-is", because it effectively delays the evaluation of filter expressions from the first pass of unwinding to the second.  Aside from that, however, it is a faithful representation of filter semantics.

I've created a [gist](https://gist.github.com/JosephTremoulet/bd635de873e90de9b710) to show the effect of the transform.  It includes a [C# input](https://gist.github.com/JosephTremoulet/bd635de873e90de9b710#file-input-cs), the [IR generated with filter outlining](https://gist.github.com/JosephTremoulet/bd635de873e90de9b710#file-outputwithfilteroutlining-ll) (as before this change), and the [IR generated with filters translated to catches](https://gist.github.com/JosephTremoulet/bd635de873e90de9b710#file-outputwithfiltertransform-ll) (as with this change).

The change is split into four commits:
 - the first two (97fe976 and f7316c0) are actually small bugfixes to the filter outlining that were needed to create the 'before' part of the gist
 - the next (7fa22f5) is the meat of the change to produce catches instead of outlining when encountering a filter
 - the last (d7cdeb3)  is a rote change almost entirely composed by reverting chunks to match master, renaming `RootFunction` back to `Function` and the like.