### PR TITLE
Set debug info version module flag

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -249,6 +249,8 @@ CorJitResult LLILCJit::compileMethod(ICorJitInfo *JitInfo,
   std::unique_ptr<Module> M = Context.getModuleForMethod(MethodInfo);
   Context.CurrentModule = M.get();
   Context.CurrentModule->setTargetTriple(LLILC_TARGET_TRIPLE);
+  Context.CurrentModule->addModuleFlag(Module::Warning, "Debug Info Version",
+                                       DEBUG_METADATA_VERSION);
   Context.MethodName = Context.CurrentModule->getModuleIdentifier();
   Context.TheABIInfo = ABIInfo::get(*Context.CurrentModule);
 


### PR DESCRIPTION
Explicitly set the module's debug info version to the current one.
Without this, writing out bitcode from LLILC and reading it back in will
strip the debug info, because the LLVM parsers check for the debug info
version and strip debug metadata if it does not match the version that the
parser was built with.