### PR TITLE
Support for CFI Unwind

### DIFF
--- a/lib/ObjWriter/.nuget/runtime.json
+++ b/lib/ObjWriter/.nuget/runtime.json
@@ -2,17 +2,17 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.4-prerelease-00001"
+        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.5-prerelease-00001"
       }
     },
     "ubuntu.14.04-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.4-prerelease-00001"
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.5-prerelease-00001"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.4-prerelease-00001"
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.5-prerelease-00001"
       }
     }
   }

--- a/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.4-prerelease-00001</version>
+    <version>1.0.5-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.4-prerelease-00001</version>
+    <version>1.0.5-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.win7-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.4-prerelease-00001</version>
+    <version>1.0.5-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/CMakeLists.txt
+++ b/lib/ObjWriter/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(objwriter)
 
 include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${CORECLR_INCLUDE})
 add_definitions(${LLVM_DEFINITIONS})
 
 if (WIN32)

--- a/lib/ObjWriter/objwriter.exports
+++ b/lib/ObjWriter/objwriter.exports
@@ -6,7 +6,10 @@ EmitBlob
 EmitIntValue
 EmitSymbolDef
 EmitSymbolRef
-EmitFrameInfo
+EmitWinFrameInfo
+EmitCFIStart
+EmitCFIEnd
+EmitCFICode
 EmitDebugFileInfo
 EmitDebugLoc
 FlushDebugLocs


### PR DESCRIPTION
This adds the following CFI unwind emission.
EmitCFIStart
EmitCFIEnd
EmitCFIBlob

The first two sets the range of the code that the frame covers.
The last one should be invoked for each offset of the code, if any.
The blob data format is shared by the one RyuJit layouts.