### PR TITLE
Add suppression of new sal annotation in CLR headers

### DIFF
--- a/include/Pal/LLILCPal.h
+++ b/include/Pal/LLILCPal.h
@@ -149,6 +149,7 @@
 
 // SAL
 #define _In_
+#define __in_z
 #define _Out_opt_
 #define _Out_writes_to_opt_(size, count)
 #define __out_ecount(count)


### PR DESCRIPTION
Closes #877.

Add __in_z to the set of suppressed annotations.