### PR TITLE
Update llilc_roslyn_stage.cmd and llilc_run.py scripts

### DIFF
--- a/test/llilc_run.py
+++ b/test/llilc_run.py
@@ -168,11 +168,10 @@ def main(argv):
         RunCommand('set complus_')
         RunCommand('set CORE_ROOT')
         RunCommand('set CORE_LIBRARIES')
-    command = ''
+    command = []
     if args.windbg_and_args:
         for arg in args.windbg_and_args:
-            arg = QuoteArg(arg)
-            command += ' ' + arg
+            command.append(arg)
     if args.corerun_and_args:
         first_corerun = True
         for arg in args.corerun_and_args:
@@ -181,15 +180,11 @@ def main(argv):
                 # the path.
                 arg = os.path.join(args.coreclr_runtime_path, arg)
                 first_corerun = False
-            arg = QuoteArg(arg)
-            command += ' ' + arg
+            command.append(arg)
         
-    if command != '':
-        command += ' '
-    command += QuoteArg(args.app_path)
+    command.append(args.app_path)
     for arg in unknown:
-        arg = QuoteArg(arg)
-        command += ' ' + arg
+        command.append(arg)
     error_level = RunCommand(command)
     if llilcverbose:
         log ('Exiting llilc_run.py with exit code ', error_level)


### PR DESCRIPTION
With these changes the lab job to run Roslyn building Roslyn
using LLILC succeeds.

llilc_roslyn_stage.cmd changes:

- Previously llilc_roslyn_stage.cmd was using c:/Python34,
  but that is no longer installed on lab machines. The script
  that it invokes will work with either Pythone 3.4 or 2.7 so
  just use the Python on the path.
- Add buildtype as an argument to llilc_roslyn_stage.cmd
  so it will work with debug, checked, or release builds.
- Revise for new Roslyn strategy for running on coreclr.
- The Roslyn analyzers sometimes throw task cancellation
  exceptions. Since LLILC cannot handle these yet,
  inhibit their use.

llilc_run.py changes:

Use lists to accumulate arguments for the command.
rather than strings. Using strings seems to cause
problems on some machines (observed for Windows Server 2012 R2)
(a quoting problem) whereas using lists the arguments
are converted to a string by the python subprocess module.
This avoided the problem.