### PR TITLE
Fix for build break in Linux

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -116,7 +116,7 @@ public:
   //@}
 
   /// \name GC Information
-  GcInfo *GcInfo; ///< GcInfo for functions in CurrentModule
+  ::GcInfo *GcInfo; ///< GcInfo for functions in CurrentModule
 };
 
 /// \brief This struct holds per-thread Jit state.

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -1744,7 +1744,7 @@ private:
   ReaderMethodSignature MethodSignature;
   ABIMethodSignature ABIMethodSig;
   llvm::Function *Function; // The current function being read
-  GcFuncInfo *GcFuncInfo;   // GcInfo for the above function
+  ::GcFuncInfo *GcFuncInfo; // GcInfo for the above function
   // The LLVMBuilder has a notion of a current insertion point.  During the
   // first-pass flow-graph construction, each method sets the insertion point
   // explicitly before inserting IR (the fg- methods typically take an

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -6883,7 +6883,7 @@ void GenIR::endFilter(IRNode *Arg1) {
   Value *ThrowCondition = LLVMBuilder->CreateIsNull(Arg1, "Rethrow");
   genConditionalThrow(ThrowCondition, CORINFO_HELP_RETHROW, "FilterFalse");
   ReaderOperandStack->push((IRNode *)CurrentRegion->HandlerRegion->Exception);
-};
+}
 
 CallSite GenIR::genConditionalHelperCall(
     Value *Condition, CorInfoHelpFunc HelperId, bool MayThrow, Type *ReturnType,


### PR DESCRIPTION
This fixes Linux build when using gcc. Some of name space qualifier are explicitly added.