### PR TITLE
Exclude some varargs tests, suppress popups in local testing

### DIFF
--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -1036,6 +1036,18 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i07\mcc_i07.cmd" >
              <Issue>970</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i10\mcc_i10.cmd" >
+             <Issue>CoreClr/1440</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i11\mcc_i11.cmd" >
+             <Issue>CoreClr/1440</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i12\mcc_i12.cmd" >
+             <Issue>CoreClr/1440</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i13\mcc_i13.cmd" >
+             <Issue>CoreClr/1440</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i14\mcc_i14.cmd" >
              <Issue>970</Issue>
         </ExcludeList>

--- a/test/llilc_run.py
+++ b/test/llilc_run.py
@@ -21,7 +21,7 @@
 #   -x [EXTRA [EXTRA ...]], --extra [EXTRA [EXTRA ...]]
 #                         list of extra COMPlus settings. Each item is
 #                         Name=Value, where Name does not have the
-#                         COMPlus_AltJit prefix.
+#                         COMPlus_ prefix.
 #   -n, --ngen            use ngened mscorlib
 #   -p, --precise-gc      test with precise gc
 #   -v, --verbose         echo commands
@@ -99,7 +99,7 @@ def main(argv):
                         help='the dump level: summary, or verbose')
     parser.add_argument('-x', '--extra', type=str, default=[], nargs='*',
                         help='''list of extra COMPlus settings. Each item is Name=Value, where
-                                Name does not have the COMPlus_AltJit prefix.
+                                Name does not have the COMPlus_ prefix.
                              ''')
     parser.add_argument('-n', '--ngen', help='use ngened mscorlib', default=False, action="store_true")
     parser.add_argument('-p', '--precise-gc', help='test with precise gc', default=False, action="store_true")
@@ -150,6 +150,7 @@ def main(argv):
     os.environ["COMPlus_AltJit"]="*"
     os.environ["COMPlus_AltJitNgen"]="*"
     os.environ["COMPlus_AltJitName"]=jit_name
+    os.environ["COMPlus_NoGuiOnAssert"]="1"
     if (args.precise_gc):
         os.environ["COMPlus_InsertStatepoints"]="1"
     else:
@@ -162,7 +163,7 @@ def main(argv):
         os.environ["COMPlus_ExecuteHandlers"]="1"
     for arg in args.extra:
         pair = UnquoteArg(arg).split('=', 1)
-        name = 'COMPLUS_AltJit' + pair[0]
+        name = 'COMPLUS_' + pair[0]
         value = pair[1]
         os.environ[name] = value
     os.environ["CORE_ROOT"]=args.coreclr_runtime_path

--- a/test/llilc_runtest.py
+++ b/test/llilc_runtest.py
@@ -193,6 +193,7 @@ def main(argv):
             test_env.write('set COMPlus_AltJit=*\n')
             test_env.write('set COMPlus_AltJitNgen=*\n')
             test_env.write('set COMPlus_AltJitName=' + time_stamped_jit_name + '\n')
+            test_env.write('set COMPlus_NoGuiOnAssert=1\n')
             if (args.precise_gc):
                 test_env.write('set COMPlus_InsertStatepoints=1\n')
             else:


### PR DESCRIPTION
With this set of four tests excluded, LLILC no longer skips any methods in the 3874 tests that remain.