### PR TITLE
Report PSPSym and WantReportOnlyLeaf to GC

### DIFF
--- a/include/GcInfo/GcInfo.h
+++ b/include/GcInfo/GcInfo.h
@@ -115,6 +115,8 @@ public:
   uint32_t GsCkValidRangeStart;
   uint32_t GsCkValidRangeEnd;
   GENERIC_CONTEXTPARAM_TYPE GenericsContextParamType;
+  uint32_t PSPSymOffset;
+  bool HasFunclets;
 
 private:
   // Record a Stack Allocation in the FuncInfo, with appropriate


### PR DESCRIPTION
PSPSym is used to find the frame when a GC occurs during execution of an
exception handler, and WantReportOnlyLeaf tells the GC that the leaf
funclet will report the live variables for the entire function.