### PR TITLE
Precise GC: Exclude Methods with Pinning

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -804,6 +804,10 @@ void GenIR::createSym(uint32_t Num, bool IsAuto, CorInfoType CorType,
     break;
   }
 
+  if (IsPinned && JitContext->Options->DoInsertStatepoints) {
+    throw NotYetImplementedException("NYI: Pinning with Precise GC");
+  }
+
   Type *LLVMType = this->getType(CorType, Class);
   if (!IsAuto) {
     const ABIArgInfo &Info = ABIMethodSig.getArgumentInfo(Num);


### PR DESCRIPTION
When compiling for Precise GC runtime, yield methods
that use pinned variables to the default JIT until #29 is fixed.