### PR TITLE
Remove vestigial EH/Region-related code

### DIFF
--- a/include/Reader/readerenum.h
+++ b/include/Reader/readerenum.h
@@ -490,48 +490,15 @@ enum StIndirOpcode {
 
 /// \brief Describes the set of region kinds.
 typedef enum {
-  RGN_Unknown = 0, ///< Indicates that the region is of unknown kind.
-  RGN_None,        ///< Indicates that the region has no kind.
   RGN_Root,        ///< Indicates the root of a region tree.
   RGN_Try,         ///< Indicates a try region.
-  RGN_Except,      ///< Indicates an SEH except region.
   RGN_Fault,       ///< Indicates a fault region.
   RGN_Finally,     ///< Indicates a finally region.
   RGN_Filter,      ///< Indicates a filter region.
-  RGN_Dtor,        ///< Indicates a destructor region.
-  RGN_Catch,       ///< Indicates a C++ catch region.
   RGN_MExcept,     ///< Indicates a managed except region.
-  RGN_MCatch,      ///< Indicates a managed catch region.
-
-  // New region types used in common reader
-  RGN_ClauseNone,    ///< Indicates that the region has no clauses.
-  RGN_ClauseFilter,  ///< Indicates a filter clause region.
-  RGN_ClauseFinally, ///< Indicates a finally clause region.
-  RGN_ClauseError,   ///< Indicates an error clause region.
-  RGN_ClauseFault,   ///< Indicates a fault clause region.
+  RGN_MCatch       ///< Indicates a managed catch region.
 } RegionKind;
 
-/// \brief Describes the set of try region kinds.
-typedef enum {
-  TRY_None = 0, ///< Indicates that the try region has no handlers.
-
-  TRY_Fin, ///< Indicates that the try region is a finally clause.
-
-  TRY_Fault, ///< Indicates that the try region is a fault handler.
-
-  TRY_MCatch, ///< Indicates that the try region has only catch handlers.
-
-  TRY_MCatchXcpt, ///< Indicates that the try region has both catch and except.
-                  ///< handlers
-
-  TRY_MXcpt, ///< Indicates that the try region has only except handlers.
-
-  TRY_Xcpt, ///< Indicates that the try region has native SEH exception
-            ///< handlers. Not used in the current JIT.
-
-  TRY_CCatch ///< Indicates that the try region has native C++ catch
-             ///< handlers. Not used in the current JIT.
-} TryKind;
 }
 
 /// \brief Used to map MSIL opcodes to function-specific opcode enumerations.

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -307,8 +307,7 @@ public:
   uint32_t updateLeaveOffset(EHRegion *Region, uint32_t LeaveOffset,
                              uint32_t NextOffset, FlowGraphNode *LeaveBlock,
                              uint32_t TargetOffset, bool &IsInHandler);
-  void leave(uint32_t TargetOffset, bool IsNonLocal,
-             bool EndsWithNonLocalGoto) override;
+  void leave(uint32_t TargetOffset) override;
   IRNode *loadArg(uint32_t ArgOrdinal, bool IsJmp) override;
   IRNode *loadLocal(uint32_t ArgOrdinal) override;
   IRNode *loadArgAddress(uint32_t ArgOrdinal) override;
@@ -499,7 +498,6 @@ public:
   // Used to maintain operand stack.
   void maintainOperandStack(FlowGraphNode *CurrentBlock) override;
   void assignToSuccessorStackNode(FlowGraphNode *, IRNode *Dst, IRNode *Src,
-
                                   bool *IsMultiByteAssign) override {
     throw NotYetImplementedException("assignToSuccessorStackNode");
   };
@@ -549,13 +547,6 @@ public:
     throw NotYetImplementedException("fgGetLabelBranchList");
   };
 
-  void insertHandlerAnnotation(EHRegion *HandlerRegion) override {
-    throw NotYetImplementedException("insertHandlerAnnotation");
-  };
-  void insertRegionAnnotation(IRNode *RegionStartNode,
-                              IRNode *RegionEndNode) override {
-    throw NotYetImplementedException("insertRegionAnnotation");
-  };
   void fgAddLabelToBranchList(IRNode *LabelNode, IRNode *BranchNode) override;
   void fgAddArc(IRNode *BranchNode, FlowGraphNode *Source,
                 FlowGraphNode *Sink) override {
@@ -583,20 +574,7 @@ public:
   // loop back-edge rather than a forward edge to the exit label.
   bool fgOptRecurse(ReaderCallTargetData *Data) override;
 
-  // Returns true if node (the start of a new eh Region) cannot be the start of
-  // a block.
-  bool fgEHRegionStartRequiresBlockSplit(IRNode *Node) override {
-    throw NotYetImplementedException("fgEHRegionStartRequiresBlockSplit");
-  };
-
-  bool fgIsExceptRegionStartNode(IRNode *Node) override {
-    throw NotYetImplementedException("fgIsExceptRegionStartNode");
-  };
   FlowGraphNode *fgSplitBlock(FlowGraphNode *Block, IRNode *Node) override;
-  void fgSetBlockToRegion(FlowGraphNode *Block, EHRegion *Region,
-                          uint32_t LastOffset) override {
-    throw NotYetImplementedException("fgSetBlockToRegion");
-  };
   IRNode *fgMakeBranch(IRNode *LabelNode, IRNode *InsertNode,
                        uint32_t CurrentOffset, bool IsConditional,
                        bool IsNominal) override;
@@ -619,25 +597,8 @@ public:
   IRNode *fgAddCaseToCaseList(IRNode *SwitchNode, IRNode *LabelNode,
                               unsigned Element) override;
 
-  void insertEHAnnotationNode(IRNode *InsertionPointNode,
-                              IRNode *InsertNode) override {
-    throw NotYetImplementedException("insertEHAnnotationNode");
-  };
   FlowGraphNode *makeFlowGraphNode(uint32_t TargetOffset,
                                    FlowGraphNode *PreviousNode) override;
-  void markAsEHLabel(IRNode *LabelNode) override {
-    throw NotYetImplementedException("markAsEHLabel");
-  };
-  IRNode *makeTryEndNode(void) override {
-    throw NotYetImplementedException("makeTryEndNode");
-  };
-  IRNode *makeRegionStartNode(ReaderBaseNS::RegionKind RegionType) override {
-    throw NotYetImplementedException("makeRegionStartNode");
-  };
-  IRNode *makeRegionEndNode(ReaderBaseNS::RegionKind RegionType) override {
-    throw NotYetImplementedException("makeRegionEndNode");
-  };
-
   // Allow client to override reader's decision to optimize castclass/isinst
   bool disableCastClassOptimization();
 
@@ -661,26 +622,9 @@ public:
     throw NotYetImplementedException("entryLabel");
   };
 
