### PR TITLE
Expect `Indirect` pointers in stack map

### DIFF
--- a/lib/GcInfo/GcInfo.cpp
+++ b/lib/GcInfo/GcInfo.cpp
@@ -580,7 +580,7 @@ void GcInfoEmitter::encodeTrackedPointers(const GcFuncInfo *GcFuncInfo) {
         assert(false && "GC-Pointer Live in Register");
         break;
 
-      case StackMapParserType::LocationKind::Direct: {
+      case StackMapParserType::LocationKind::Indirect: {
         // __LLVM_Stackmap reports the liveness of pointers wrt SP even for
         // methods which have a FP.
         assert(Loc.getDwarfRegNum() == DW_STACK_POINTER &&


### PR DESCRIPTION
LLVM change r256352 (llvm-mirror/llvm@da801219) had the effect of
switching the reporting at statepoints in LLILC from being annotated with
LocationKind::Direct (which would mean that the GC pointer being reported
is a pointer to the stack location indicated) to being annotated with
LocatoinKind::Indirect (which, correctly, means taht the stack location
being reported holds a GC pointer that the GC must track/update).  Update
LLILC's expectations when parsing the stack map accordingly.