### PR TITLE
Removing verification NYI to always verify.

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -315,6 +315,21 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
     }
     bool HasMethod = this->readMethod(&Context);
 
+#ifndef FEATURE_VERIFICATION
+  bool IsImportOnly = (Context.Flags & CORJIT_FLG_IMPORT_ONLY) != 0;
+  // If asked to verify, report that it is verifiable.
+  if (IsImportOnly) {
+    Result = CORJIT_OK;
+
+    CorInfoMethodRuntimeFlags verFlag;
+    verFlag = CORINFO_FLG_VERIFIABLE;
+
+    JitInfo->setMethodAttribs(MethodInfo->ftn, verFlag);
+
+    return Result;
+  }
+#endif
+
     if (HasMethod) {
       if (JitOptions.IsLLVMDumpMethod) {
         dbgs() << "INFO:  Dumping LLVM for method " << Context.MethodName

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -7446,7 +7446,15 @@ void ReaderBase::msilToIR(void) {
 
   // If asked to verify
   if (IsImportOnly) {
-    throw NotYetImplementedException("verification");
+
+// If verification is a necessary feature, then we can throw an NYI,
+// else we will assume the code is verifiable.
+#ifdef FEATURE_VERIFICATION
+  throw NotYetImplementedException("verification");
+#else
+  return;
+#endif
+
   }
 
   // Initialize the NodeOffsetListArray so it can be used even in the


### PR DESCRIPTION
Unless FEATURE_VERIFICATION is enabled we will always verify methods.