-  // Function is passed a try region, and is expected to return the first label
-  // or instruction
-  // after the region.
-  IRNode *findTryRegionEndOfClauses(EHRegion *TryRegion) override {
-    throw NotYetImplementedException("findTryRegionEndOfClauses");
-  };
-
   bool isCall() override { throw NotYetImplementedException("isCall"); };
   bool isRegionStartBlock(FlowGraphNode *Fg) override {
     throw NotYetImplementedException("isRegionStartBlock");
-  };
-  bool isRegionEndBlock(FlowGraphNode *Fg) override {
-    throw NotYetImplementedException("isRegionEndBlock");
-  };
-
-  // Create a symbol node that will be used to represent the stack-incoming
-  // exception object
-  // upon entry to funclets.
-  IRNode *makeExceptionObject() override {
-    throw NotYetImplementedException("makeExceptionObject");
   };
 
   // //////////////////////////////////////////////////////////////////////////

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -43,8 +43,6 @@ extern int _cdecl dbPrint(const char *Form, ...);
 // Max elements per entry in FlowGraphNodeListArray.
 #define FLOW_GRAPH_NODE_LIST_ARRAY_STRIDE 32
 
-#define CANONICAL_EXIT_INIT_VAL (-2)
-
 // OPCODE REMAP
 ReaderBaseNS::CallOpcode remapCallOpcode(ReaderBaseNS::OPCODE Op) {
   ReaderBaseNS::CallOpcode CallOp = (ReaderBaseNS::CallOpcode)OpcodeRemap[Op];
@@ -1452,16 +1450,8 @@ EHRegion *ReaderBase::rgnMakeRegion(ReaderBaseNS::RegionKind Type,
 
   // Convert from ReaderBaseNS region kind to compiler region kind...
   rgnSetRegionType(Result, Type);
-  rgnSetHead(Result, nullptr);
-  rgnSetLast(Result, nullptr);
-  rgnSetIsLive(Result, false);
   rgnSetParent(Result, Parent);
   rgnSetChildList(Result, nullptr);
-  rgnSetHasNonLocalFlow(Result, false);
-
-  if (Type == ReaderBaseNS::RGN_Try) {
-    rgnSetTryCanonicalExitOffset(Result, CANONICAL_EXIT_INIT_VAL);
-  }
 
   if (Parent) {
     rgnPushRegionChild(Parent, Result);
@@ -1510,9 +1500,8 @@ yet
 #ifndef NDEBUG
 
 const char *const RegionTypeNames[] = {
-    "RGN_UNKNOWN", "RGN_NONE",  "RGN_ROOT",    "RGN_TRY",
-    "RGN_EXCEPT",  "RGN_FAULT", "RGN_FINALLY", "RGN_FILTER",
-    "RGN_DTOR",    "RGN_CATCH", "RGN_MEXCEPT", "RGN_MCATCH"};
+    "RGN_ROOT",    "RGN_TRY", "RGN_FAULT", "RGN_FINALLY",
+    "RGN_FILTER", "RGN_MEXCEPT", "RGN_MCATCH"};
 
 void dumpRegion(EHRegion *Region, int Indent = 0) {
   EHRegionList *RegionList;
@@ -1687,9 +1676,6 @@ void ReaderBase::rgnCreateRegionTree(void) {
       rgnSetStartMSILOffset(RegionTry, CurrentEHClause->TryOffset);
       rgnSetEndMSILOffset(RegionTry, CurrentEHClause->TryOffset +
                                          CurrentEHClause->TryLength);
-      rgnSetEndOfClauses(RegionTry, nullptr);
-      rgnSetTryBodyEnd(RegionTry, nullptr);
-      rgnSetTryType(RegionTry, ReaderBaseNS::TRY_None);
     }
 
     if (CurrentEHClause->Flags & CORINFO_EH_CLAUSE_FILTER) {
@@ -1697,26 +1683,9 @@ void ReaderBase::rgnCreateRegionTree(void) {
       RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_MExcept, RegionTry,
                                     RegionTreeRoot, &WorkingAllRegionList);
 
-      ReaderBaseNS::TryKind TryKind = rgnGetTryType(RegionTry);
-      if (TryKind == ReaderBaseNS::TRY_MCatch) {
-        rgnSetTryType(RegionTry, ReaderBaseNS::TRY_MCatchXcpt);
-      } else {
-        if (TryKind == ReaderBaseNS::TRY_None) {
-          rgnSetTryType(RegionTry, ReaderBaseNS::TRY_MXcpt);
-        } else {
-          ASSERTNR(TryKind == ReaderBaseNS::TRY_MXcpt ||
-                   TryKind == ReaderBaseNS::TRY_MCatchXcpt);
-        }
-      }
-
       RegionFilter = rgnMakeRegion(ReaderBaseNS::RGN_Filter, RegionTry,
                                    RegionTreeRoot, &WorkingAllRegionList);
 
-      rgnSetExceptFilterRegion(RegionHandler, RegionFilter);
-      rgnSetExceptTryRegion(RegionHandler, RegionTry);
-      rgnSetExceptUsesExCode(RegionHandler, false);
-
-      rgnSetFilterTryRegion(RegionFilter, RegionTry);
       rgnSetFilterHandlerRegion(RegionFilter, RegionHandler);
 
       rgnSetStartMSILOffset(RegionFilter, CurrentEHClause->FilterOffset);
@@ -1727,19 +1696,11 @@ void ReaderBase::rgnCreateRegionTree(void) {
       if (CurrentEHClause->Flags & CORINFO_EH_CLAUSE_FINALLY) {
         RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_Finally, RegionTry,
                                       RegionTreeRoot, &WorkingAllRegionList);
-
-        ASSERTNR(rgnGetTryType(RegionTry) == ReaderBaseNS::TRY_None);
-        rgnSetTryType(RegionTry, ReaderBaseNS::TRY_Fin);
-        rgnSetFinallyTryRegion(RegionHandler, RegionTry);
-
       } else {
         if (CurrentEHClause->Flags & CORINFO_EH_CLAUSE_FAULT) {
 
-          ASSERTNR(rgnGetTryType(RegionTry) == ReaderBaseNS::TRY_None);
           RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_Fault, RegionTry,
                                         RegionTreeRoot, &WorkingAllRegionList);
-          rgnSetTryType(RegionTry, ReaderBaseNS::TRY_Fault);
-          rgnSetFaultTryRegion(RegionHandler, RegionTry);
         } else {
           // we need to touch the class at JIT time
           // otherwise the classloader kicks in at exception time
@@ -1757,22 +1718,7 @@ void ReaderBase::rgnCreateRegionTree(void) {
           RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_MCatch, RegionTry,
                                         RegionTreeRoot, &WorkingAllRegionList);
 
-          ReaderBaseNS::TryKind TryKind;
-
-          TryKind = rgnGetTryType(RegionTry);
-          if (TryKind == ReaderBaseNS::TRY_MXcpt) {
-            rgnSetTryType(RegionTry, ReaderBaseNS::TRY_MCatchXcpt);
-          } else {
-            if (TryKind == ReaderBaseNS::TRY_None) {
-              rgnSetTryType(RegionTry, ReaderBaseNS::TRY_MCatch);
-            } else {
-              ASSERTNR(
-                  (rgnGetTryType(RegionTry) == ReaderBaseNS::TRY_MCatch) ||
-                  (rgnGetTryType(RegionTry) == ReaderBaseNS::TRY_MCatchXcpt));
-            }
-          }
           rgnSetCatchClassToken(RegionHandler, CurrentEHClause->ClassToken);
-          rgnSetCatchTryRegion(RegionHandler, RegionTry);
         }
       }
     }
@@ -1927,199 +1873,6 @@ void ReaderBase::fgRemoveUnusedBlocks(FlowGraphNode *FgHead) {
   }
 }
 
-// This code returns the MSIL offset of the "canonical" landing point
-// for leaves from a region.  If the last instruction of a region is a
-// leave that doesn't point to this point, then it is nonLocal!
-uint32_t ReaderBase::fgGetRegionCanonicalExitOffset(EHRegion *Region) {
-  uint32_t CanonicalOffset;
-  EHRegion *ChildRegion, *TryRegion = nullptr, *ParentRegion;
-  ReaderBaseNS::RegionKind RegionType;
-
-  RegionType = rgnGetRegionType(Region);
-
-  switch (RegionType) {
-  case ReaderBaseNS::RGN_Try:
-    TryRegion = Region;
-    break;
-  case ReaderBaseNS::RGN_MCatch:
-  case ReaderBaseNS::RGN_MExcept:
-    TryRegion = rgnGetParent(Region);
-    break;
-  default:
-    // Nonlocal gotos are not legal in other regions!
-    // ASSERTNR(UNREACHED);
-    return (uint32_t)-1;
-    ;
-  }
-
-  // Short circuit, use cached result if canonical offset
-  // has already been determined for this try region.
-  CanonicalOffset = (uint32_t)rgnGetTryCanonicalExitOffset(TryRegion);
-  if (CanonicalOffset != (uint32_t)CANONICAL_EXIT_INIT_VAL) {
-    return CanonicalOffset;
-  }
-
-  // A canonical offset is the last catch of a series of adjacent
-  // catch blocks, all belonging to a single try, the first of whom
-  // starts at the end offset of the try.
-  //
-  // To discover this, write each catch end offset in a Bufferer at its
-  // start offset.  Then iterate over the Bufferer from the try end
-  // offset to discover the last adjacent try. The last discovered
-  // offset will be the canonical one.
-  //
-  // TODO: We could cache the canonical offset on the try region, but
-  // even in extreme cases (2000 catches on a single try) this showed
-  // no significant overall speedup.
-  EHRegionList *RegionList;
-  int *Buffer;
-  int BufferSize;
-  int Index;
-
-  // Buff size must include an entry for 1 past the end of the
-  // Bufferer. This will be used if the try region ends at the end of
-  // the code Bufferer.
-  BufferSize = (MethodInfo->ILCodeSize + 1) * sizeof(uint32_t);
-
-  // If the user gave us an absurd amount of IL (say computer
-  // generated test cases), then an alloca here could stack overflow.
-  // Going to a pool allocator is overkill because we only need the
-  // memory for this short period of time, so go directly to malloc.
-  // We arbitrarily pick 100 * 1024 as a threshold for this.
-  if (FgGetRegionCanonicalExitOffsetBuff != nullptr) {
-    ASSERTNR(BufferSize >= 100 * 1024);
-    Buffer = FgGetRegionCanonicalExitOffsetBuff;
-  } else if (BufferSize < 100 * 1024) {
-    Buffer = (int *)_alloca(BufferSize);
-  } else {
-    Buffer = (int *)getTempMemory(BufferSize);
-
-    // Wups, out of memory!
-    if (Buffer == nullptr) {
-      fatal(CORJIT_OUTOFMEM);
-    }
-
-    FgGetRegionCanonicalExitOffsetBuff = Buffer;
-  }
-
-  memset(Buffer, -1, BufferSize);
-
-  // Place catch end offsets at the catch start offsets.
-  for (RegionList = rgnGetChildList(TryRegion); RegionList;
-       RegionList = rgnListGetNext(RegionList)) {
-    ChildRegion = rgnListGetRgn(RegionList);
-    Buffer[rgnGetStartMSILOffset(ChildRegion)] =
-        rgnGetEndMSILOffset(ChildRegion);
-  }
-
-  // From the end of the current try region, walk to the last adjacent catch.
-
-  Index = rgnGetEndMSILOffset(TryRegion);
-  while (Buffer[Index] != -1) {
-    Index = Buffer[Index];
-  }
-
-  CanonicalOffset = Index;
-
-  if (CanonicalOffset != (uint32_t)-1) {
-    // It is possible that we have multiple nested regions all ending
-    // on the same MSIL offset.  If this happens, then we really don't
-    // have a "canonical" landing point in our framework.  We detect
-    // this here, and return 0, so that the reader will consider this
-    // a nonlocal goto.
-    ParentRegion = rgnGetParent(TryRegion);
-
-    while (ParentRegion) {
-      if (rgnGetEndMSILOffset(ParentRegion) == CanonicalOffset) {
-        CanonicalOffset = (uint32_t)-1;
-        break;
-      }
-      ParentRegion = rgnGetParent(ParentRegion);
-    }
-  }
-
-  // We've determined the canonical exit for this try, cache it.
-  rgnSetTryCanonicalExitOffset(TryRegion, CanonicalOffset);
-
-  return CanonicalOffset;
-}
-
-// Determines if leave causes region exit. This is true if the target
-// of the leave lies in an EH region outside of the EH region that
-// contains the leave.
-bool ReaderBase::fgLeaveIsNonLocal(FlowGraphNode *Fg, uint32_t LeaveOffset,
-                                   uint32_t LeaveTarget,
-                                   bool *EndsWithNonLocalGoto) {
-  EHRegion *CurrentRegion;
-
-  *EndsWithNonLocalGoto = false;
-
-  // We want to find the non-local control flow out of any of
-  // the regions that is due to a leave.  If we are on a LEAVE
-  // and the next MSIL instruction is not a region delimiter in
-  // the little table used to buffer a sorted EIT then clearly this
-  // is a jmp out of the middle of some region.
-  // However (there's always one of these) This example indicates
-  // an additional special case we need to check for.
-  //
-  //   try {
-  //   }
-  //   catch {
-  //
-  //         leave
-  //         try {
-  //
-  //
-  // Here the next instruction after the leave is in the marker array
-  // but the leave is a non-local control flow. In these edge situations
-  // I need to check against the current region node.
-  //
-  // If the offsets of the current TRY_REGION node contain
-  // the next instruction then we may trivially deduce that
-  // the leave is out of the region if the currOffset is NOT
-  // pointing to the end of the current region.
-  //
-  // This has been refined to actually look at the destination of the
-  // jump.  We did this for a couple of reasons.
-  //
-  // (1) There can be a leave instruction in the middle of a region which
-  //     actually is staying within the region.  This is why the check below
-  //     include the checks with currOffset + nDelta... if we are staying within
-  //     our region, then this is not a nonLocalGoto!
-  // (2) It is possible that we do indeed have a leave as the last instruction
-  //     in a region, but this doesn't mean that the leave is actually going
-  //     to the canonical place that we expect!  This is why we say currOffset
-  //     <=
-  //     REGION_END_MSIL...   If we are in the case where currOffset ==
-  //     REGION_END
-  //     then we'll need to do additional work to see if this is actually not
-  //     going to the canonical place!
-
-  CurrentRegion = fgNodeGetRegion(Fg);
-  if ((CurrentRegion) &&
-      (rgnGetRegionType(CurrentRegion) != ReaderBaseNS::RGN_Root) &&
-      (rgnGetStartMSILOffset(CurrentRegion) < LeaveOffset) &&
-      (LeaveOffset <= rgnGetEndMSILOffset(CurrentRegion)) &&
-      ((LeaveTarget < rgnGetStartMSILOffset(CurrentRegion)) ||
-       (LeaveTarget >= rgnGetEndMSILOffset(CurrentRegion)))) {
-    if (LeaveOffset == rgnGetEndMSILOffset(CurrentRegion)) {
-      // We need to confirm whether this leave is going to the canonical place!
-      uint32_t CanonicalOffset = fgGetRegionCanonicalExitOffset(CurrentRegion);
-      if (LeaveTarget == CanonicalOffset) {
-        // Though this was an explicit goto which is to a nonlocal location,
-        // it is canonical and correct... therefore it doesn't need any
-        // tracking!
-        return false;
-      }
-      *EndsWithNonLocalGoto = true;
-    }
-    // Record that this region is the source of a non-local goto.
-    rgnSetHasNonLocalFlow(CurrentRegion, true);
-    return true;
-  }
-  return false;
-}
-
 // fgSplitBlock
 //
 // Common block split routine.  Splits a block in the flow graph and
@@ -2242,274 +1995,6 @@ void ReaderBase::fgReplaceBranchTargets() {
          List = List->getNext()) {
       Block = fgReplaceBranchTarget(List->getOffset(), List->getNode(), Block);
     }
-  }
-}
-
-// fgInsertBeginRegionExceptionNode
-//
-// Given an exception node (that begins a region (OPTRY,
-// OPFILTERBEGIN, etc...))  and its offset this function searches the
-// flow graph for the basic block that this node belongs in. It then
-// inserts the node at the appropriate location and modifies the flow
-// graph if necesary.
-//
-// This function serves the secondary purpose of fixing any errors
-// made by getRegionFromOffset(). The block that contains the node and
-// any other non-EH nodes in the block will have their region info
-// patched up to match the region info of the inserted node.
-void ReaderBase::fgInsertBeginRegionExceptionNode(
-    uint32_t Offset, // This is the offset where you want Node to be
-    IRNode *Node     // This is our actual EH end node (OPTRY, etc.)
-    ) {
-  FlowGraphNode *Block;
-
-  irNodeExceptSetMSILOffset(Node, Offset);
-  bool Found = false;
-
-  // Find the block that this exception node should be placed into
-  for (Block = fgGetHeadBlock(); Block != nullptr;
-       Block = fgNodeGetNext(Block)) {
-    uint32_t Start = fgNodeGetStartMSILOffset(Block);
-    uint32_t End = fgNodeGetEndMSILOffset(Block);
-
-    IRNode *InsertionPointNode;
-
-    // If the offset is in this range we've Found the correct block
-    if (Offset >= Start && Offset < End) {
-      EHRegion *StartNodeRegion;
-      uint32_t LastOffset;
-      bool PreceedingNodeIsExceptRegionStart;
-
-      // Start with the first node in the block
-      InsertionPointNode = irNodeGetInsertPointAfterMSILOffset(
-          fgNodeGetStartInsertIRNode(Block), Offset);
-      PreceedingNodeIsExceptRegionStart =
-          fgEHRegionStartRequiresBlockSplit(InsertionPointNode);
-
-      // Insert the EH node here
-      irNodeInsertBefore(InsertionPointNode, Node);
-
-      // We must split the block if the InsertionPointNode was already
-      // preceeded by an exception node because otherwise the block
-      // would contain two adjacent exception nodes. Also split if the
-      // offset is not the start of this block.
-      //
-      // The first node in a block that contains execption nodes can
-      //  be one of two things...
-      //     (1) An exception node
-      //     (2) A label
-      //
-      // If the exception node does NOT have the same offset as the
-      // start of the block then we need to split the block along the
-      // exception node. If the offset of the exception node is the
-      // same as the starting offset of the block then the block only
-      // needs to be split if the block already begins with a
-      // different exception node.
-      if ((Offset != Start) || PreceedingNodeIsExceptRegionStart) {
-        Block = fgSplitBlock(Block, Offset, Node);
-      }
-
-      // Now set the block to have the same region as EH node that was
-      // just inserted. This corrects the mistake from when two
-      // regions begin with the same offset.
-      StartNodeRegion = irNodeGetRegion(Node);
-      LastOffset = rgnGetEndMSILOffset(StartNodeRegion);
-      fgSetBlockToRegion(Block, StartNodeRegion, LastOffset);
-
-      Found = true;
-      break;
-    }
-  }
-  ASSERTNR(Found);
-}
-
-// fgInsertEndRegionExceptionNode
-//
-// Given an exception node that ends a region, and its offset this
-// function searches the flow graph for the basic block that this node
-// belongs in. It then inserts the node at the appropriate location
-// and modifies the flow graph if necesary.
-void ReaderBase::fgInsertEndRegionExceptionNode(
-    uint32_t Offset, // This is the offset where you want Node to be
-    IRNode *Node     // This is our actual EH End node
-    ) {
-  FlowGraphNode *Block;
-
-  irNodeExceptSetMSILOffset(Node, Offset);
-
-  for (Block = fgGetHeadBlock(); Block != nullptr;
-       Block = fgNodeGetNext(Block)) {
-    uint32_t Start = fgNodeGetStartMSILOffset(Block);
-    uint32_t End = fgNodeGetEndMSILOffset(Block);
-    IRNode *InsertionPointNode;
-
-    // Please note that we are checking for Start < Offset <= End !
-    // For the beginning marker we were checking for Start <= Offset < End.
-    if (Start < Offset && Offset <= End) {
-
-      // We're about to insert the terminallabel into the middle of a block.
-      // That means we need to get the correct place to insert it.
-      // We'll start with the last tuple in the block.
-      InsertionPointNode = irNodeGetInsertPointBeforeMSILOffset(
-          fgNodeGetEndInsertIRNode(Block), Offset);
-
-      // Insert the EH tuple
-      insertEHAnnotationNode(InsertionPointNode, Node);
-
-      // No need to keep processing blocks!
-      break;
-    }
-  }
-}
-
-void ReaderBase::fgEnsureEnclosingRegionBeginsWithLabel(
-    IRNode *HandlerStartNode) {
-  EHRegion *HandlerRegion, *TryRegion;
-  IRNode *HandlerLabelNode, *ExceptNode;
-
-  ASSERTNR(HandlerStartNode);
-
-  HandlerRegion = irNodeGetRegion(HandlerStartNode);
-
-  ASSERTNR(rgnGetRegionType(HandlerRegion) == ReaderBaseNS::RGN_Finally ||
-           rgnGetRegionType(HandlerRegion) == ReaderBaseNS::RGN_Filter ||
-           rgnGetRegionType(HandlerRegion) == ReaderBaseNS::RGN_Fault ||
-           rgnGetRegionType(HandlerRegion) == ReaderBaseNS::RGN_MCatch ||
-           rgnGetRegionType(HandlerRegion) == ReaderBaseNS::RGN_MExcept);
-
-  TryRegion = rgnGetParent(HandlerRegion);
-  ASSERTNR(rgnGetRegionType(TryRegion) == ReaderBaseNS::RGN_Try);
-
-  // Adjust region start to any labels that are located before the region
-  HandlerLabelNode =
-      irNodeGetFirstLabelOrInstrNodeInEnclosingBlock(HandlerStartNode);
-  ASSERTNR(HandlerLabelNode); // Assert that we found something
-
-  if (HandlerLabelNode == nullptr) {
-    return;
-  }
-
-  // If this handler doesn't begin with a label make it so.
-  if (!irNodeIsLabel(HandlerLabelNode)) {
-    ExceptNode = HandlerLabelNode;
-    /*HandlerLabelNode =
-        MakeLabel(irNodeGetMSILOffset(HandlerLabelNode), HandlerRegion);*/
-    throw NotYetImplementedException("handler doesn't begin with label");
-    irNodeInsertBefore(ExceptNode, HandlerLabelNode);
-  }
-  //  Mark the label as an EH label, otherwise the FG builder might remove it.
-  markAsEHLabel(HandlerLabelNode);
-
-  // Point the region head to the label that at the
-  //  start of the handler
-  rgnSetHead((EHRegion *)HandlerRegion, (IRNode *)HandlerLabelNode);
-}
-
-void ReaderBase::fgInsertTryEnd(EHRegion *Region) {
-  IRNode *TryEndNode, *EndOfClausesNode;
-
-  TryEndNode = makeTryEndNode();
-  irNodeExceptSetMSILOffset(TryEndNode,
-                            irNodeGetMSILOffset(rgnGetLast(Region)));
-  irNodeInsertAfter(rgnGetLast(Region), TryEndNode);
-  rgnSetLast(Region, TryEndNode);
-
-  EndOfClausesNode = findTryRegionEndOfClauses(Region);
-  rgnSetEndOfClauses(Region, EndOfClausesNode);
-  insertRegionAnnotation(rgnGetHead(Region), rgnGetLast(Region));
-}
-
-// fgInsertEHAnnotations
-//
-// - Create region start and end nodes
-// - Insert EH-flow nodes which indicate eh flow arcs.
-//
-// This function works recursively to insert all of the EH IR.  Start
-// at the root of the region tree and moves down. Along its path it
-// first inserts the start-of-region node, then the end-of-region node
-// for its given region. It then inserts EH-Flow nodes to indicate
-// reachibility for eh funclets and handlers.  On the way back up the
-// recursive path the algorithm inserts try end nodes and an EH-Flow
-// edge from the try region start to the try region end. This
-// additional flow from try to tryend is necessary for placekeeping,
-// to prevent the reader from deleting the region end node.
-void ReaderBase::fgInsertEHAnnotations(EHRegion *Region) {
-  uint32_t OffsetStart, OffsetEnd;
-  IRNode *RegionStartNode, *RegionEndNode;
-  ReaderBaseNS::RegionKind RegionType;
-
-  RegionType = rgnGetRegionType(Region);
-  if (RegionType != ReaderBaseNS::RGN_Root) {
-
-    OffsetStart = rgnGetStartMSILOffset(Region);
-    OffsetEnd = rgnGetEndMSILOffset(Region);
-
-    // If verification is turned on, make sure that all the
-    //  EIT offsets are acutally instructions
-    if (VerificationNeeded) {
-      if (!isOffsetInstrStart(OffsetStart))
-        BADCODE(RegionType == ReaderBaseNS::RGN_Try ? MVER_E_TRY_START
-                                                    : MVER_E_HND_START);
-      if (OffsetEnd != MethodInfo->ILCodeSize &&
-          (!isOffsetInstrStart(OffsetEnd)))
-        BADCODE(RegionType == ReaderBaseNS::RGN_Try ? MVER_E_TRY_START
-                                                    : MVER_E_HND_START);
-    }
-
-    // Add the region starting marker
-    RegionStartNode = makeRegionStartNode(RegionType);
-    rgnSetHead(Region, RegionStartNode);
-
-    fgInsertBeginRegionExceptionNode(OffsetStart, RegionStartNode);
-
-    // Add the region ending marker.
-    RegionEndNode = makeRegionEndNode(rgnGetRegionType(Region));
-    rgnSetLast(Region, RegionEndNode);
-    fgInsertEndRegionExceptionNode(OffsetEnd, RegionEndNode);
-
-    // Patch the REGION_TRYBODY_END field and REGION_LAST field
-    if (RegionType == ReaderBaseNS::RGN_Try) {
-      rgnSetTryBodyEnd(Region, RegionEndNode);
-    } else if ((rgnGetRegionType(rgnGetParent(Region)) ==
-                ReaderBaseNS::RGN_Try) &&
-               (irNodeGetMSILOffset(RegionEndNode) >
-                irNodeGetMSILOffset(rgnGetLast(rgnGetParent(Region))))) {
-      rgnSetLast(rgnGetParent(Region), RegionEndNode);
-    }
-
-    // Notify GenIR that we've encountered a handler region (so that
-    // it might insert flow annotations.)
-    switch (RegionType) {
-    case ReaderBaseNS::RGN_Finally:
-    case ReaderBaseNS::RGN_Filter:
-    case ReaderBaseNS::RGN_Fault:
-    case ReaderBaseNS::RGN_MCatch:
-    case ReaderBaseNS::RGN_MExcept:
-      fgEnsureEnclosingRegionBeginsWithLabel(RegionStartNode);
-
-      insertHandlerAnnotation(Region);
-    default:
-      // reached
-      break;
-    }
-
-    // GenIR annotation of all EH regions
-    insertRegionAnnotation(RegionStartNode, RegionEndNode);
-  }
-
-  EHRegionList *ChildList;
-  for (ChildList = rgnGetChildList(Region); ChildList != nullptr;
-       ChildList = rgnListGetNext(ChildList)) {
-    fgInsertEHAnnotations(rgnListGetRgn(ChildList));
-  }
-
-  if (RegionType == ReaderBaseNS::RGN_Try) {
-    // Insert the try end IR based on information gathered above
-    fgInsertTryEnd(Region);
-
-    // Move any blocks that that are not from a handler (these should
-    // all be from the parent Region)
-    fgCleanupTryEnd(Region);
   }
 }
 
