### PR TITLE
Update LLILC to generate new funclet EH IR

### DIFF
--- a/include/Reader/reader.h
+++ b/include/Reader/reader.h
@@ -967,6 +967,7 @@ EHRegion *rgnGetParent(EHRegion *EhRegion);
 /// \param Region   The child region to check against its parent
 /// \returns True iff this region is lexically outside its parent
 bool rgnIsOutsideParent(EHRegion *Region);
+EHRegion *rgnGetEnclosingAncestor(EHRegion *Region);
 void rgnSetChildList(EHRegion *EhRegion, EHRegionList *Children);
 EHRegionList *rgnGetChildList(EHRegion *EhRegion);
 EHRegion *rgnGetFilterHandlerRegion(EHRegion *EhRegion);

--- a/include/Reader/readerir.h
+++ b/include/Reader/readerir.h
@@ -533,18 +533,14 @@ public:
 
   void fgEnterRegion(EHRegion *Region) override;
 
-  /// Make an EH pad suitable as an unwind label for code in the try region
-  /// protected by the given handler, and any dispatch code needed after the
-  /// EH pad to transfer control to the handler code.
+  /// Make an EH pad suitable as the head of the given handler.
   ///
-  /// \param Handler           Catch/Finally/Fault/Filter region we need to
-  ///                          build an EH pad for.
-  /// \param EndPad [in/out]   CatchEndPad/CleanupEndPad that should be the
-  ///                          unwind target of code in the handler body.
-  /// \param NextPad           Next outer (or successor catch) EH region.
+  /// \param Handler       Catch/Finally/Fault/Filter region we need to
+  ///                      build an EH pad for.
+  /// \param EnclosingPad  EH pad representing the handler enclosing this one
+  ///                      if there is one, ConstantTokenNone otherwise.
   /// \returns A new CatchPad/CleanupPad in a populated EH pad block.
-  llvm::Instruction *createEHPad(EHRegion *Handler, llvm::Instruction *&EndPad,
-                                 llvm::Instruction *NextPad);
+  llvm::Instruction *createEHPad(EHRegion *Handler, llvm::Value *EnclosingPad);
 
   IRNode *fgNodeFindStartLabel(FlowGraphNode *Block) override;
 

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -2205,11 +2205,7 @@ EHRegion *ReaderBase::fgSwitchRegion(EHRegion *OldRegion, uint32_t Offset,
     // Exit this region; recursively check parent (may need to exit to ancestor
     // and/or may need to enter sibling/cousin).
     assert(Offset == TransitionOffset && "over-stepped region end");
-    EHRegion *ParentRegion = rgnGetParent(OldRegion);
-    if (rgnIsOutsideParent(OldRegion)) {
-      // We want the enclosing ancestor, not the immediate parent.
-      ParentRegion = rgnGetParent(ParentRegion);
-    }
+    EHRegion *ParentRegion = rgnGetEnclosingAncestor(OldRegion);
     return fgSwitchRegion(ParentRegion, Offset, NextOffset);
   }
 

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -1147,6 +1147,18 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\localloc\*" >
              <Issue>13</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_r\*" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_ro\*" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_do\*" >
+             <Issue>13</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_relthrow\*" >
+             <Issue>13</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\v4\dev10_804810\dev10_804810\*" >
              <Issue>636</Issue>
         </ExcludeList>
@@ -1753,12 +1765,6 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b112982\b112982\*" >
-             <Issue>13</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_ro\*" >
-             <Issue>13</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_do\*" >
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\structarr_cs_do\*" >
@@ -3432,9 +3438,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_ldsfld_mulovf\*" >
              <Issue>13</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_relthrow\*" >
-             <Issue>13</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_reladdsub\*" >
              <Issue>13</Issue>
         </ExcludeList>
@@ -3757,9 +3760,6 @@
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\iface\_il_dbgiface2\*" >
-             <Issue>13</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_r\*" >
              <Issue>13</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgldfld_mulovf\*" >


### PR DESCRIPTION
LLVM has streamlined the representation for funclet-style EH somewhat, by
pulling the dispatch aspect of catchpad out into a separate catchswitch
instruction, and by explicitly annotating EH pads with their enclosing
parents, obviating the need for endpads.

Update LLILC to generate catchswitch, emit the enclosing pad linkage, and
stop generating endpads.

Also update finally cloning accordingly.