### PR TITLE
Emit frame info in Object writer

### DIFF
--- a/lib/ObjWriter/.nuget/Linux/Microsoft.Dotnet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Linux/Microsoft.Dotnet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.1-prerelease</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/Microsoft.Dotnet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Microsoft.Dotnet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.1-prerelease</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/objwriter.exports
+++ b/lib/ObjWriter/objwriter.exports
@@ -6,3 +6,4 @@ EmitBlob
 EmitIntValue
 EmitSymbolDef
 EmitSymbolRef
+EmitFrameInfo


### PR DESCRIPTION
This supports for emitting frame info for Windows.
Basically pdata/xdata is constructed like C++ to allow call stack dumps.
EH table itself is not populated yet since EH model is not determined.