### PR TITLE
Add CoreDisTools Library

### DIFF
--- a/include/CoreDisTools/coredistools.h
+++ b/include/CoreDisTools/coredistools.h
@@ -1,0 +1,64 @@
+//===--------- coredistools.h - Dissassembly tools for CoreClr
+//-------------===//
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Core Disassembly Tools API for CoreClr AOT/JIT
+///
+//===----------------------------------------------------------------------===//
+
+#if !defined(LLILC_TOOLS_COREDISTOOLS)
+#define LLILC_TOOLS_COREDISTOOLS
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+#define EXTERN_C extern "C"
+#else
+#define EXTERN_C
+#endif // defined(__cplusplus)
+
+#if defined(_MSC_VER)
+#if defined(DllInterfaceExporter)
+#define DllIface EXTERN_C __declspec(dllexport)
+#else
+#define DllIface EXTERN_C __declspec(dllimport)
+#endif // defined(DllInterfaceExporter)
+#else
+#define DllIface
+#endif // defined(_MSC_VER)
+
+enum TargetArch {
+  Target_Host, // Target is the same as host architecture
+  Target_X86,
+  Target_X64,
+  Target_Thumb,
+  Target_Arm64
+};
+
+struct CorDisasm;
+
+DllIface CorDisasm *InitDisasm(enum TargetArch Target);
+
+// DisasmInstruction -- Disassemble one instruction
+// Arguments:
+// Address -- The address at which the bytes of the instruction
+//            are intended to execute
+// Bytes -- Pointer to the actual bytes which need to be disassembled
+// MaxLength -- Number of bytes available in Bytes buffer
+// PrintAssembly -- Whether to dump the decoded instriction to stdout
+// Returns:
+//   -- The Size of the disassembled instruction
+//   -- Zero on failure
+DllIface size_t DisasmInstruction(const CorDisasm *Disasm, size_t Address,
+                                  const uint8_t *Bytes, size_t Maxlength,
+                                  bool PrintAssembly);
+
+DllIface void FinishDisasm(const CorDisasm *Disasm);
+
+#endif // !defined(LLILC_TOOLS_COREDISTOOLS)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,4 +2,5 @@ add_subdirectory(Reader)
 add_subdirectory(Jit)
 add_subdirectory(GcInfo)
 add_subdirectory(ObjWriter)
+add_subdirectory(CoreDisTools)
 

--- a/lib/CoreDisTools/.nuget/Microsoft.DotNet.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/Microsoft.DotNet.CoreDisTools.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.CoreDisTools </id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET Instruction-wise Disassembler</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Machine Code Disassembly Tools</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="runtime.json" />
+  </files>
+</package>

--- a/lib/CoreDisTools/.nuget/runtime.json
+++ b/lib/CoreDisTools/.nuget/runtime.json
@@ -1,0 +1,19 @@
+{
+  "runtimes": {
+    "win7-x64": {
+      "Microsoft.DotNet.CoreDisTools": {
+        "toolchain.win7-x64.Microsoft.DotNet.CoreDisTools": "1.0.0-prerelease"
+      }
+    },
+    "ubuntu.14.04-x64": {
+      "Microsoft.DotNet.CoreDisTools": {
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.CoreDisTools": "1.0.0-prerelease"
+      }
+    },
+    "osx.10.10-x64": {
+      "Microsoft.DotNet.CoreDisTools": {
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.CoreDisTools": "1.0.0-prerelease"
+      }
+    }
+  }
+}

--- a/lib/CoreDisTools/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.CoreDisTools.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.osx.10.10-x64.Microsoft.DotNet.CoreDisTools</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET Instruction-wise Disassembler</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Machine Code Disassembly Tools</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="../libcoredistools.dylib" target="runtimes/osx.10.10-x64/native/libcoredistools.dylib" />
+    <file src="../include/coredistools.h" target="runtimes/osx.10.10-x64/native/coredistools.h" />
+  </files>
+</package>

--- a/lib/CoreDisTools/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.CoreDisTools.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.CoreDisTools</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET Instruction-wise Disassembler</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Machine Code Disassembly Tools</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="../libcoredistools.so" target="runtimes/ubuntu.14.04-x64/native/libcoredistools.so" />
+    <file src="../include/coredistools.h" target="runtimes/ubuntu.14.04-x64/native/coredistools.h" />
+  </files>
+</package>

--- a/lib/CoreDisTools/.nuget/toolchain.win7-x64.Microsoft.DotNet.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/toolchain.win7-x64.Microsoft.DotNet.CoreDisTools.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.win7-x64.Microsoft.DotNet.CoreDisTools</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft .NET Instruction-wise Disassembler</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Machine Code Disassembly Tools</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="..\coredistools.dll" target="runtimes\win7-x64\native\coredistools.dll" />
+    <file src="..\include\coredistools.h" target="runtimes\win7-x64\native\coredistools.h" />
+  </files>
+</package>

