### PR TITLE
Exclusion of b99969

### DIFF
--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -383,7 +383,8 @@ extern "C" void EmitFrameInfo(ObjectWriter *OW, const char *FunctionName,
   // The chained info is not currently emitted, verify that we don't see it.
   assert((flags & (Win64EH::UNW_ChainInfo << 3)) == 0);
   if ((flags &
-      (Win64EH::UNW_TerminateHandler | Win64EH::UNW_ExceptionHandler) << 3) != 0) {
+       (Win64EH::UNW_TerminateHandler | Win64EH::UNW_ExceptionHandler) << 3) !=
+      0) {
     assert(PersonalityFunctionName != nullptr);
     const MCExpr *PersonalityFn = GetSymbolRefExpr(
         OW, PersonalityFunctionName, MCSymbolRefExpr::VK_COFF_IMGREL32);

--- a/test/exclusion.targets
+++ b/test/exclusion.targets
@@ -4440,6 +4440,12 @@
 	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b27077\b27077\b27077.cmd" >
 	     <Issue>13</Issue>
 	</ExcludeList>
+	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b99969\b99969\b99969.cmd" >
+	     <Issue>13</Issue>
+	</ExcludeList>
+	<ExcludeList Include="$(XunitTestBinBase)\JIT\RyuJIT\DoWhileBndChk\DoWhileBndChk.cmd" >
+	     <Issue>13</Issue>
+	</ExcludeList>
     </ItemGroup>
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(COMPLUS_INSERTSTATEPOINTS)' != ''">	
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\113574\113574\*" >


### PR DESCRIPTION
https://github.com/dotnet/coreclr/commit/8353857ecea0fb4410d72fcf69aeb55fb09feef5 enabled this test,
but it appears it fails with llilc due to EH.