### PR TITLE
Fix some Linux build breaks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,12 +260,12 @@ if ( NOT LLVM_TARGET_IS_CROSSCOMPILE_HOST )
     set(LLILC_HAS_VERSION_PATCHLEVEL 0)
   endif()
 
-  if (CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-    set(DEBUG)
+  if ((CMAKE_BUILD_TYPE STREQUAL "DEBUG") OR (CMAKE_BUILD_TYPE STREQUAL ""))
+    set(DEBUG 1)
   endif()
 
   if (DEBUG)
-    add_definitions( -DDEBUG -D_DEBUG )
+    add_definitions( -D_DEBUG )
   endif()
 
   # Add appropriate flags for MSVC

--- a/lib/GcInfo/GcInfo.cpp
+++ b/lib/GcInfo/GcInfo.cpp
@@ -243,7 +243,8 @@ void GcFuncInfo::recordGsCookie(const AllocaInst *Alloca,
 
 void GcFuncInfo::getEscapingLocations(SmallVector<Value *, 4> &EscapingLocs) {
   for (auto AllocaIterator : AllocaMap) {
-    EscapingLocs.push_back((Value *)AllocaIterator.first);
+    EscapingLocs.push_back(
+        const_cast<Value *>(static_cast<const Value *>(AllocaIterator.first)));
   }
 }
 

--- a/lib/Jit/jitoptions.cpp
+++ b/lib/Jit/jitoptions.cpp
@@ -214,7 +214,7 @@ bool JitOptions::queryMethodSet(LLILCJitContext &JitContext, MethodSet &TheSet,
     char16_t *ConfigStr = getStringConfigValue(JitContext.JitInfo, Name);
     bool NeedFree = true;
     if (ConfigStr == nullptr) {
-      ConfigStr = (char16_t *)UTF16("");
+      ConfigStr = const_cast<char16_t*>((const char16_t *)UTF16(""));
       NeedFree = false;
     }
     std::unique_ptr<std::string> ConfigUtf8 = Convert::utf16ToUtf8(ConfigStr);


### PR DESCRIPTION
- _DEBUG was not being defined when CMake was invoked without an explicit
  build type. The build now defaults to debug unless otherwise specified.
- A couple of GC-related types needed global namespace qualifiers to avoid
  name collisions.
- There were various const-cast related issues that needed resolution.