### PR TITLE
CoreDisTools: Handle disassembly of X86 Prefix bytes.

### DIFF
--- a/include/CoreDisTools/coredistools.h
+++ b/include/CoreDisTools/coredistools.h
@@ -30,7 +30,7 @@
 #define DllIface EXTERN_C __declspec(dllimport)
 #endif // defined(DllInterfaceExporter)
 #else
-#define DllIface
+#define DllIface EXTERN_C
 #endif // defined(_MSC_VER)
 
 enum TargetArch {


### PR DESCRIPTION
On X86, LLVM disassembler does not handle instruction prefixes
correctly -- please see LLVM bug 7709.

The disassembler reports instruction prefixes separate from the
actual instruction. In order to work-around this problem, we
continue decoding past the prefix bytes.

Instead of checking for LLVM Opcodes (which are subject to change
after any checkin), the check is performed using Machine opcode.

The tool also has a checker to verify our understanding of the way
X86 prefix bytes are decoded by LLVM. It is possible to add a
cross-verification wrt LLCM-opcodes, but the code will need
frequent updating.