@@ -3403,18 +2888,6 @@ FlowGraphNode *ReaderBase::fgBuildBasicBlocksFromBytes(uint8_t *Buffer,
                          BranchInfo->TargetOffset, BranchInfo->IsLeave);
       BranchInfo = BranchInfo->Next;
     }
-  }
-
-  // PHASE 4:
-  // GenIR calls to annotate IR stream with EH information
-  if (EhRegionTree) {
-    // The common reader must insert reachibility edges to indicate
-    // that filter and handler blocks are reachable.
-    //
-    // The client is also free to insert his own edges/code annotations.
-    //
-    // TODO: figure out how much of this we need in LLILC:
-    // fgInsertEHAnnotations(EhRegionTree);
   }
 
   // POST-PHASE - Compiler dependent flow graph cleanup
@@ -6879,11 +6352,6 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
       Param->HasFallThrough = false;
       BREAK_ON_VERIFY_ONLY;
 
-      // It is useful to know that the ENDFINALLY was actually reachable
-      // in this finally.  (Some clients, may for example, make cloning
-      // decisions based on this.)
-      rgnSetFinallyEndIsReachable(CurrentRegion, true);
-
       // Doesn't turn into anything,
       // but it's a block marker, so it needs to consume some bytes
       // However, this information should also been conveyed by
