### PR TITLE
Emit DebugLocInfo/DebugFileInfo in ObjectWriter for Windows

### DIFF
--- a/lib/ObjWriter/.nuget/Microsoft.Dotnet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Microsoft.Dotnet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.1-prerelease</version>
+    <version>1.0.2-prerelease</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.linux-x64.Microsoft.Dotnet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.linux-x64.Microsoft.Dotnet.ObjectWriter.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.1-prerelease</version>
+    <id>toolchain.linux-x64.Microsoft.DotNet.ObjectWriter</id>
+    <version>1.0.2-prerelease</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/objwriter.exports
+++ b/lib/ObjWriter/objwriter.exports
@@ -7,3 +7,6 @@ EmitIntValue
 EmitSymbolDef
 EmitSymbolRef
 EmitFrameInfo
+EmitDebugFileInfo
+EmitDebugLoc
+FlushDebugLocs


### PR DESCRIPTION
This basically emits two tables.
One is for file name tables (along with index table).
The other is for native offset to source location info.
Adapted CodeView emission logic from LLVM mainline. Ideally this code should be refactored to be shared, which I will follow-up.

Nuget package version (and name for linux) is updated.