### PR TITLE
Add hooks for loadfield via helper and storefield

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -2345,7 +2345,20 @@ private:
                                      IRNode **ThisPtr);
 
 public:
-  void rdrCallFieldHelper(
+  /// \brief Generate IR for getting a helper for a field and calling it.
+  ///
+  /// \param ResolvedToken     Resolved token.
+  /// \param HelperId          Helper ID.
+  /// \param IsLoad            True iff the call is for a load.
+  /// \param Dst               Destination \p IRNode.
+  /// \param Obj               Object \p IRNode.
+  /// \param Value             Value \p IRNode.
+  /// \param Alignment         Alignment.
+  /// \param IsVolatile        True iff it is volatile.
+  ///
+  /// \returns An \p IRNode that represents the target of the call helper, or
+  //           the destination if the field is a struct.
+  IRNode *rdrCallFieldHelper(
       CORINFO_RESOLVED_TOKEN *ResolvedToken, CorInfoHelpFunc HelperId,
       bool IsLoad,
       IRNode *Dst, // dst node if this is a load, otherwise nullptr

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -1500,7 +1500,7 @@ yet
 #ifndef NDEBUG
 
 const char *const RegionTypeNames[] = {
-    "RGN_ROOT",    "RGN_TRY", "RGN_FAULT", "RGN_FINALLY",
+    "RGN_ROOT",   "RGN_TRY",     "RGN_FAULT", "RGN_FINALLY",
     "RGN_FILTER", "RGN_MEXCEPT", "RGN_MCATCH"};
 
 void dumpRegion(EHRegion *Region, int Indent = 0) {
@@ -3521,7 +3521,7 @@ IRNode *ReaderBase::rdrGetCritSect() {
 //
 // For loads, the prototype is 'type ldfld(object, fieldHandle)'.
 // For stores, the prototype is 'void stfld(object, fieldHandle, value)'.
-void ReaderBase::rdrCallFieldHelper(
+IRNode *ReaderBase::rdrCallFieldHelper(
     CORINFO_RESOLVED_TOKEN *ResolvedToken, CorInfoHelpFunc HelperId,
     bool IsLoad,
     IRNode *Dst, // Dst node if this is a load, otherwise nullptr
@@ -3562,6 +3562,7 @@ void ReaderBase::rdrCallFieldHelper(
       const bool MayThrow = true;
       callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, Arg4, Alignment,
                  IsVolatile);
+      return Dst;
     } else {
       // OTHER LOAD
 
@@ -3573,8 +3574,8 @@ void ReaderBase::rdrCallFieldHelper(
 
       // Make the helper call
       const bool MayThrow = true;
-      callHelper(HelperId, MayThrow, Dst, Arg1, Arg2, nullptr, nullptr,
-                 Alignment, IsVolatile);
+      return callHelper(HelperId, MayThrow, Dst, Arg1, Arg2, nullptr, nullptr,
+                        Alignment, IsVolatile);
     }
   } else {
     // STORE
@@ -3608,8 +3609,8 @@ void ReaderBase::rdrCallFieldHelper(
 
       // Make the helper call
       const bool MayThrow = true;
-      callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, Arg4, Alignment,
-                 IsVolatile);
+      return callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, Arg4,
+                        Alignment, IsVolatile);
     } else {
       // assert that the helper id is expected
       ASSERTNR(HelperId == CORINFO_HELP_SETFIELD8 ||
@@ -3630,8 +3631,8 @@ void ReaderBase::rdrCallFieldHelper(
 
       // Make the helper call
       const bool MayThrow = true;
-      callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, nullptr,
-                 Alignment, IsVolatile);
+      return callHelper(HelperId, MayThrow, nullptr, Arg1, Arg2, Arg3, nullptr,
+                        Alignment, IsVolatile);
     }
   }
 }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -4094,7 +4094,24 @@ IRNode *GenIR::loadField(CORINFO_RESOLVED_TOKEN *ResolvedToken, IRNode *Obj,
   // call the helper routine; we can't just load the address
   // and do a load-indirect off it.
   if (FieldInfo.fieldAccessor == CORINFO_FIELD_INSTANCE_HELPER) {
-    throw NotYetImplementedException("LoadField via helper");
+    handleMemberAccess(FieldInfo.accessAllowed, FieldInfo.accessCalloutHelper);
+    
+    IRNode *Destination;
+    const bool IsLoad = true;
+    IRNode *ValueToStore = nullptr;
+    
+    if (FieldInfo.helper == CORINFO_HELP_GETFIELDSTRUCT) {
+      Destination = (IRNode *)createTemporary(FieldTy);
+      setValueRepresentsStruct(Destination);
+    } else {
+      Destination = (IRNode *)Constant::getNullValue(FieldTy);
+    }
+
+    IRNode *Result =
+        rdrCallFieldHelper(ResolvedToken, FieldInfo.helper, IsLoad, Destination,
+                           Obj, ValueToStore, AlignmentPrefix, IsVolatile);
+
+    return convertToStackType(Result, CorInfoType);
   }
 
   // The operand on top of the stack may be the address of the
@@ -4239,7 +4256,11 @@ void GenIR::storeField(CORINFO_RESOLVED_TOKEN *FieldToken, IRNode *ValueToStore,
   if (FieldInfo.fieldAccessor == CORINFO_FIELD_INSTANCE_HELPER) {
     handleMemberAccess(FieldInfo.accessAllowed, FieldInfo.accessCalloutHelper);
 
-    throw NotYetImplementedException("store field via helper");
+    const bool IsLoad = false;
+    IRNode *Destination = nullptr;
+
+    rdrCallFieldHelper(FieldToken, FieldInfo.helper, IsLoad, Destination, Object,
+                       ValueToStore, Alignment, IsVolatile);
     return;
   }
 


### PR DESCRIPTION
* Change rdrCallFieldHelper to return an IRNode: return Destination for
  struct fields and the call instruction for others field types for
  load. Return the call for store, but it is not used by store field.
* Add support for LoadField via helper: For struct fields, we want to
  create a temporary IRNode, for all other types, we want to get a
  nullValue of the field type.
* Add call to rdrCallFieldHelper for store field via helper.