### PR TITLE
Elf relocations include the addend as part of the relocation

### DIFF
--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -7450,11 +7450,10 @@ void ReaderBase::msilToIR(void) {
 // If verification is a necessary feature, then we can throw an NYI,
 // else we will assume the code is verifiable.
 #ifdef FEATURE_VERIFICATION
-  throw NotYetImplementedException("verification");
+    throw NotYetImplementedException("verification");
 #else
-  return;
+    return;
 #endif
-
   }
 
   // Initialize the NodeOffsetListArray so it can be used even in the


### PR DESCRIPTION
Closes #865.

Elf relocations (at least on x64) carry the addend as part of the relocation.
Also skip looking at relocations the plain `.eh_frames` section.

Also for some reason I am seeing funny whitespace in existing checked in code. When I reformat this gets "fixed".