@@ -7324,14 +6792,8 @@ void ReaderBase::readBytesForFlowGraphNodeHelper(
       BREAK_ON_VERIFY_ONLY;
 
       {
-        bool NonLocal, EndsWithNonLocalGoto;
-
         clearStack();
-        NonLocal = fgLeaveIsNonLocal(Fg, NextOffset, TargetOffset,
-                                     &EndsWithNonLocalGoto);
-
-        // Note here we record the nonlocal flow
-        leave(TargetOffset, NonLocal, EndsWithNonLocalGoto);
+        leave(TargetOffset);
       }
       break;
 
@@ -8248,11 +7710,6 @@ void ReaderBase::msilToIR(void) {
     free(RegionList);
     free(Region);
     RegionList = Next;
-  }
-
-  if (FgGetRegionCanonicalExitOffsetBuff != nullptr) {
-    free(FgGetRegionCanonicalExitOffsetBuff);
-    FgGetRegionCanonicalExitOffsetBuff = nullptr;
   }
 }
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -174,18 +174,6 @@ void rgnSetEndMSILOffset(EHRegion *Region, uint32_t Offset) {
   Region->EndMsilOffset = Offset;
 }
 
-IRNode *rgnGetHead(EHRegion *Region) { return nullptr; }
-
-void rgnSetHead(EHRegion *Region, IRNode *Head) { return; }
-
-IRNode *rgnGetLast(EHRegion *Region) { return nullptr; }
-
-void rgnSetLast(EHRegion *Region, IRNode *Last) { return; }
-
-bool rgnGetIsLive(EHRegion *Region) { return false; }
-
-void rgnSetIsLive(EHRegion *Region, bool Live) { return; }
-
 void rgnSetParent(EHRegion *Region, EHRegion *Parent) {
   Region->Parent = Parent;
 }
