### PR TITLE
Always ask for the non-null entry point for a method

### DIFF
--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -4917,10 +4917,12 @@ IRNode *ReaderBase::rdrGetDirectCallTarget(CORINFO_METHOD_HANDLE Method,
     Address = CodePointerLookup.constLookup.addr;
     assert(Address != nullptr);
   } else {
+    // Ask for the generic "ANY" entry point. If NeedsNullCheck is true,
+    // we could instead ask for the CORINFO_ACCESS_NONNULL entry,
+    // but then we'd have to generalize the key used to look things
+    // up in the HandleToGlobalObjectMap.
     CORINFO_CONST_LOOKUP AddressInfo;
-    getFunctionEntryPoint(Method, &AddressInfo, NeedsNullCheck
-                                                    ? CORINFO_ACCESS_NONNULL
-                                                    : CORINFO_ACCESS_ANY);
+    getFunctionEntryPoint(Method, &AddressInfo, CORINFO_ACCESS_ANY);
     AccessType = AddressInfo.accessType;
     Address = AddressInfo.addr;
   }


### PR DESCRIPTION
We were seeing two different entry point addresses for some methods.

LLILC will insert an explicit null check for calls in the cases that require one, so always request the non-null entry point for a method. Otherwise we  need to (potentially) keep track of the two entry point addresses for each function, and make sure the right one is used at each call site.

This closes #957 and should also fix #951.