### PR TITLE
Packaging object writer

### DIFF
--- a/lib/ObjWriter/.nuget/Linux/Microsoft.Dotnet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Linux/Microsoft.Dotnet.ObjectWriter.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.ObjectWriter</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET Object File Generator</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides object writer to the managed to native code-generator.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="../libobjwriter.so" target="libobjwriter.so" />
+  </files>
+</package>

--- a/lib/ObjWriter/.nuget/Microsoft.Dotnet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Microsoft.Dotnet.ObjectWriter.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.ObjectWriter</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET Object File Generator</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides object writer to the managed to native code-generator.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="..\objwriter.dll" target="objwriter.dll" />
+  </files>
+</package>

--- a/utils/make_package.py
+++ b/utils/make_package.py
@@ -1,0 +1,87 @@
+﻿#!/usr/bin/env python
+
+import sys
+import argparse
+import os
+import subprocess
+import platform
+import io
+import string
+import urllib2
+import shutil
+import stat
+
+def run(args):
+  nugetFolder = os.path.join(args.target, ".nuget")
+  print("\nEnsuring folder: %s" % nugetFolder )
+  if not os.path.exists(nugetFolder):
+    os.makedirs(nugetFolder)
+
+  nugetExe = os.path.join(nugetFolder, "nuget.exe")
+  if not os.path.exists(nugetExe):
+    nugetOrg = "http://nuget.org/nuget.exe"
+    print("Downloading... %s" % nugetOrg )
+    response = urllib2.urlopen(nugetOrg)
+    output = open(nugetExe,'wb')
+    output.write(response.read())
+    output.close()
+    # Ensure it's executable
+    st = os.stat(nugetExe)
+    os.chmod(nugetExe, st.st_mode | stat.S_IEXEC)
+
+  if (sys.platform != "win32"):
+    mono = "/usr/bin/mono"
+    if not os.path.exists(mono):
+      raise mono + " is required to run nuget.exe"
+    nugetExe = mono + " " + nugetExe
+
+  nugetSpec = os.path.join(nugetFolder, os.path.basename(args.nuspec))
+  if args.nuspec != nugetSpec:
+    print("\nCopying " + args.nuspec + " to " + nugetSpec)
+    shutil.copyfile(args.nuspec, nugetSpec)
+
+  nugetCommand = nugetExe + " pack " + nugetSpec \
+                 + " -NoPackageAnalysis -NoDefaultExcludes" \
+                 " -OutputDirectory %s" % nugetFolder
+
+  ret = os.system(nugetCommand)
+  return ret
+
+def main(argv):
+  parser = argparse.ArgumentParser(description=
+   "Download nuget and run it to create a package using the given nuspec. " \
+   "Example: make_package.py " \
+   "--target f:\llilc-rel\\bin\Release " \
+   "--nuspec f:\llilc\lib\ObjWriter\.nuget\Microsoft.Dotnet.ObjectWriter.nuspec",
+   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument("--target", metavar="PATH",
+            default=None,
+            help="path to a target directory that contains files that will " \
+                 "packaged")
+  parser.add_argument("--nuspec", metavar="PATH",
+            default=None,
+            help="path to a nuspec file. This file is assumed to be under " \
+                 "a child directory (.nuget) of the target by convetion")
+  args,unknown = parser.parse_known_args(argv)
+
+  if unknown:
+    print("Unknown argument(s): ", ", ".join(unknown))
+    return -3
+
+  returncode=0
+  if args.target == None:
+    print("--target is not specified.")
+    return -3
+
+  if args.nuspec == None:
+    print("--nuspec is not specified")
+    return -3
+
+  returncode = run(args)
+
+  return returncode
+
+
+if __name__ == "__main__":
+  returncode = main(sys.argv[1:])
+  sys.exit(returncode)


### PR DESCRIPTION
Added nuspec file to package object writer.
For now instead of creating package step into Cmake build, I provided a standalone python script which should run in any platform.
It takes target folder and nuspec file to create a package out of it.