### PR TITLE
Fix types of IRNodes in interlocked functions

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -6386,6 +6386,10 @@ void GenIR::dup(IRNode *Opr, IRNode **Result1, IRNode **Result2) {
 bool GenIR::interlockedCmpXchg(IRNode *Destination, IRNode *Exchange,
                                IRNode *Comparand, IRNode **Result,
                                CorInfoIntrinsics IntrinsicID) {
+  if (Exchange->getType()->isPointerTy()) {
+    Exchange = (IRNode *)LLVMBuilder->CreatePtrToInt(Exchange, Comparand->getType());
+  }
+
   ASSERT(Exchange->getType() == Comparand->getType());
   switch (IntrinsicID) {
   case CORINFO_INTRINSIC_InterlockedCmpXchg32:
@@ -6441,6 +6445,12 @@ bool GenIR::interlockedIntrinsicBinOp(IRNode *Arg1, IRNode *Arg2,
   }
 
   if (Op != AtomicRMWInst::BinOp::BAD_BINOP) {
+    assert(Arg1->getType()->isPointerTy());
+    Type *CastTy = isManagedPointerType(Arg1->getType())
+                     ? getManagedPointerType(Arg2->getType())
+                     : getUnmanagedPointerType(Arg2->getType());
+    Arg1 = (IRNode *)LLVMBuilder->CreatePointerCast(Arg1, CastTy);
+
     Value *Result = LLVMBuilder->CreateAtomicRMW(
         Op, Arg1, Arg2, AtomicOrdering::SequentiallyConsistent);
     *RetVal = (IRNode *)Result;


### PR DESCRIPTION
This change updated interlockedCmpXchg and interlockedIntrinsicBinOp:
* In interlockedCmpXchg, the Exchange IRNode and Comparand IR node must
  have the same type, however, we can have cases where Exchange comes in
  as a pointer. If Exchange is a pointer, we want to cast it to the same
  type as Comparand.
* In interlockedIntrinsicBinOp, we call CreateAtomicRMW, which assumes
  that Arg1 is a pointer to the type of Arg2, however, we have instances
  where Arg1 is a pointer to a pointer of the type of Arg2, so we need
  to cast it to a pointer, like we do with Destination in
  interlockedCmpXchg.