### PR TITLE
Don't sort includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+SortIncludes:    false


### PR DESCRIPTION
Closes #953.

We might want to support this someday, but right now sorting includes per this rule breaks lots of stuff.