### PR TITLE
Exclude gettypetypeofmatrix test if eh is not enabled.

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -2373,6 +2373,9 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_i1\*" >
              <Issue>13</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\gettypetypeof\gettypetypeofmatrix\*" >
+             <Issue>13</Issue>
+        </ExcludeList>
     </ItemGroup>
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(COMPLUS_INSERTSTATEPOINTS)' != ''">	
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\113574\113574\*" >


### PR DESCRIPTION
In preparation for the addition of a new test,
JIT\Directed\gettypetypeof\gettypetypeofmatrix\gettypetypeofmatrix.exe,
add an exclusion for it. The test fails if LLILC's
COMPlus_ExecuteHandlers is not set, but passes if it is, so
add the exclusion to the part where it is not set.