### PR TITLE
We don't need to chcp anymore

### DIFF
--- a/Documentation/Debugging.md
+++ b/Documentation/Debugging.md
@@ -203,24 +203,6 @@ the following environment variables are consulted:
   is executing. It is a semi-colon-separated list of
   directories in which to look for the assemblies.
 
-
-### Code Page Bug
-There is (or was) a bug which caused an exception to be
-thrown if the current code page is not 65001. 
-Since LLILC is not currently able to produce code that
-catches exception, testing must be done in an environment
-where the code page is 65001. This may be set using
-the command
-
-```
-chcp 65001
-```
-
-The LLILC scripts that run tests set this code page, but
-if you are setting up to run LLILC by hand, e.g. so
-you can run a single test, possibly under the control of
-a debugger, then you may need to set this manually.
-
 ## Running A Single Test from the command line
 To run a single test from the command line, use the
 python script llilc_run.py. Assuming your 

--- a/test/LLILCEnv.ps1
+++ b/test/LLILCEnv.ps1
@@ -877,9 +877,6 @@ function Global:RunTest
   $LLILCTestResult = LLILCTestResult
   $CoreCLRTestTargetBinaries = CoreCLRTestTargetBinaries -Arch $Arch -Build $Build
   
-  # Workaround exception handling issue
-  chcp 65001 | Out-Null
-
   # Reserve the old jit and copy in the specified jit.
   if ($Jit -ne "") {
     #$CoreCLRRuntime = CoreCLRRuntime

--- a/test/llilc_run.py
+++ b/test/llilc_run.py
@@ -147,7 +147,6 @@ def main(argv):
         log("llilc jit not found at ", jit_path)
         return 1
     
-    RunCommand('chcp 65001')
     os.environ["COMPlus_AltJit"]="*"
     os.environ["COMPlus_AltJitNgen"]="*"
     os.environ["COMPlus_AltJitName"]=jit_name

--- a/test/llilc_runtest.py
+++ b/test/llilc_runtest.py
@@ -201,7 +201,6 @@ def main(argv):
                 test_env.write('set COMPlus_InsertStatepoints=1\n')
             if (not args.ngen):
               test_env.write('set COMPlus_ZapDisable=1\n')
-            test_env.write('chcp 65001\n')
             if args.dump_level is not None:
                 test_env.write('set COMPlus_DumpLLVMIR=' + args.dump_level + '\n')
             if args.eh:

--- a/test/make_sln.py
+++ b/test/make_sln.py
@@ -208,9 +208,6 @@ EndProject
         log("llilc jit not found at ", jit_path)
         return 1
 
-    # Avoid code-page exception.
-    RunCommand('chcp 65001')
-    
     # Compute desired environment.
 
     # First initialize empty values for variables known to LLILC.


### PR DESCRIPTION
The issue in CoreFX that lead to us needing to run tests in code page 65001 is long since fixed. So remove the chcp from our test scripts and docs.

Closes #12.