### PR TITLE
Insert gc.sagepoint_poll() after the real Method

### DIFF
--- a/include/GcInfo/GcInfo.h
+++ b/include/GcInfo/GcInfo.h
@@ -171,9 +171,8 @@ public:
   /// \param StackMapData A pointer to the .llvm_stackmaps section
   ///        loaded in memory
   /// \param Allocator The allocator to be used by GcInfo encoder
-  /// \param OffsetCorrection FunctionStart - CodeBlockStart difference
   GcInfoEmitter(LLILCJitContext *JitCtx, uint8_t *StackMapData,
-                GcInfoAllocator *Allocator, size_t OffsetCorrection);
+                GcInfoAllocator *Allocator);
 
   /// Emit GC Info to the EE using GcInfoEncoder.
   void emitGCInfo();
@@ -204,17 +203,6 @@ private:
   const LLILCJitContext *JitContext;
   const uint8_t *LLVMStackMapData;
   GcInfoEncoder Encoder;
-
-  // The InstructionOffsets reported at Call-sites are with respect to:
-  // (1) FunctionEntry in LLVM's StackMap
-  // (2) CodeBlockStart in CoreCLR's GcTable
-  // OffsetCorrection accounts for the difference:
-  // FunctionStart - CodeBlockStart
-  //
-  // There is typically a difference between the two even in the JIT case
-  // (where we emit one function per module) because of some additional
-  // code like the gc.statepoint_poll() method.
-  size_t OffsetCorrection;
 
   // Offset to SlotID Map
   // Currently, the base pointer for all slots is the current function's SP.

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -274,10 +274,6 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
 
   const uint32_t JitFlags = JitContext->Flags;
 
-  if (JitContext->Options->DoInsertStatepoints) {
-    createSafepointPoll();
-  }
-
   CORINFO_METHOD_HANDLE MethodHandle = JitContext->MethodInfo->ftn;
 
   // Capture low-level info about the return type for use in Return.
@@ -747,6 +743,13 @@ void GenIR::readerPostPass(bool IsImportOnly) {
   // Cleanup the memory we've been using.
   delete DBuilder;
   delete LLVMBuilder;
+
+  // While Jitting a method, SafepointPoll must appear after the function
+  // actually being Jitted. EE's DebugInfoManager depends on the fact that
+  // the Jitted function starts at the allocated code block.
+  if (JitContext->Options->DoInsertStatepoints) {
+    createSafepointPoll();
+  }
 }
 
 void GenIR::insertIRToKeepGenericContextAlive() {


### PR DESCRIPTION
The EE DebugInfoManager requires the Jitted method to start at
the beginning of allocated Code block.
Therefore, this change moves gc.safepoint_poll() from the
beginning to the end of the module.