### PR TITLE
Add support for the SysV AMD64 ABI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@
 # pass the required WITH_CORECLR variable, so we would fail if we tried.
 
 if ( NOT LLVM_TARGET_IS_CROSSCOMPILE_HOST )
-
   # If we are not building as a part of LLVM, build LLILCJit as an
   # standalone project, using LLVM as an external library:
   if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
@@ -16,6 +15,8 @@ if ( NOT LLVM_TARGET_IS_CROSSCOMPILE_HOST )
         cmake_policy(SET CMP0042 NEW)
       endif()
     endif()
+
+    set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
     set(WITH_LLVM "" CACHE PATH "Path to the directory where LLVM was built or installed.")
 

--- a/include/Reader/abisignature.h
+++ b/include/Reader/abisignature.h
@@ -37,7 +37,39 @@ protected:
   ABISignature(const ReaderCallSignature &Signature, GenIR &Reader,
                const ABIInfo &TheABIInfo);
 
+  /// \brief Returns the number of arguments to the ABI signature.
+  ///
+  /// \returns The number of arguments to the ABI signature.
+  uint32_t getNumABIArgs() const;
+
 public:
+  /// \brief Expand a value according to a specific list of expansions.
+  ///
+  /// \param Reader        The \p GenIR instance that will be used to emit IR.
+  /// \param Expansions    The list of expansions to be applied.
+  /// \param Source        The value to expand.
+  /// \param Values [in]   A slice that will hold the values that result from
+  ///                      the expansion.
+  /// \param Values [in]   A slice that will hold the types of the values that
+  ///                      result from the expansion.
+  /// \param IsResult      True if the value being expanded is the result value
+  ///                      for a function.
+  static void expand(GenIR &Reader,
+                     llvm::ArrayRef<ABIArgInfo::Expansion> Expansions,
+                     llvm::Value *Source,
+                     llvm::MutableArrayRef<llvm::Value *> Values,
+                     llvm::MutableArrayRef<llvm::Type *> Types, bool IsResult);
+
+  /// \brief Store a single value from an expanded argument into its
+  /// destination.
+  ///
+  /// \param Reader  The \p GenIR instance that will be used to emit IR.
+  /// \param Exp     The expansion information for the given value.
+  /// \param Val     The value to be collapsed.
+  /// \param Base    The base address of the target value as an i8*.
+  static void collapse(GenIR &Reader, const ABIArgInfo::Expansion &Exp,
+                       llvm::Value *Val, llvm::Value *Base);
+
   /// \brief Coerces a value to a particular target type, casting or
   ///        reinterpreting as necessary.
   ///