@@ -210,53 +198,11 @@ void rgnSetChildList(EHRegion *Region, EHRegionList *Children) {
 }
 EHRegionList *rgnGetChildList(EHRegion *Region) { return Region->Children; }
 
-bool rgnGetHasNonLocalFlow(EHRegion *Region) { return false; }
-void rgnSetHasNonLocalFlow(EHRegion *Region, bool NonLocalFlow) { return; }
-IRNode *rgnGetEndOfClauses(EHRegion *Region) { return nullptr; }
-void rgnSetEndOfClauses(EHRegion *Region, IRNode *Node) { return; }
-IRNode *rgnGetTryBodyEnd(EHRegion *Region) { return nullptr; }
-void rgnSetTryBodyEnd(EHRegion *Region, IRNode *Node) { return; }
-ReaderBaseNS::TryKind rgnGetTryType(EHRegion *Region) {
-  return ReaderBaseNS::TryKind::TRY_None;
-}
-void rgnSetTryType(EHRegion *Region, ReaderBaseNS::TryKind Type) { return; }
-int rgnGetTryCanonicalExitOffset(EHRegion *TryRegion) { return 0; }
-void rgnSetTryCanonicalExitOffset(EHRegion *TryRegion, int32_t Offset) {
-  return;
-}
-EHRegion *rgnGetExceptFilterRegion(EHRegion *Region) { return nullptr; }
-void rgnSetExceptFilterRegion(EHRegion *Region, EHRegion *FilterRegion) {
-  return;
-}
-EHRegion *rgnGetExceptTryRegion(EHRegion *Region) { return nullptr; }
-void rgnSetExceptTryRegion(EHRegion *Region, EHRegion *TryRegion) { return; }
-bool rgnGetExceptUsesExCode(EHRegion *Region) { return false; }
-void rgnSetExceptUsesExCode(EHRegion *Region, bool UsesExceptionCode) {
-  return;
-}
-EHRegion *rgnGetFilterTryRegion(EHRegion *Region) { return nullptr; }
-void rgnSetFilterTryRegion(EHRegion *Region, EHRegion *TryRegion) { return; }
 EHRegion *rgnGetFilterHandlerRegion(EHRegion *Region) {
   return Region->HandlerRegion;
 }
 void rgnSetFilterHandlerRegion(EHRegion *Region, EHRegion *Handler) {
   Region->HandlerRegion = Handler;
-}
-EHRegion *rgnGetFinallyTryRegion(EHRegion *FinallyRegion) { return nullptr; }
-void rgnSetFinallyTryRegion(EHRegion *FinallyRegion, EHRegion *TryRegion) {
-  return;
-}
-bool rgnGetFinallyEndIsReachable(EHRegion *FinallyRegion) { return false; }
-void rgnSetFinallyEndIsReachable(EHRegion *FinallyRegion, bool IsReachable) {
-  return;
-}
-EHRegion *rgnGetFaultTryRegion(EHRegion *FaultRegion) { return nullptr; }
-void rgnSetFaultTryRegion(EHRegion *FaultRegion, EHRegion *TryRegion) {
-  return;
-}
-EHRegion *rgnGetCatchTryRegion(EHRegion *CatchRegion) { return nullptr; }
-void rgnSetCatchTryRegion(EHRegion *CatchRegion, EHRegion *TryRegion) {
-  return;
 }
 mdToken rgnGetCatchClassToken(EHRegion *CatchRegion) {
   return CatchRegion->CatchClassToken;
@@ -6751,8 +6697,7 @@ uint32_t GenIR::updateLeaveOffset(EHRegion *Region, uint32_t LeaveOffset,
   return InnermostTargetOffset;
 }
 
-void GenIR::leave(uint32_t TargetOffset, bool IsNonLocal,
-                  bool EndsWithNonLocalGoto) {
+void GenIR::leave(uint32_t TargetOffset) {
   // TODO: handle leaves from handler regions
   return;
 }


### PR DESCRIPTION
Delete a bunch of code left over from a previous EH tracking regime, which
we won't be using going forward.