### PR TITLE
ReWriteStatepointsForGC: Compute base-pointer

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -347,7 +347,7 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
         PMBuilder.SizeLevel = 0; // so that no additional phases are run.
         PMBuilder.populateModulePassManager(Passes);
 
-        Passes.add(createRewriteStatepointsForGCPass(false));
+        Passes.add(createRewriteStatepointsForGCPass());
         Passes.run(*M);
       }
 


### PR DESCRIPTION
PR  Microsoft/llvm#92 removes the parametrization of
RewriteStatepointsForGC phase on whether the base-pointers
of all live gc-pointers must be computed.

This change adapts LLILC code to use of new API.