### PR TITLE
Some retargeting support and warnings cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,55 +121,55 @@ if ( NOT LLVM_TARGET_IS_CROSSCOMPILE_HOST )
   endif()
 
   # Check for CoreCLR headers
-  find_path(CORINFO_H "corinfo.h" HINTS "${CORECLR_INCLUDE}")
+  find_path(CORINFO_H "corinfo.h" HINTS "${CORECLR_INCLUDE}" NO_CMAKE_FIND_ROOT_PATH)
   if(CORINFO_H STREQUAL CORINFO_H-NOTFOUND)
-    message(FATAL_ERROR "Cannot find corinfo.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
+    message(FATAL_ERROR "Cannot find corinfo.h in ${CORECLR_INCLUDE}. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
     unset(WITH_CORECLR CACHE)
   endif()
 
   get_filename_component(CORECLR_INCLUDE "${CORECLR_INCLUDE}" DIRECTORY CACHE)
 
-  find_path(CORJIT_H "corjit.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+  find_path(CORJIT_H "corjit.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(CORJIT_H STREQUAL CORJIT_H-NOTFOUND)
     message(FATAL_ERROR "Cannot find corjit.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
 
-  find_path(CORERROR_H "corerror.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+  find_path(CORERROR_H "corerror.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(CORERROR_H STREQUAL CORERROR_H-NOTFOUND)
     message(FATAL_ERROR "Cannot find corerror.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
 
-  find_path(CORHDR_H "corhdr.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+  find_path(CORHDR_H "corhdr.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(CORHDR_H STREQUAL CORHDR_H-NOTFOUND)
     message(FATAL_ERROR "Cannot find corhdr.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
 
-  find_path(COR_H "cor.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+  find_path(COR_H "cor.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(COR_H STREQUAL COR_H-NOTFOUND)
     message(FATAL_ERROR "Cannot find cor.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
 
-  find_path(OPCODE_DEF "opcode.def" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+  find_path(OPCODE_DEF "opcode.def" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(OPCODE_DEF STREQUAL OPCODE_DEF-NOTFOUND)
     message(FATAL_ERROR "Cannot find opcode.def. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
 
-  find_path(OPENUM_H "openum.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+  find_path(OPENUM_H "openum.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(OPENUM_H STREQUAL OPENUM_H-NOTFOUND)
     message(FATAL_ERROR "Cannot find openum.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
 
-  find_path(GCINFOTYPES_H "gcinfotypes.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+  find_path(GCINFOTYPES_H "gcinfotypes.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(GCINFOTYPES_H STREQUAL GCINFOENCODER_H-NOTFOUND)
     message(FATAL_ERROR "Cannot find gcinfotypes.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
 
-  find_path(GCINFOENCODER_H "gcinfoencoder.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH)
+  find_path(GCINFOENCODER_H "gcinfoencoder.h" PATHS "${CORECLR_INCLUDE}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(GCINFOENCODER_H STREQUAL GCINFOENCODER_H-NOTFOUND)
     message(FATAL_ERROR "Cannot find gcinfoencoder.h. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
 
-  find_path(GCINFOENCODER_CPP "gcinfoencoder.cpp" PATHS "${CORECLR_GCINFO}" NO_DEFAULT_PATH)
+  find_path(GCINFOENCODER_CPP "gcinfoencoder.cpp" PATHS "${CORECLR_GCINFO}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if(GCINFOENCODER_CPP STREQUAL GCINFOENCODER_CPP-NOTFOUND)
     message(FATAL_ERROR "Cannot find gcinfoencoder.cpp. Please set WITH_CORECLR to a directory where CoreCLR was built or installed.")
   endif()
@@ -180,7 +180,8 @@ if ( NOT LLVM_TARGET_IS_CROSSCOMPILE_HOST )
     find_library(CORECLR_PATH "coreclr"
       HINTS ${CORECLR_SEARCH_PATHS}
       DOC "Path to libcoreclr"
-      NO_DEFAULT_PATH)
+      NO_DEFAULT_PATH
+      NO_CMAKE_FIND_ROOT_PATH)
     find_library(CORECLR_PATH "coreclr"
       DOC "Path to libcoreclr")
 

--- a/include/GcInfo/Target.h
+++ b/include/GcInfo/Target.h
@@ -19,15 +19,20 @@
 #include "global.h"
 #include "corinfo.h"
 
-#if (defined(_TARGET_X86_) || defined(_TARGET_X64_) || defined(_TARGET_AMD64_))
+#if (defined(_TARGET_X86_) || defined(_TARGET_X64_) ||                         \
+     defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_))
 
 // Identify the frame-pointer register number
 
 #if defined(_TARGET_X86_)
 #define REGNUM_FPBASE ICorDebugInfo::RegNum::REGNUM_EBP
-#else
+#elif (defined(_TARGET_AMD64_) || defined(_TARGET_X64_))
 #define REGNUM_FPBASE ICorDebugInfo::RegNum::REGNUM_RBP
-#endif // defined(_TARGET_X86_)
+#elif defined(_TARGET_ARM64_)
+#define REGNUM_FPBASE ICorDebugInfo::RegNum::REGNUM_FP
+#endif
+
+#if (defined(_TARGET_X86_) || defined(_TARGET_X64_) || defined(_TARGET_AMD64_))
 
 // Define encodings for DWARF registers
 // Size variants (ex: AL,AH,AX,EAX,RAX) all get the same Dwarf register number
@@ -53,8 +58,16 @@
 #define DW_FRAME_POINTER DW_RBP
 #define DW_STACK_POINTER DW_RSP
 
+#elif defined(_TARGET_ARM64_)
+
+#define DW_FRAME_POINTER 29
+#define DW_STACK_POINTER 31
+
+#endif
+
 #else
 #error GCTables not implemented for this target
-#endif // defined(_TARGET_X86_ || _TARGET_X64_ || _TARGET_AMD64_)
+#endif // defined(_TARGET_X86_ || _TARGET_X64_ || _TARGET_AMD64_ ||
+       // _TARGET_ARM64_)
 
 #endif // GCINFO_TARGET_H

--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -124,8 +124,9 @@ struct LLILCJitPerThreadState {
 public:
   /// Construct a new state.
   LLILCJitPerThreadState()
-      : LLVMContext(), ClassTypeMap(), ReverseClassTypeMap(), BoxedTypeMap(),
-        ArrayTypeMap(), FieldIndexMap(), JitContext(nullptr) {}
+      : LLVMContext(), JitContext(nullptr), ClassTypeMap(),
+        ReverseClassTypeMap(), BoxedTypeMap(), ArrayTypeMap(), FieldIndexMap() {
+  }
 
   /// Each thread maintains its own \p LLVMContext. This is where
   /// LLVM keeps definitions of types and similar constructs.

--- a/include/Reader/ophelper.def
+++ b/include/Reader/ophelper.def
@@ -59,7 +59,7 @@
 #define InlineSig             4
 #define ShortInlineBrTarget   1
 #define InlineBrTarget        4
-#define InlineSwitch          (BYTE)-1
+#define InlineSwitch          -1
 #define InlineType            4
 #define InlineString          4
 #define InlineField           4

--- a/include/Reader/readerenum.h
+++ b/include/Reader/readerenum.h
@@ -504,7 +504,7 @@ typedef enum {
 /// \brief Used to map MSIL opcodes to function-specific opcode enumerations.
 ///
 /// Uses the same ordering as enum opcode_t from openum.h.
-SELECTANY const char
+SELECTANY const int8_t
     OpcodeRemap[ReaderBaseNS::CEE_MACRO_END - ReaderBaseNS::CEE_NOP] = {
         -1,                     // CEE_NOP,
         -1,                     // CEE_BREAK,

--- a/lib/GcInfo/GcInfo.cpp
+++ b/lib/GcInfo/GcInfo.cpp
@@ -26,8 +26,8 @@ using namespace llvm;
 GCInfo::GCInfo(LLILCJitContext *JitCtx, uint8_t *StackMapData,
                GcInfoAllocator *Allocator, size_t OffsetCor)
     : JitContext(JitCtx), LLVMStackMapData(StackMapData),
-      OffsetCorrection(OffsetCor),
-      Encoder(JitContext->JitInfo, JitContext->MethodInfo, Allocator) {
+      Encoder(JitContext->JitInfo, JitContext->MethodInfo, Allocator),
+      OffsetCorrection(OffsetCor) {
 #if !defined(NDEBUG)
   this->EmitLogs = JitContext->Options->LogGcInfo;
 #endif // !NDEBUG

--- a/lib/GcInfo/GcInfoUtil.cpp
+++ b/lib/GcInfo/GcInfoUtil.cpp
@@ -13,6 +13,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include <stdint.h>
 #include "GcInfoUtil.h"
 
 //*****************************************************************************
@@ -46,7 +47,7 @@ unsigned BitPosition(unsigned value) {
   _ASSERTE((value != 0) && ((value & (value - 1)) == 0));
   const unsigned PRIME = 37;
 
-  static const char hashTable[PRIME] = {
+  static const int8_t hashTable[PRIME] = {
       -1, 0,  1,  26, 2,  23, 27, -1, 3, 16, 24, 30, 28, 11, -1, 13, 4,  7, 17,
       -1, 25, 22, 31, 15, 29, 10, 12, 6, -1, 21, 14, 9,  5,  20, 8,  19, 18};
 
@@ -54,10 +55,10 @@ unsigned BitPosition(unsigned value) {
   _ASSERTE(sizeof(hashTable) == PRIME);
 
   unsigned hash = value % PRIME;
-  unsigned index = hashTable[hash];
-  _ASSERTE(index != (unsigned char)-1);
+  int8_t index = hashTable[hash];
+  _ASSERTE(index != -1);
 
-  return index;
+  return (unsigned)index;
 }
 
 //*****************************************************************************

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -243,7 +243,7 @@ uint32_t getMSILInstrLength(ReaderBaseNS::OPCODE Opcode, uint8_t *Operand) {
   // -1 indicates either an undefined opcode, or an operand
   // with variable length, in both cases the table should
   // not be used.
-  static const uint8_t OperandSizeMap[] = {
+  static const int8_t OperandSizeMap[] = {
 #define OPDEF_HELPER OPDEF_OPERANDSIZE
 #include "ophelper.def"
 #undef OPDEF_HELPER
@@ -258,7 +258,7 @@ uint32_t getMSILInstrLength(ReaderBaseNS::OPCODE Opcode, uint8_t *Operand) {
     uint32_t NumCases = readNumberOfSwitchCases(&Operand);
     Length = sizeof(uint32_t) + (NumCases * sizeof(uint32_t));
   } else {
-    Length = OperandSizeMap[Opcode - ReaderBaseNS::CEE_NOP];
+    Length = (uint32_t)OperandSizeMap[Opcode - ReaderBaseNS::CEE_NOP];
   }
   return Length;
 }
@@ -2120,13 +2120,13 @@ EHRegion *ReaderBase::fgGetRegionFromMSILOffset(uint32_t Offset) {
 void ReaderBase::getMSILInstrStackDelta(ReaderBaseNS::OPCODE Opcode,
                                         uint8_t *Operand, uint16_t *Pop,
                                         uint16_t *Push) {
-  static const char StackPopMap[] = {
+  static const int8_t StackPopMap[] = {
 #define OPDEF_HELPER OPDEF_POPCOUNT
 #include "ophelper.def"
 #undef OPDEF_HELPER
   };
 
-  static const char StackPushMap[] = {
+  static const int8_t StackPushMap[] = {
 #define OPDEF_HELPER OPDEF_PUSHCOUNT
 #include "ophelper.def"
 #undef OPDEF_HELPER

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -328,7 +328,7 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   // Add storage for the indirect result, if any.
   const ABIArgInfo &ResultInfo = ABIMethodSig.getResultInfo();
   bool HasIndirectResult = ResultInfo.getKind() == ABIArgInfo::Indirect;
-  int32_t IndirectResultIndex = -1;
+  uint32_t IndirectResultIndex = (uint32_t)-1;
   if (HasIndirectResult) {
     IndirectResultIndex = ResultInfo.getIndex();
     IndirectResult = functionArgAt(Function, IndirectResultIndex);
@@ -348,7 +348,7 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   Function::arg_iterator ArgI = Function->arg_begin();
   Function::arg_iterator ArgE = Function->arg_end();
   for (uint32_t I = 0, J = 0; ArgI != ArgE; ++I, ++ArgI) {
-    if (IndirectResultIndex >= 0 && I == IndirectResultIndex) {
+    if (HasIndirectResult && I == IndirectResultIndex) {
       // Indirect results aren't homed.
       continue;
     }
@@ -8548,7 +8548,7 @@ IRNode *GenIR::vectorCtorFromOne(int VectorSize, IRNode *Vector,
 
 IRNode *GenIR::vectorCtorFromFloats(int VectorSize, IRNode *Vector,
                                     std::vector<IRNode *> Args) {
-  assert(Args.size() == VectorSize);
+  assert((int)Args.size() == VectorSize);
   std::vector<Type *> Types;
   llvm::LLVMContext &LLVMContext = *JitContext->LLVMContext;
   Type *FloatTy = Type::getFloatTy(LLVMContext);
@@ -8619,7 +8619,7 @@ IRNode *GenIR::vectorCtor(CORINFO_CLASS_HANDLE Class, IRNode *This,
       } else {
         return 0;
       }
-    } else if (Args.size() == VectorSize) {
+    } else if ((int)Args.size() == VectorSize) {
       Return = vectorCtorFromFloats(VectorSize, Vector, Args);
     } else {
       std::vector<Type *> Types;
@@ -8747,7 +8747,6 @@ llvm::Type *GenIR::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE Class,
   static CORINFO_CLASS_HANDLE SIMDVector2Handle = 0;
   static CORINFO_CLASS_HANDLE SIMDVector3Handle = 0;
   static CORINFO_CLASS_HANDLE SIMDVector4Handle = 0;
-  static CORINFO_CLASS_HANDLE SIMDVectorHandle = 0;
 
   LLVMContext &Context = *JitContext->LLVMContext;
 


### PR DESCRIPTION
For headers in "fixed" locations like the ones we get from the CLR, suppress CMake's desire to add cross-targeting prefixes.

Add some Arm64 register mappings for the GC info.

Fix warnings from Clang that were not caused by `-Wnon-virtual-dtor` or `-Wunknown-pragma`.