### PR TITLE
Updates for LLVM FI signature changes

### DIFF
--- a/include/Jit/EEObjectLinkingLayer.h
+++ b/include/Jit/EEObjectLinkingLayer.h
@@ -34,9 +34,10 @@ private:
   class ConcreteLinkedObjectSet : public LinkedObjectSet {
   public:
     ConcreteLinkedObjectSet(MemoryManagerPtrT MemMgr,
-                            SymbolResolverPtrT Resolver)
-        : LinkedObjectSet(*MemMgr, *Resolver), MemMgr(std::move(MemMgr)),
-          Resolver(std::move(Resolver)) {}
+                            SymbolResolverPtrT Resolver,
+                            bool ProcessAllSections)
+        : LinkedObjectSet(*MemMgr, *Resolver, ProcessAllSections),
+          MemMgr(std::move(MemMgr)), Resolver(std::move(Resolver)) {}
 
     void finalize() override {
       State = Finalizing;
@@ -52,9 +53,11 @@ private:
 
   template <typename MemoryManagerPtrT, typename SymbolResolverPtrT>
   std::unique_ptr<LinkedObjectSet>
-  createLinkedObjectSet(MemoryManagerPtrT MemMgr, SymbolResolverPtrT Resolver) {
+  createLinkedObjectSet(MemoryManagerPtrT MemMgr, SymbolResolverPtrT Resolver,
+                        bool ProcessAllSections) {
     typedef ConcreteLinkedObjectSet<MemoryManagerPtrT, SymbolResolverPtrT> LoS;
-    return llvm::make_unique<LoS>(std::move(MemMgr), std::move(Resolver));
+    return llvm::make_unique<LoS>(std::move(MemMgr), std::move(Resolver),
+                                  ProcessAllSections);
   }
 
 public:
@@ -72,7 +75,18 @@ public:
       NotifyLoadedFtor NotifyLoaded = NotifyLoadedFtor(),
       NotifyFinalizedFtor NotifyFinalized = NotifyFinalizedFtor())
       : NotifyLoaded(std::move(NotifyLoaded)),
-        NotifyFinalized(std::move(NotifyFinalized)) {}
+        NotifyFinalized(std::move(NotifyFinalized)), ProcessAllSections(false) {
+  }
+
+  /// @brief Set the 'ProcessAllSections' flag.
+  ///
+  /// If set to true, all sections in each object file will be allocated using
+  /// the memory manager, rather than just the sections required for execution.
+  ///
+  /// This is kludgy, and may be removed in the future.
+  void setProcessAllSections(bool ProcessAllSections) {
+    this->ProcessAllSections = ProcessAllSections;
+  }
 
   /// @brief Add a set of objects (or archives) that will be treated as a unit
   ///        for the purposes of symbol lookup and memory management.
@@ -91,7 +105,8 @@ public:
                              SymbolResolverPtrT Resolver) {
     ObjSetHandleT Handle = LinkedObjSetList.insert(
         LinkedObjSetList.end(),
-        createLinkedObjectSet(std::move(MemMgr), std::move(Resolver)));
+        createLinkedObjectSet(std::move(MemMgr), std::move(Resolver),
+                              ProcessAllSections));
 
     LinkedObjectSet &LoS = **Handle;
     LoadedObjInfoList LoadedObjInfos;
@@ -186,6 +201,7 @@ private:
   LinkedObjectSetListT LinkedObjSetList;
   NotifyLoadedFtor NotifyLoaded;
   NotifyFinalizedFtor NotifyFinalized;
+  bool ProcessAllSections;
 };
 
 } // End namespace orc.

--- a/include/Jit/EEObjectLinkingLayer.h
+++ b/include/Jit/EEObjectLinkingLayer.h
@@ -42,7 +42,6 @@ private:
       State = Finalizing;
       RTDyld->registerEHFrames();
       MemMgr->finalizeMemory();
-      OwnedBuffers.clear();
       State = Finalized;
     }
 

--- a/lib/Reader/readerir.cpp
+++ b/lib/Reader/readerir.cpp
@@ -332,7 +332,7 @@ void GenIR::readerPrePass(uint8_t *Buffer, uint32_t NumBytes) {
   DISubprogram *SP = DBuilder->createFunction(
       FContext, Function->getName(), StringRef(), Unit, LineNo,
       createFunctionType(Function, Unit), Function->hasInternalLinkage(),
-      IsDefinition, ScopeLine, DINode::FlagPrototyped, IsOptimized, Function);
+      IsDefinition, ScopeLine, DINode::FlagPrototyped, IsOptimized);
 
   LLILCDebugInfo.FunctionScope = SP;
 


### PR DESCRIPTION
Three changes in the next FI require changes to LLILC sources, which are bundled up here.

This will need to be committed in tandem with Microsoft/llvm#113.

@AndyAyersMS PTAL.