### PR TITLE
Pass extra argument to createMCObjectStreamer

### DIFF
--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -207,6 +207,7 @@ bool ObjectWriter::init(llvm::StringRef ObjectFilePath) {
 
   MS = TheTarget->createMCObjectStreamer(TheTriple, *MC, *MAB, *OS, MCE, *MSTI,
                                          RelaxAll,
+                                         /*IncrementalLinkerCompatible*/ true,
                                          /*DWARFMustBeAtTheEnd*/ false);
   if (!MS)
     return error("no object streamer for target " + TripleName);


### PR DESCRIPTION
LLVM change r256203 (git hash 56afa6e6) added the
IncrementalLinkerCompatible flag to createMCObjectStreamer.  Update our
usage to pass the conservative value, true.