--- a/lib/CoreDisTools/CMakeLists.txt
+++ b/lib/CoreDisTools/CMakeLists.txt
@@ -1,0 +1,47 @@
+project(coredistools)
+
+get_filename_component(LLILC_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../include ABSOLUTE)
+
+include_directories(${LLVM_INCLUDE_DIRS}
+                    ${LLILC_INCLUDES}/CoreDisTools)
+
+add_definitions(${LLVM_DEFINITIONS})
+
+if (WIN32)
+  # Create .def file containing a list of exports preceeded by
+  # 'EXPORTS'.  The file "coredistools.exports" already contains the list, 
+  # so we massage it into the correct format here to create 
+  # "coredistools.exports.def".
+  set(COREDISTOOLS_EXPORTS_DEF ${CMAKE_CURRENT_BINARY_DIR}/coredistools.exports.def)
+  set(COREDISTOOLS_EXPORTS_DEF_TEMP ${COREDISTOOLS_EXPORTS_DEF}.txt)
+  file(READ "coredistools.exports" exports_list)
+  file(WRITE ${COREDISTOOLS_EXPORTS_DEF_TEMP} "LIBRARY COREDISTOOLS\n")
+  file(APPEND ${COREDISTOOLS_EXPORTS_DEF_TEMP} "EXPORTS\n")
+  file(APPEND ${COREDISTOOLS_EXPORTS_DEF_TEMP} ${exports_list})
+  # Copy the file only if it has changed.
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${COREDISTOOLS_EXPORTS_DEF_TEMP} ${COREDISTOOLS_EXPORTS_DEF})
+endif()
+
+# Now build our tools
+add_library(coredistools
+   SHARED
+   coredistools.cpp
+   ${COREDISTOOLS_EXPORTS_DEF}
+)
+
+# Find the libraries that correspond to the LLVM components
+# that we wish to use
+llvm_map_components_to_libnames(llvm_libs
+  ${LLVM_TARGETS_TO_BUILD}
+)
+
+# Link against LLVM libraries
+target_link_libraries(coredistools
+${llvm_libs})
+
+# Output the export header corresponding to the coredistools library
+add_custom_command(TARGET coredistools POST_BUILD 
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+  ${LLILC_INCLUDES}/CoreDisTools/coredistools.h 
+  $<TARGET_FILE_DIR:coredistools>/include/coredistools.h)

