### PR TITLE
Don't register LLVM signal handlers in CoreCLR tools

### DIFF
--- a/lib/CoreDisTools/coredistools.cpp
+++ b/lib/CoreDisTools/coredistools.cpp
@@ -25,7 +25,6 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/PrettyStackTrace.h"
-#include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
@@ -164,8 +163,6 @@ bool CorDisasm::setTarget() {
 }
 
 bool CorDisasm::init() {
-  // Print a stack trace if we signal out.
-  sys::PrintStackTraceOnErrorSignal();
   // Call llvm_shutdown() on exit.
   llvm_shutdown_obj Y;
 

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -39,7 +39,6 @@
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/PrettyStackTrace.h"
-#include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
@@ -155,8 +154,6 @@ public:
 };
 
 bool ObjectWriter::init(llvm::StringRef ObjectFilePath) {
-  // Print a stack trace if we signal out.
-  sys::PrintStackTraceOnErrorSignal();
   llvm_shutdown_obj Y; // Call llvm_shutdown() on exit.
 
   // Initialize targets


### PR DESCRIPTION
Objectwriter and ObjectWriter and CoreDistools as tools loaded as DLLs.
They currently always register signal handlers for SIGABRT and SIGSEGV,
which interferes with CoreCLR's signal handlers. This caused unexpected
behavior and dumps in certain GCStress runs. So, this change removes
the use of LLVM's signal handlers.