### PR TITLE
Insert failfast calls at exception handler entries

### DIFF
--- a/include/Jit/jitoptions.h
+++ b/include/Jit/jitoptions.h
@@ -77,6 +77,11 @@ private:
   /// \returns true if COMPLUS_JitGCInfoLogging is set in the environment.
   static bool queryLogGcInfo(LLILCJitContext &JitContext);
 
+  /// \brief Set ExecuteHandlers based on envirionment variable.
+  ///
+  /// \returns true if COMPlus_ExecuteHandlers is set in the environment.
+  static bool queryExecuteHandlers(LLILCJitContext &JitContext);
+
   /// \brief Define set of methods to exclude from LLILC compilation
   ///
   /// \returns true if current method is in that set.

--- a/include/Reader/options.h
+++ b/include/Reader/options.h
@@ -54,6 +54,7 @@ struct Options {
   bool DoInsertStatepoints; ///< True if the environment calls for statepoints.
   bool DoTailCallOpt;       ///< Tail call optimization.
   bool LogGcInfo;           ///< Generate GCInfo Translation logs
+  bool ExecuteHandlers;     ///< Squelch handler suppression.
   bool DoSIMDIntrinsic;     ///< True if SIMD intrinsic is on.
   unsigned PreferredIntrinsicSIMDVectorLength; ///< Prefer Intrinsic SIMD Vector
   /// Length in bytes.

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1731,6 +1731,13 @@ private:
   /// \param FinallyRegion  The region whose IR is to be cloned.
   void cloneFinallyBody(EHRegion *FinallyRegion);
 
+  /// Determine whether the IR generated for the given handler should be
+  /// allowed to execute (as opposed to inserting a failfast at handler entry).
+  /// Does not affect non-exceptional executions of finally handlers.
+  ///
+  /// \param Handler  The catchpad/cleanuppad for the handler.
+  bool canExecuteHandler(llvm::BasicBlock &Handler);
+
 private:
   LLILCJitContext *JitContext;
   ABIInfo *TheABIInfo;

--- a/lib/Jit/jitoptions.cpp
+++ b/lib/Jit/jitoptions.cpp
@@ -77,6 +77,9 @@ JitOptions::JitOptions(LLILCJitContext &Context) {
 
   LogGcInfo = queryLogGcInfo(Context);
 
+  // Set whether to insert failfast in exception handlers.
+  ExecuteHandlers = queryExecuteHandlers(Context);
+
   IsExcludeMethod = queryIsExcludeMethod(Context);
   IsBreakMethod = queryIsBreakMethod(Context);
   IsMSILDumpMethod = queryIsMSILDumpMethod(Context);
@@ -252,6 +255,12 @@ bool JitOptions::queryDoInsertStatepoints(LLILCJitContext &Context) {
 bool JitOptions::queryLogGcInfo(LLILCJitContext &Context) {
   return queryNonNullNonEmpty(Context,
                               (const char16_t *)UTF16("JitGCInfoLogging"));
+}
+
+// Determine if exception handlers should be executed.
+bool JitOptions::queryExecuteHandlers(LLILCJitContext &Context) {
+  return queryNonNullNonEmpty(Context,
+                              (const char16_t *)UTF16("ExecuteHandlers"));
 }
 
 // Determine if SIMD intrinsics should be used.

--- a/test/llilc_run.py
+++ b/test/llilc_run.py
@@ -25,6 +25,7 @@
 #   -n, --ngen            use ngened mscorlib
 #   -p, --precise-gc      test with precise gc
 #   -v, --verbose         echo commands
+#   -e, --eh              enable exception handlers to run (as opposed to failfast)
 #   -r [CORERUN_AND_ARGS [CORERUN_AND_ARGS ...]], --corerun-and-args [CORERUN_AND_ARGS [CORERUN_AND_ARGS ...]]
 #                         If explicit CoreRun is needed (app is not
 #                         CoreConsole), the CoreRun command and args to pass to
@@ -103,6 +104,7 @@ def main(argv):
     parser.add_argument('-n', '--ngen', help='use ngened mscorlib', default=False, action="store_true")
     parser.add_argument('-p', '--precise-gc', help='test with precise gc', default=False, action="store_true")
     parser.add_argument('-v', '--verbose', help='echo commands', default=False, action="store_true")
+    parser.add_argument('-e', '--eh', help='enable exception handlers to run (as opposed to failfast)', default=False, action="store_true")
     parser.add_argument('-r', '--corerun-and-args', type=str, nargs='*', default=[],
                         help='''If explicit CoreRun is needed (app is not CoreConsole),
                                 the CoreRun command and args to pass to CoreRun, e.g. /v for verbose.
@@ -157,6 +159,8 @@ def main(argv):
         os.environ["COMPlus_ZapDisable"]="1"
     if args.dump_level:
         os.environ["COMPlus_DumpLLVMIR"]=args.dump_level
+    if args.eh:
+        os.environ["COMPlus_ExecuteHandlers"]="1"
     for arg in args.extra:
         pair = UnquoteArg(arg).split('=', 1)
         name = 'COMPLUS_AltJit' + pair[0]


### PR DESCRIPTION
This will make it easier to triage failures due to unsupported EH
behavior.

Also add a setting that overrides this behavior to facilitate EH testing.