--- a/lib/Reader/abi.cpp
+++ b/lib/Reader/abi.cpp
@@ -32,8 +32,12 @@ using namespace llvm;
 class X86_64_Win64 {
 private:
   X86_64_Win64() {}
+
   static ABIArgInfo classify(const ABIType Ty, const DataLayout &DL,
                              bool IsManagedCallingConv);
+
+  static ABIArgInfo classifyResult(const ABIType Ty, const DataLayout &DL,
+                                   bool IsManagedCallingConv);
 
 public:
   static void computeSignatureInfo(bool IsManagedCallingConv,
@@ -48,8 +52,24 @@ class X86_64_SysV {
 private:
   X86_64_SysV() {}
 
+  static ABIArgInfo classify(LLILCJitContext &JitContext, const ABIType Ty,
+                             const DataLayout &DL, bool IsManagedCallingConv,
+                             bool IsResult, uint32_t &RequiredIntRegs,
+                             uint32_t &RequiredSSERegs);
+
+  static ABIArgInfo classifyArgument(LLILCJitContext &JitContext,
+                                     const ABIType Ty, const DataLayout &DL,
+                                     bool IsManagedCallingConv,
+                                     uint32_t &RequiredIntRegs,
+                                     uint32_t &RequiredSSERegs);
+
+  static ABIArgInfo classifyResult(LLILCJitContext &JitContext,
+                                   const ABIType Ty, const DataLayout &DL,
+                                   bool IsManagedCallingConv);
+
 public:
-  static void computeSignatureInfo(bool IsManagedCallingConv,
+  static void computeSignatureInfo(LLILCJitContext &JitContext,
+                                   bool IsManagedCallingConv,
                                    ABIType ResultType,
                                    ArrayRef<ABIType> ArgTypes,
                                    const DataLayout &DL, ABIArgInfo &ResultInfo,
@@ -64,15 +84,16 @@ private:
 public:
   X86_64ABIInfo(Triple TargetTriple, const DataLayout &DL);
 
-  void computeSignatureInfo(CallingConv::ID CC, bool IsManagedCallingConv,
-                            ABIType ResultType, ArrayRef<ABIType> ArgTypes,
-                            ABIArgInfo &ResultInfo,
+  void computeSignatureInfo(LLILCJitContext &JitContext, CallingConv::ID CC,
+                            bool IsManagedCallingConv, ABIType ResultType,
+                            ArrayRef<ABIType> ArgTypes, ABIArgInfo &ResultInfo,
                             std::vector<ABIArgInfo> &ArgInfos) const override;
 };
 
 ABIArgInfo X86_64_Win64::classify(const ABIType ABITy, const DataLayout &DL,
                                   bool IsManagedCallingConv) {
   Type *Ty = ABITy.getType();
+  assert(!Ty->isVoidTy());
 
   if (Ty->isAggregateType() || Ty->isVectorTy()) {
     // If the aggregate's size in bytes is a power of 2 that is less than or
@@ -107,9 +128,19 @@ ABIArgInfo X86_64_Win64::classify(const ABIType ABITy, const DataLayout &DL,
     return ABIArgInfo::getDirect(Ty);
   }
 
-  // TODO: vector types
-  assert(Ty->isPointerTy() || Ty->isVoidTy());
+  assert(Ty->isPointerTy());
   return ABIArgInfo::getDirect(Ty);
+}
+
+ABIArgInfo X86_64_Win64::classifyResult(const ABIType ABITy,
+                                        const DataLayout &DL,
+                                        bool IsManagedCallingConv) {
+  Type *Ty = ABITy.getType();
+  if (Ty->isVoidTy()) {
+    return ABIArgInfo::getDirect(Ty);
+  }
+
+  return classify(ABITy, DL, IsManagedCallingConv);
 }
 
 void X86_64_Win64::computeSignatureInfo(bool IsManagedCallingConv,
@@ -118,24 +149,173 @@ void X86_64_Win64::computeSignatureInfo(bool IsManagedCallingConv,
                                         const DataLayout &DL,
                                         ABIArgInfo &ResultInfo,
                                         std::vector<ABIArgInfo> &ArgInfos) {
-  ResultInfo = classify(ResultType, DL, IsManagedCallingConv);
+  ResultInfo = classifyResult(ResultType, DL, IsManagedCallingConv);
 
   for (auto &Arg : ArgTypes) {
     ArgInfos.push_back(classify(Arg, DL, IsManagedCallingConv));
   }
 }
 
-void X86_64_SysV::computeSignatureInfo(bool IsManagedCallingConv,
-                                       ABIType ResultType,
-                                       ArrayRef<ABIType> ArgTypes,
+ABIArgInfo X86_64_SysV::classify(LLILCJitContext &Context, const ABIType ABITy,
+                                 const DataLayout &DL,
+                                 bool IsManagedCallingConv, bool IsResult,
+                                 uint32_t &RequiredIntRegs,
+                                 uint32_t &RequiredSSERegs) {
+  Type *Ty = ABITy.getType();
+  assert(!Ty->isVoidTy());
+
+  if (Ty->isAggregateType() || Ty->isVectorTy()) {
+    SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR Desc;
+
+    bool Ok = Context.JitInfo->getSystemVAmd64PassStructInRegisterDescriptor(
+        ABITy.getClass(), &Desc);
+    assert(Ok);
+    (void)Ok; // Silence unused variable warnings in release builds.
+
+    if (!Desc.passedInRegisters) {
+      if (IsResult) {
+        // Per the SysV ABI spec, return values that are not enregistered are
+        // instead passed via a buffer argument allocated by the caller. In this
+        // case, the buffer argument will consume a single integer register.
+        RequiredIntRegs = 1;
+        RequiredSSERegs = 0;
+        return ABIArgInfo::getIndirect(Ty);
+      } else {
+        // Argument values that are not enregistered are passed on the stack.
+        RequiredIntRegs = 0;
+        RequiredSSERegs = 0;
+        return ABIArgInfo::getDirect(Ty);
+      }
+    } else {
+      RequiredIntRegs = 0;
+      RequiredSSERegs = 0;
+
+      LLVMContext &LLVMContext = *Context.LLVMContext;
+      SmallVector<ABIArgInfo::Expansion, 2> Expansions;
+      for (uint32_t I = 0; I < Desc.eightByteCount; I++) {
+        Type *Ty;
+        uint32_t Size = Desc.eightByteSizes[I];
+        switch (Desc.eightByteClassifications[I]) {
+        case SystemVClassificationTypeInteger:
+          Ty = Type::getIntNTy(LLVMContext, Size * 8);
+          RequiredIntRegs++;
+          break;
+
+        case SystemVClassificationTypeSSE:
+          Ty = Size <= 4 ? Type::getFloatTy(LLVMContext)
+                         : Type::getDoubleTy(LLVMContext);
+          RequiredSSERegs++;
+          break;
+
+        case SystemVClassificationTypeIntegerReference:
+          assert(Size == 8);
+
+          // This eightbyte contains a GC reference. Type it as a manged
+          // pointer.
+          Ty = Type::getInt8Ty(LLVMContext)->getPointerTo(1);
+          RequiredIntRegs++;
+          break;
+
+        default:
+          llvm_unreachable("unexpected SysV classification");
+        }
+
+        ABIArgInfo::Expansion Expansion;
+        Expansion.TheType = Ty;
+        Expansion.Offset = Desc.eightByteOffsets[I];
+        Expansions.push_back(Expansion);
+      }
+
+      return ABIArgInfo::getExpand(Expansions);
+    }
+  }
+
+  if (Ty->isIntegerTy()) {
+    assert(Ty->getIntegerBitWidth() <= 64);
+
+    RequiredIntRegs = 1;
+    RequiredSSERegs = 0;
+
+    // RyuJIT requires that all arguments and return values smaller than 32 bits
+    // are zero- or sign-extended.
+    if (IsManagedCallingConv && Ty->getIntegerBitWidth() < 32) {
+      return ABITy.isSigned() ? ABIArgInfo::getSignExtend(Ty)
+                              : ABIArgInfo::getZeroExtend(Ty);
+    }
+
+    return ABIArgInfo::getDirect(Ty);
+  }
+
+  if (Ty->isFloatingPointTy()) {
+    assert(Ty->isFloatTy() || Ty->isDoubleTy());
+    RequiredIntRegs = 0;
+    RequiredSSERegs = 1;
+    return ABIArgInfo::getDirect(Ty);
+  }
+
+  assert(Ty->isPointerTy());
+  RequiredIntRegs = 1;
+  RequiredSSERegs = 0;
+  return ABIArgInfo::getDirect(Ty);
+}
+
+ABIArgInfo X86_64_SysV::classifyArgument(LLILCJitContext &JitContext,
+                                         const ABIType ABITy,
+                                         const DataLayout &DL,
+                                         bool IsManagedCallingConv,
+                                         uint32_t &RequiredIntRegs,
+                                         uint32_t &RequiredSSERegs) {
+  const bool IsResult = false;
+  return classify(JitContext, ABITy, DL, IsManagedCallingConv, IsResult,
+                  RequiredIntRegs, RequiredSSERegs);
+}
+
+ABIArgInfo X86_64_SysV::classifyResult(LLILCJitContext &JitContext,
+                                       const ABIType ABITy,
                                        const DataLayout &DL,
-                                       ABIArgInfo &ResultInfo,
-                                       std::vector<ABIArgInfo> &ArgInfos) {
-  // TODO: RyuJIT does not implement the SysV ABI rules as decribed in "System V
-  //       Application Binary Interface". For now, agree and just use the Win64
-  //       rules.
-  X86_64_Win64::computeSignatureInfo(IsManagedCallingConv, ResultType, ArgTypes,
-                                     DL, ResultInfo, ArgInfos);
+                                       bool IsManagedCallingConv) {
+  Type *Ty = ABITy.getType();
+  if (Ty->isVoidTy()) {
+    return ABIArgInfo::getDirect(Ty);
+  }
+
+  const bool IsResult = true;
+  uint32_t RequiredIntRegs, RequiredSSERegs;
+  return classify(JitContext, ABITy, DL, IsManagedCallingConv, IsResult,
+                  RequiredIntRegs, RequiredSSERegs);
+}
+
+void X86_64_SysV::computeSignatureInfo(
+    LLILCJitContext &Context, bool IsManagedCallingConv, ABIType ResultType,
+    ArrayRef<ABIType> ArgTypes, const DataLayout &DL, ABIArgInfo &ResultInfo,
+    std::vector<ABIArgInfo> &ArgInfos) {
+  ResultInfo = classifyResult(Context, ResultType, DL, IsManagedCallingConv);
+
+  uint32_t FreeIntRegs = ResultInfo.getKind() == ABIArgInfo::Indirect ? 5 : 6;
+  uint32_t FreeSSERegs = 8;
+
+  for (auto &Arg : ArgTypes) {
+    uint32_t RequiredIntRegs = 0, RequiredSSERegs = 0;
+    ABIArgInfo Info = classifyArgument(Context, Arg, DL, IsManagedCallingConv,
+                                       RequiredIntRegs, RequiredSSERegs);
+
+    // As per the ABI, if any eightbyte of a struct value does not fit in the
+    // number of available registers, the entire struct value is passed on the
+    // stack.
+    if (Info.getKind() == ABIArgInfo::Expand &&
+        (FreeIntRegs < RequiredIntRegs || FreeSSERegs < RequiredSSERegs)) {
+      Info = ABIArgInfo::getDirect(Arg.getType());
+    } else {
+      if (RequiredIntRegs > 0 && FreeIntRegs >= RequiredIntRegs) {
+        FreeIntRegs -= RequiredIntRegs;
+      }
+      if (RequiredSSERegs > 0 && FreeSSERegs >= RequiredSSERegs) {
+        FreeSSERegs -= RequiredSSERegs;
+      }
+    }
+
+    ArgInfos.push_back(std::move(Info));
+  }
 }
 
 X86_64ABIInfo::X86_64ABIInfo(Triple TargetTriple, const DataLayout &DL)
@@ -145,8 +325,8 @@ X86_64ABIInfo::X86_64ABIInfo(Triple TargetTriple, const DataLayout &DL)
 }
 
 void X86_64ABIInfo::computeSignatureInfo(
-    CallingConv::ID CC, bool IsManagedCallingConv, ABIType ResultType,
-    ArrayRef<ABIType> ArgTypes, ABIArgInfo &ResultInfo,
+    LLILCJitContext &Context, CallingConv::ID CC, bool IsManagedCallingConv,
+    ABIType ResultType, ArrayRef<ABIType> ArgTypes, ABIArgInfo &ResultInfo,
     std::vector<ABIArgInfo> &ArgInfos) const {
   if (CC == CallingConv::C) {
     CC = IsWindows ? CallingConv::X86_64_Win64 : CallingConv::X86_64_SysV;
@@ -160,7 +340,7 @@ void X86_64ABIInfo::computeSignatureInfo(
     break;
 
   case CallingConv::X86_64_SysV:
-    X86_64_SysV::computeSignatureInfo(IsManagedCallingConv, ResultType,
+    X86_64_SysV::computeSignatureInfo(Context, IsManagedCallingConv, ResultType,
                                       ArgTypes, TheDataLayout, ResultInfo,
                                       ArgInfos);
     break;
@@ -186,8 +366,40 @@ ABIInfo *ABIInfo::get(Module &M) {
 ABIArgInfo::ABIArgInfo(Kind TheKind, Type *TheType)
     : TheKind(TheKind), TheType(TheType) {}
 
+ABIArgInfo::ABIArgInfo(Kind TheKind, ArrayRef<Expansion> Expansions)
+    : TheKind(TheKind) {
+  this->Expansions = new SmallVector<Expansion, 2>();
+  for (const Expansion &Exp : Expansions) {
+    this->Expansions->push_back(Exp);
+  }
+}
+
+ABIArgInfo::ABIArgInfo(ABIArgInfo &&Other) { *this = std::move(Other); }
+
+ABIArgInfo::~ABIArgInfo() {
+  if (TheKind == Kind::Expand && Expansions != nullptr) {
+    delete Expansions;
+  }
+}
+
+ABIArgInfo &ABIArgInfo::operator=(ABIArgInfo &&Other) {
+  TheKind = Other.TheKind;
+  if (TheKind == Kind::Expand) {
+    Expansions = Other.Expansions;
+    Other.Expansions = nullptr;
+  } else {
+    TheType = Other.TheType;
+  }
+
+  return *this;
+}
+
 ABIArgInfo ABIArgInfo::getDirect(llvm::Type *TheType) {
   return ABIArgInfo(Kind::Direct, TheType);
+}
+
+ABIArgInfo ABIArgInfo::getExpand(ArrayRef<Expansion> Expansions) {
+  return ABIArgInfo(Kind::Expand, Expansions);
 }
 
 ABIArgInfo ABIArgInfo::getZeroExtend(llvm::Type *TheType) {
@@ -206,13 +418,21 @@ ABIArgInfo::Kind ABIArgInfo::getKind() const { return TheKind; }
 
 Type *ABIArgInfo::getType() const { return TheType; }
 
+llvm::ArrayRef<ABIArgInfo::Expansion> ABIArgInfo::getExpansions() const {
+  assert(TheKind == Kind::Expand);
+  assert(Expansions != nullptr);
+  return ArrayRef<Expansion>(*Expansions);
+}
+
 void ABIArgInfo::setIndex(uint32_t Index) { this->Index = Index; }
 
 uint32_t ABIArgInfo::getIndex() const { return Index; }
 
-ABIType::ABIType(llvm::Type *TheType, bool IsSigned)
-    : TheType(TheType), IsSigned(IsSigned) {}
+ABIType::ABIType(llvm::Type *TheType, CORINFO_CLASS_HANDLE Class, bool IsSigned)
+    : TheType(TheType), Class(Class), IsSigned(IsSigned) {}
 
 llvm::Type *ABIType::getType() const { return TheType; }
+
+CORINFO_CLASS_HANDLE ABIType::getClass() const { return Class; }
 
 bool ABIType::isSigned() const { return IsSigned; }


### PR DESCRIPTION
Most of the work here involves adding support for aggregate arguments
that are represented as multiple primitive and aggregate arguments
that are represented as LLVM 'byvalue' arguments (i.e. LLVM arguments
with the 'byvalue' attribute). The former are used for IL by-value
struct arguments that must be passed in multiple registers; the latter
are used for by-value struct arguments that must be passed on the
stack. All arguments are classified as do enregister/do not
enregister using the interface provided by CoreCLR.