### PR TITLE
Account for try regions that follow their handlers

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -975,6 +975,10 @@ void rgnSetFilterHandlerRegion(EHRegion *EhRegion, EHRegion *Handler);
 EHRegion *rgnGetFinallyTryRegion(EHRegion *FinallyRegion);
 mdToken rgnGetCatchClassToken(EHRegion *CatchRegion);
 void rgnSetCatchClassToken(EHRegion *CatchRegion, mdToken Token);
+/// A try region's "entry region" is either the try region itself or one of
+/// its handlers; whichever from that set comes lexically first.
+void rgnSetEntryRegion(EHRegion *TryRegion, EHRegion *EntryRegion);
+EHRegion *rgnGetEntryRegion(EHRegion *TryRegion);
 
 /// Get the finally region attached to the given \p TryRegion, if any.
 ///

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -1676,8 +1676,10 @@ void ReaderBase::rgnCreateRegionTree(void) {
       rgnSetStartMSILOffset(RegionTry, CurrentEHClause->TryOffset);
       rgnSetEndMSILOffset(RegionTry, CurrentEHClause->TryOffset +
                                          CurrentEHClause->TryLength);
+      rgnSetEntryRegion(RegionTry, RegionTry);
     }
 
+    EHRegion *CheckEntryRegion;
     if (CurrentEHClause->Flags & CORINFO_EH_CLAUSE_FILTER) {
       EHRegion *RegionFilter;
       RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_MExcept, RegionTry,
@@ -1691,40 +1693,48 @@ void ReaderBase::rgnCreateRegionTree(void) {
       rgnSetStartMSILOffset(RegionFilter, CurrentEHClause->FilterOffset);
       // The end of the filter, is the start of its handler
       rgnSetEndMSILOffset(RegionFilter, CurrentEHClause->HandlerOffset);
+      // The filter might precede the try and its other children; the handler
+      // will never precede the try.
+      CheckEntryRegion = RegionFilter;
     } else {
-
       if (CurrentEHClause->Flags & CORINFO_EH_CLAUSE_FINALLY) {
         RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_Finally, RegionTry,
                                       RegionTreeRoot, &WorkingAllRegionList);
+      } else if (CurrentEHClause->Flags & CORINFO_EH_CLAUSE_FAULT) {
+
+        RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_Fault, RegionTry,
+                                      RegionTreeRoot, &WorkingAllRegionList);
       } else {
-        if (CurrentEHClause->Flags & CORINFO_EH_CLAUSE_FAULT) {
+        // we need to touch the class at JIT time
+        // otherwise the classloader kicks in at exception time
+        // (possibly stack overflow exception) in which case
+        // we are in danger of going past the stack guard
 
-          RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_Fault, RegionTry,
-                                        RegionTreeRoot, &WorkingAllRegionList);
-        } else {
-          // we need to touch the class at JIT time
-          // otherwise the classloader kicks in at exception time
-          // (possibly stack overflow exception) in which case
-          // we are in danger of going past the stack guard
-
-          if (CurrentEHClause->ClassToken) {
-            CORINFO_RESOLVED_TOKEN ResolvedToken;
-            resolveToken(CurrentEHClause->ClassToken, CORINFO_TOKENKIND_Class,
-                         &ResolvedToken);
-          }
-
-          // this will be a catch (EH_CLAUSE_NONE)
-          // we need to keep the token somewhere
-          RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_MCatch, RegionTry,
-                                        RegionTreeRoot, &WorkingAllRegionList);
-
-          rgnSetCatchClassToken(RegionHandler, CurrentEHClause->ClassToken);
+        if (CurrentEHClause->ClassToken) {
+          CORINFO_RESOLVED_TOKEN ResolvedToken;
+          resolveToken(CurrentEHClause->ClassToken, CORINFO_TOKENKIND_Class,
+                        &ResolvedToken);
         }
+
+        // this will be a catch (EH_CLAUSE_NONE)
+        // we need to keep the token somewhere
+        RegionHandler = rgnMakeRegion(ReaderBaseNS::RGN_MCatch, RegionTry,
+                                      RegionTreeRoot, &WorkingAllRegionList);
+
+        rgnSetCatchClassToken(RegionHandler, CurrentEHClause->ClassToken);
       }
+      // The handler might precede the try and its other children
+      CheckEntryRegion = RegionHandler;
     }
     rgnSetStartMSILOffset(RegionHandler, CurrentEHClause->HandlerOffset);
     rgnSetEndMSILOffset(RegionHandler, CurrentEHClause->HandlerOffset +
                                            CurrentEHClause->HandlerLength);
