### PR TITLE
Some fixes for ELF relocation processing

### DIFF
--- a/include/Reader/readerenum.h
+++ b/include/Reader/readerenum.h
@@ -490,15 +490,14 @@ enum StIndirOpcode {
 
 /// \brief Describes the set of region kinds.
 typedef enum {
-  RGN_Root,        ///< Indicates the root of a region tree.
-  RGN_Try,         ///< Indicates a try region.
-  RGN_Fault,       ///< Indicates a fault region.
-  RGN_Finally,     ///< Indicates a finally region.
-  RGN_Filter,      ///< Indicates a filter region.
-  RGN_MExcept,     ///< Indicates a managed except region.
-  RGN_MCatch       ///< Indicates a managed catch region.
+  RGN_Root,    ///< Indicates the root of a region tree.
+  RGN_Try,     ///< Indicates a try region.
+  RGN_Fault,   ///< Indicates a fault region.
+  RGN_Finally, ///< Indicates a finally region.
+  RGN_Filter,  ///< Indicates a filter region.
+  RGN_MExcept, ///< Indicates a managed except region.
+  RGN_MCatch   ///< Indicates a managed catch region.
 } RegionKind;
-
 }
 
 /// \brief Used to map MSIL opcodes to function-specific opcode enumerations.

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -1500,7 +1500,7 @@ yet
 #ifndef NDEBUG
 
 const char *const RegionTypeNames[] = {
-    "RGN_ROOT",    "RGN_TRY", "RGN_FAULT", "RGN_FINALLY",
+    "RGN_ROOT",   "RGN_TRY",     "RGN_FAULT", "RGN_FINALLY",
     "RGN_FILTER", "RGN_MEXCEPT", "RGN_MCATCH"};
 
 void dumpRegion(EHRegion *Region, int Indent = 0) {


### PR DESCRIPTION
Addresses #865.

Make sure to use the relocated section for determining final addresses.

Skip some elf-specific sections that contain debut and unwind info when processing relocations.