### PR TITLE
Add hooks for loadfield via helper and storefield via helper

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2345,7 +2345,7 @@ private:
                                      IRNode **ThisPtr);
 
 public:
-  void rdrCallFieldHelper(
+  IRNode *rdrCallFieldHelper(
       CORINFO_RESOLVED_TOKEN *ResolvedToken, CorInfoHelpFunc HelperId,
       bool IsLoad,
       IRNode *Dst, // dst node if this is a load, otherwise nullptr

--- a/include/Reader/readerenum.h
+++ b/include/Reader/readerenum.h
@@ -490,15 +490,14 @@ enum StIndirOpcode {
 
 /// \brief Describes the set of region kinds.
 typedef enum {
-  RGN_Root,        ///< Indicates the root of a region tree.
-  RGN_Try,         ///< Indicates a try region.
-  RGN_Fault,       ///< Indicates a fault region.
-  RGN_Finally,     ///< Indicates a finally region.
-  RGN_Filter,      ///< Indicates a filter region.
-  RGN_MExcept,     ///< Indicates a managed except region.
-  RGN_MCatch       ///< Indicates a managed catch region.
+  RGN_Root,    ///< Indicates the root of a region tree.
+  RGN_Try,     ///< Indicates a try region.
+  RGN_Fault,   ///< Indicates a fault region.
+  RGN_Finally, ///< Indicates a finally region.
+  RGN_Filter,  ///< Indicates a filter region.
+  RGN_MExcept, ///< Indicates a managed except region.
+  RGN_MCatch   ///< Indicates a managed catch region.
 } RegionKind;
-
 }
 
 /// \brief Used to map MSIL opcodes to function-specific opcode enumerations.

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -1500,7 +1500,7 @@ yet
 #ifndef NDEBUG
 
 const char *const RegionTypeNames[] = {
-    "RGN_ROOT",    "RGN_TRY", "RGN_FAULT", "RGN_FINALLY",
+    "RGN_ROOT",   "RGN_TRY",     "RGN_FAULT", "RGN_FINALLY",
     "RGN_FILTER", "RGN_MEXCEPT", "RGN_MCATCH"};
 
 void dumpRegion(EHRegion *Region, int Indent = 0) {
@@ -3521,7 +3521,7 @@ IRNode *ReaderBase::rdrGetCritSect() {
 //
 // For loads, the prototype is 'type ldfld(object, fieldHandle)'.
 // For stores, the prototype is 'void stfld(object, fieldHandle, value)'.
-void ReaderBase::rdrCallFieldHelper(
+IRNode *ReaderBase::rdrCallFieldHelper(
     CORINFO_RESOLVED_TOKEN *ResolvedToken, CorInfoHelpFunc HelperId,
     bool IsLoad,
     IRNode *Dst, // Dst node if this is a load, otherwise nullptr
@@ -3562,6 +3562,7 @@ void ReaderBase::rdrCallFieldHelper(
       const bool MayThrow = true;
       callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, Arg4, Alignment,
                  IsVolatile);
+      return Dst;
     } else {
       // OTHER LOAD
 
@@ -3573,8 +3574,8 @@ void ReaderBase::rdrCallFieldHelper(
 
       // Make the helper call
       const bool MayThrow = true;
-      callHelper(HelperId, MayThrow, Dst, Arg1, Arg2, nullptr, nullptr,
-                 Alignment, IsVolatile);
+      return callHelper(HelperId, MayThrow, Dst, Arg1, Arg2, nullptr, nullptr,
+                        Alignment, IsVolatile);
     }
   } else {
     // STORE
@@ -3608,8 +3609,8 @@ void ReaderBase::rdrCallFieldHelper(
 
       // Make the helper call
       const bool MayThrow = true;
-      callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, Arg4, Alignment,
-                 IsVolatile);
+      return callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, Arg4,
+                        Alignment, IsVolatile);
     } else {
       // assert that the helper id is expected
       ASSERTNR(HelperId == CORINFO_HELP_SETFIELD8 ||
@@ -3630,8 +3631,8 @@ void ReaderBase::rdrCallFieldHelper(
 
       // Make the helper call
       const bool MayThrow = true;
-      callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, nullptr,
-                 Alignment, IsVolatile);
+      return callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, nullptr,
+                        Alignment, IsVolatile);
     }
   }
 }


### PR DESCRIPTION
* Change rdrCallFieldHelper to return an IRNode: return Destination for
  struct fields and the call instruction for others field types for
  load. Return the call for store, but it is not used by store field.
* Add support for LoadField via helper: For struct fields, we want to
  create a temporary IRNode, for all other types, we want to get a
  nullValue of the field type.
* Add call to rdrCallFieldHelper for store field via helper.