+    // See if this handler precedes the try and its other handlers
+    EHRegion *EntryRegion = rgnGetEntryRegion(RegionTry);
+    if (rgnGetStartMSILOffset(CheckEntryRegion) <
+        rgnGetStartMSILOffset(EntryRegion)) {
+      rgnSetEntryRegion(RegionTry, CheckEntryRegion);
+    }
   } while (I != 0);
 
   delete[] EHClauses;
@@ -2232,23 +2242,23 @@ EHRegion *ReaderBase::fgSwitchRegion(EHRegion *OldRegion, uint32_t Offset,
       if (ChildStartOffset < TransitionOffset) {
         TransitionOffset = ChildStartOffset;
       }
-
-      continue;
-    }
-
-    uint32_t ChildEndOffset = rgnGetEndMSILOffset(ChildRegion);
-
-    if (Offset < ChildEndOffset) {
-      // Enter this region; recursively check it (may need to enter descendant)
-      fgEnterRegion(ChildRegion);
+    } else if (Offset < rgnGetEndMSILOffset(ChildRegion)) {
+      if (ChildRegion == rgnGetEntryRegion(ChildRegion)) {
+        // This try region lexically precedes all its handlers (which is the
+        // common case).  Let the client do any processing necessary for its
+        // entry.
+        fgEnterRegion(ChildRegion);
+      }
+      // Switch to the child and recursively check (we may need to enter some
+      // descendant(s) of it as well).
       return fgSwitchRegion(ChildRegion, Offset, NextOffset);
     }
 
     if (rgnGetRegionType(ChildRegion) == ReaderBaseNS::RegionKind::RGN_Try) {
       // A handler region for the try is a child of it in the tree but follows
-      // it in the IR, so we explicitly have to check for grandchildren in this
-      // case (the current offset falls in the grandchild's range but not the
-      // child's range).
+      // (or, in some hand-crafted IL cases, precedes) it in the IR, so we
+      // explicitly have to check for grandchildren in this case (the current
+      // offset falls in the grandchild's range but not the child's range).
       for (EHRegionList *GrandchildNode = rgnGetChildList(ChildRegion);
            GrandchildNode; GrandchildNode = rgnListGetNext(GrandchildNode)) {
 
@@ -2269,9 +2279,14 @@ EHRegion *ReaderBase::fgSwitchRegion(EHRegion *OldRegion, uint32_t Offset,
         uint32_t GrandchildEndOffset = rgnGetEndMSILOffset(Grandchild);
 
         if (Offset < GrandchildEndOffset) {
-          // Recursively check this region (it may need to enter a descendant).
-          // Don't call fgEnterRegion here, since we already processed the
-          // region entry for this try when we visited it the first time.
+          if (Grandchild == rgnGetEntryRegion(ChildRegion)) {
+            // This handler lexically precedes its try.  Give the client a
+            // chance to set up any necessary state for the try before
+            // switching to the handler.
+            fgEnterRegion(ChildRegion);
+          }
+          // Switch to this region and recursively check -- we may need to
+          // enter a some descendant(s) of it as well.
           return fgSwitchRegion(Grandchild, Offset, NextOffset);
         }
       }

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -112,6 +112,7 @@ public:
   uint32_t EndMsilOffset;
   llvm::Instruction *HandlerEHPad;
   union {
+    EHRegion *EntryRegion;              // Only used for Try regions
     llvm::SwitchInst *EndFinallySwitch; // Only used for Finally regions
     mdToken CatchClassToken;            // Only used for Catch regions
     EHRegion *HandlerRegion;            // Only used for Filter regions
@@ -209,6 +210,15 @@ mdToken rgnGetCatchClassToken(EHRegion *CatchRegion) {
 }
 void rgnSetCatchClassToken(EHRegion *CatchRegion, mdToken Token) {
   CatchRegion->CatchClassToken = Token;
+}
+
+void rgnSetEntryRegion(EHRegion *TryRegion, EHRegion *EntryRegion) {
+  assert(TryRegion->Kind == ReaderBaseNS::RegionKind::RGN_Try);
+  TryRegion->EntryRegion = EntryRegion;
+}
+EHRegion *rgnGetEntryRegion(EHRegion *TryRegion) {
+  assert(TryRegion->Kind == ReaderBaseNS::RegionKind::RGN_Try);
+  return TryRegion->EntryRegion;
 }
 
 #pragma endregion


### PR DESCRIPTION
It's legal MSIL for a protected region's handler(s) to precede it, but
fgSwitchRegion wasn't expecting this.  Add a property of try regions that
indicates which of the try region itself or its handlers is lexically
first (called its "EntryRegion"), computed during EH Region Tree
construction, which fgSwitchRegion can use to make sure it calls
fgEnterRegion exactly once for each try, and before switching to any
handler of the try.