### PR TITLE
Make GcInfo lib depend on intrinsics_gen

### DIFF
--- a/lib/GcInfo/CMakeLists.txt
+++ b/lib/GcInfo/CMakeLists.txt
@@ -17,3 +17,7 @@ add_llilcjit_library(GcInfo
 	GcInfoUtil.cpp
 	GcInfo.cpp
 )
+
+if( NOT LLILC_BUILT_STANDALONE )
+  add_dependencies(GcInfo intrinsics_gen)
+endif()


### PR DESCRIPTION
LLVM change r252796 (git hash f805775e) reworked llvm/IR/Attributes.h so
that it now #includes a generated .inc file.  GCInfo.cpp transitively
 #includes Attributes.h, so make it depend on the intrinsics_gen target
(which includes the generation of the .inc file)