### PR TITLE
Remove references to deleted options

### DIFF
--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -201,17 +201,6 @@ ICorJitCompiler *__stdcall getJit() {
       Opts["disable-cgp-gc-opts"]->addOccurrence(0, "disable-cgp-gc-opts",
                                                  "true");
     }
-    // Set flags indicating to statepoint lowering that call->statepoint
-    // rewriting happens in rs4gc rather than statepoint placement, and
-    // that we use operand bundles for deopt/transition arguments.
-    if (Opts["spp-no-statepoints"]->getNumOccurrences() == 0) {
-      Opts["spp-no-statepoints"]->addOccurrence(0, "spp-no-statepoints",
-                                                "true");
-    }
-    if (Opts["rs4gc-use-deopt-bundles"]->getNumOccurrences() == 0) {
-      Opts["rs4gc-use-deopt-bundles"]->addOccurrence(
-          0, "rs4gc-use-deopt-bundles", "true");
-    }
   }
 
   return LLILCJit::TheJit;


### PR DESCRIPTION
Remove the code that sets `spp-no-statepoints` and
`rs4gc-use-deopt-bundles` to true; the options have been removed in
r259096 and r259129 and the behavior is now always as though they were set
to true.