### PR TITLE
Stop passing a DIFile to createSubroutineType

### DIFF
--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -1137,8 +1137,7 @@ llvm::DISubroutineType *GenIR::createFunctionType(llvm::Function *F,
 
     EltTys.push_back(ParamTy);
   }
-  return DBuilder->createSubroutineType(Unit,
-                                        DBuilder->getOrCreateTypeArray(EltTys));
+  return DBuilder->createSubroutineType(DBuilder->getOrCreateTypeArray(EltTys));
 }
 
 llvm::DIType *GenIR::convertType(Type *Ty) {


### PR DESCRIPTION
This parameter was unused and so was removed from the method in r250374.

This requires a paired change to the MS branch of LLVM; http://dotnet-ci.cloudapp.net/view/dotnet_llilc/job/dotnet_llilc_prtest/1188/console has the test with both changes together.

@adiaaida or @russellhadley PTAL.