### PR TITLE
Change casing of options text to be more consistent and match CoreCLR

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -155,7 +155,7 @@ ICorJitCompiler *__stdcall getJit() {
     sys::AddSignalHandler(&LLILCJit::signalHandler, LLILCJit::TheJit);
 
     // Allow LLVM to pick up options via the environment
-    cl::ParseEnvironmentOptions("LLILCJit", "COMplus_altjitOptions");
+    cl::ParseEnvironmentOptions("LLILCJit", "COMPlus_AltJitOptions");
 
     // Statepoint GC does not support Fast ISel yet.
     auto &Opts = cl::getRegisteredOptions();

--- a/lib/Jit/jitoptions.cpp
+++ b/lib/Jit/jitoptions.cpp
@@ -239,7 +239,7 @@ bool JitOptions::queryNonNullNonEmpty(LLILCJitContext &JitContext,
 // Get the GC-Scheme used by the runtime -- conservative/precise
 bool JitOptions::queryUseConservativeGC(LLILCJitContext &Context) {
   return queryNonNullNonEmpty(Context,
-                              (const char16_t *)UTF16("GCCONSERVATIVE"));
+                              (const char16_t *)UTF16("gcConservative"));
 }
 
 // Determine if GC statepoints should be inserted.


### PR DESCRIPTION
Closes #866.

Casing of environment variables doesn't matter on Windows but does on Linux. Make sure we're consistently using `COMPlus` as the prefix and that the suffix is generally camel-cased. There are two classes of exceptions:
* `COMPlus_gcConservative` is specified that way by the CoreCLR.
* LLILC specific options (ones that the CoreCLR doesn't look for or care about) are generally all uppercased, eg `COMPlus_DUMPLLVMIR`.