### PR TITLE
Make b28158 test exclusion unconditional

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -2365,6 +2365,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgseq\*" >
              <Issue>CoreCLR/1440</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b28158\b28158\*" >
+             <Issue>898</Issue>
+        </ExcludeList>
     </ItemGroup>
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(COMPLUS_INSERTSTATEPOINTS)' != ''">	
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\113574\113574\*" >
@@ -2372,9 +2375,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68361\b68361\*" >
              <Issue>CoreCLR\1541</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b28158\b28158\*" >
-             <Issue>898</Issue>
         </ExcludeList>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This can time out with non-statepoints runs too; for example, it held up
the last FI from LLVM.