### PR TITLE
Formalize object writer package names.

### DIFF
--- a/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.ObjectWriter</id>
+    <version>1.0.2-prerelease</version>
+    <title>Microsoft .NET Object File Generator</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corert</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides object writer to the managed to native code-generator.</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="runtime.json" />
+  </files>
+</package>

--- a/lib/ObjWriter/.nuget/runtime.json
+++ b/lib/ObjWriter/.nuget/runtime.json
@@ -1,0 +1,14 @@
+{
+  "runtimes": {
+    "win7-x64": {
+      "Microsoft.DotNet.ObjectWriter": {
+        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.2-prerelease"
+      }
+    },
+    "ubuntu.14.04-x64": {
+      "Microsoft.DotNet.ObjectWriter": {
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.2-prerelease"
+      }
+    }
+  }
+}

--- a/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>toolchain.linux-x64.Microsoft.DotNet.ObjectWriter</id>
+    <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter</id>
     <version>1.0.2-prerelease</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
@@ -15,6 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="../libobjwriter.so" target="libobjwriter.so" />
+    <file src="../libobjwriter.so" target="runtimes/ubuntu.14.04-x64/native/libobjwriter.so" />
   </files>
 </package>

--- a/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft.DotNet.ObjectWriter</id>
+    <id>toolchain.win7-x64.Microsoft.DotNet.ObjectWriter</id>
     <version>1.0.2-prerelease</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
@@ -15,6 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="..\objwriter.dll" target="objwriter.dll" />
+    <file src="..\objwriter.dll" target="runtimes\win7-x64\native\objwriter.dll" />
   </files>
 </package>

--- a/utils/make_package.py
+++ b/utils/make_package.py
@@ -40,6 +40,12 @@ def run(args):
     print("\nCopying " + args.nuspec + " to " + nugetSpec)
     shutil.copyfile(args.nuspec, nugetSpec)
 
+  if args.json != None:
+    nugetJson = os.path.join(nugetFolder, os.path.basename(args.json))
+    if args.json != nugetJson:
+      print("\nCopying " + args.json + " to " + nugetJson)
+      shutil.copyfile(args.json, nugetJson)
+
   nugetCommand = nugetExe + " pack " + nugetSpec \
                  + " -NoPackageAnalysis -NoDefaultExcludes" \
                  " -OutputDirectory %s" % nugetFolder
@@ -62,6 +68,10 @@ def main(argv):
             default=None,
             help="path to a nuspec file. This file is assumed to be under " \
                  "a child directory (.nuget) of the target by convetion")
+  parser.add_argument("--json", metavar="PATH",
+            default=None,
+            help="path to a json file. This file is used to create " \
+                 "a redirection package")
   args,unknown = parser.parse_known_args(argv)
 
   if unknown:


### PR DESCRIPTION
Add support for redirection package using json.
Add individual nuspec for each platform.
Change local script to handle json file.

Note this doesn't affect any CIbuild but it is used for a post-process to create packages. 