### PR TITLE
Exclude new Interop test causing an assert in llilc testing

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -2356,6 +2356,10 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_i1.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)
+        \Interop\NativeCallable\NativeCallableTest.cmd" >
+             <Issue>860</Issue>
+        </ExcludeList>
     </ItemGroup>
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(COMPLUS_INSERTSTATEPOINTS)' != ''">	
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\113574\113574.cmd" >

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -2356,8 +2356,7 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_i1.cmd" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)
-        \Interop\NativeCallable\NativeCallableTest.cmd" >
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\NativeCallable\NativeCallableTest.cmd" >
              <Issue>860</Issue>
         </ExcludeList>
     </ItemGroup>


### PR DESCRIPTION
Until we have a chance to investigate exclude this new test from our testing.
Issue is tracked as #860