--- a/lib/CoreDisTools/coredistools.cpp
+++ b/lib/CoreDisTools/coredistools.cpp
@@ -1,0 +1,226 @@
+//===-------- coredistools.cpp - Dissassembly tools for CoreClr -----------===//
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// \brief Implementation of Disassembly Tools API for AOT/JIT
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDisassembler.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/Signals.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetRegistry.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/DataTypes.h"
+
+#define DllInterfaceExporter
+#include "coredistools.h"
+
+using namespace llvm;
+using namespace std;
+
+// Instruction-wise disassembler helper.
+// This utility is used to implement GcStress in CoreCLr
+// Adapted from LLVM-objdump
+
+struct CorDisasm {
+public:
+  bool init();
+  size_t disasmInstruction(size_t Address, const uint8_t *Bytes,
+                           size_t Maxlength, bool PrintAsm = false) const;
+  void printInstruction(const MCInst *MI, size_t Address, size_t InstSize,
+                        ArrayRef<uint8_t> Bytes) const;
+
+  CorDisasm(TargetArch Target) { TargetArch = Target; }
+
+private:
+  bool setTarget();
+
+  TargetArch TargetArch;
+  string TargetTriple;
+  const Target *TheTarget;
+
+  unique_ptr<MCRegisterInfo> MRI;
+  unique_ptr<const MCAsmInfo> AsmInfo;
+  unique_ptr<const MCSubtargetInfo> STI;
+  unique_ptr<const MCInstrInfo> MII;
+  unique_ptr<const MCObjectFileInfo> MOFI;
+  unique_ptr<MCContext> Ctx;
+  unique_ptr<MCDisassembler> Disassembler;
+  unique_ptr<MCInstPrinter> IP;
+};
+
+bool CorDisasm::setTarget() {
+  // Figure out the target triple.
+
+  TargetTriple = sys::getDefaultTargetTriple();
+  TargetTriple = Triple::normalize(TargetTriple);
+  Triple TheTriple(TargetTriple);
+
+  switch (TargetArch) {
+  case Target_Host:
+    break;
+  case Target_Thumb:
+    TheTriple.setArch(Triple::thumb);
+    break;
+  case Target_Arm64:
+    TheTriple.setArch(Triple::aarch64);
+  case Target_X86:
+    TheTriple.setArch(Triple::x86);
+  case Target_X64:
+    TheTriple.setArch(Triple::x86_64);
+  }
+
+  // Get the target specific parser.
+  string Error;
+  string ArchName; // Target architecture is picked up from TargetTriple.
+  TheTarget = TargetRegistry::lookupTarget(ArchName, TheTriple, Error);
+  if (TheTarget == nullptr) {
+    errs() << Error;
+    return false;
+  }
+
+  // Update the triple name and return the found target.
+  TargetTriple = TheTriple.getTriple();
+  return true;
+}
+
+bool CorDisasm::init() {
+  // Print a stack trace if we signal out.
+  sys::PrintStackTraceOnErrorSignal();
+  // Call llvm_shutdown() on exit.
+  llvm_shutdown_obj Y;
+
+  // Initialize targets and assembly printers/parsers.
+  InitializeAllTargetInfos();
+  InitializeAllTargetMCs();
+  InitializeAllDisassemblers();
+
+  if (!setTarget()) {
+    // setTarget() prints error message if necessary
+    return false;
+  }
+
+  MRI.reset(TheTarget->createMCRegInfo(TargetTriple));
+  if (!MRI) {
+    errs() << "error: no register info for target " << TargetTriple << "\n";
+    return false;
+  }
+
+  // Set up disassembler.
+  AsmInfo.reset(TheTarget->createMCAsmInfo(*MRI, TargetTriple));
+  if (!AsmInfo) {
+    errs() << "error: no assembly info for target " << TargetTriple << "\n";
+    return false;
+  }
+
+  string Mcpu;        // Not specifying any particular CPU type.
+  string FeaturesStr; // No additional target specific attributes.
+  STI.reset(TheTarget->createMCSubtargetInfo(TargetTriple, Mcpu, FeaturesStr));
+  if (!STI) {
+    errs() << "error: no subtarget info for target " << TargetTriple << "\n";
+    return false;
+  }
+
+  MII.reset(TheTarget->createMCInstrInfo());
+  if (!MII) {
+    errs() << "error: no instruction info for target " << TargetTriple << "\n";
+    return false;
+  }
+
+  MOFI.reset(new MCObjectFileInfo);
+  Ctx.reset(new MCContext(AsmInfo.get(), MRI.get(), MOFI.get()));
+
+  Disassembler.reset(TheTarget->createMCDisassembler(*STI, *Ctx));
+
+  if (!Disassembler) {
+    errs() << "error: no disassembler for target " << TargetTriple << "\n";
+    return false;
+  }
+
+  int AsmPrinterVariant = AsmInfo->getAssemblerDialect();
+  IP.reset(TheTarget->createMCInstPrinter(
+      Triple(TargetTriple), AsmPrinterVariant, *AsmInfo, *MII, *MRI));
+
+  if (!IP) {
+    errs() << "error: No Instruction Printer for target " << TargetTriple
+           << "\n";
+    return false;
+  }
+
+  return true;
+}
+
+size_t CorDisasm::disasmInstruction(size_t Address, const uint8_t *Bytes,
+                                    size_t Maxlength, bool PrintAsm) const {
+  uint64_t Size;
+  MCInst Inst;
+  raw_ostream &CommentStream = nulls();
+  raw_ostream &DebugOut = nulls();
+  ArrayRef<uint8_t> ByteArray(Bytes, Maxlength);
+
+  bool success = Disassembler->getInstruction(Inst, Size, ByteArray, Address,
+                                              DebugOut, CommentStream);
+
+  if (!success) {
+    errs() << "Invalid instruction encoding\n";
+    return 0;
+  }
+
+  if (PrintAsm) {
+    printInstruction(&Inst, Address, Size, ByteArray.slice(0, Size));
+  }
+
+  return Size;
+}
+
+void CorDisasm::printInstruction(const MCInst *MI, size_t Address,
+                                 size_t InstSize,
+                                 ArrayRef<uint8_t> Bytes) const {
+  outs() << format("%8" PRIx64 ":", Address);
+  outs() << "\t";
+  dumpBytes(Bytes.slice(0, InstSize), outs());
+
+  IP->printInst(MI, outs(), "", *STI);
+  outs() << "\n";
+}
+
+// Implementation for CoreDisTools Interface
+
+CorDisasm *InitDisasm(TargetArch Target) {
+  CorDisasm *Disassembler = new CorDisasm(Target);
+  if (Disassembler->init()) {
+    return Disassembler;
+  }
+
+  delete Disassembler;
+  return nullptr;
+}
+
+void FinishDisasm(const CorDisasm *Disasm) { delete Disasm; }
+
+size_t DisasmInstruction(const CorDisasm *Disasm, size_t Address,
+                         const uint8_t *Bytes, size_t Maxlength,
+                         bool PrintAssembly) {
+  assert((Disasm != nullptr) && "Disassembler object Expected ");
+  return Disasm->disasmInstruction(Address, Bytes, Maxlength, PrintAssembly);
+}

--- a/lib/CoreDisTools/coredistools.exports
+++ b/lib/CoreDisTools/coredistools.exports
@@ -1,0 +1,3 @@
+InitDisasm
+FinishDisasm
+DisasmInstruction


### PR DESCRIPTION
This change adds CoreDisTools -- a library containing
LLVM disassembly tools for CoreClr to LLILC repo.

Currently, the library supports instruction-wise
disassembly API required for implementing GcStress.

coredistools.h -- the export/import header
coredistools.cpp -- the implementation as a wrapper around
    LLVM disassemblers to suite the required API.

This change also adds code to package the library into a
NuGet package.