### PR TITLE
Rename CoreDisTools Package

### DIFF
--- a/lib/CoreDisTools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,21 +1,20 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>toolchain.osx.10.10-x64.Microsoft.DotNet.CoreDisTools</id>
-    <version>1.0.0-prerelease</version>
-    <title>Microsoft .NET Instruction-wise Disassembler</title>
+    <id>Microsoft.NETCore.CoreDisTools </id>
+    <version>1.0.0-prerelease-00001</version>
+    <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
     <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>Machine Code Disassembly Tools</description>
+    <description>Disassembly Tools for CoreCLR</description>
     <releaseNotes>Initial release</releaseNotes>
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="../libcoredistools.dylib" target="runtimes/osx.10.10-x64/native/libcoredistools.dylib" />
-    <file src="../include/coredistools.h" target="runtimes/osx.10.10-x64/native/coredistools.h" />
+    <file src="runtime.json" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.json
+++ b/lib/CoreDisTools/.nuget/runtime.json
@@ -1,18 +1,18 @@
 {
   "runtimes": {
     "win7-x64": {
-      "Microsoft.DotNet.CoreDisTools": {
-        "toolchain.win7-x64.Microsoft.DotNet.CoreDisTools": "1.0.0-prerelease"
+      "Microsoft.NETCore.CoreDisTools": {
+        "runtime.win7-x64.Microsoft.NETCore.CoreDisTools": "1.0.0-prerelease-00001"
       }
     },
     "ubuntu.14.04-x64": {
-      "Microsoft.DotNet.CoreDisTools": {
-        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.CoreDisTools": "1.0.0-prerelease"
+      "Microsoft.NETCore.CoreDisTools": {
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools": "1.0.0-prerelease-00001"
       }
     },
     "osx.10.10-x64": {
-      "Microsoft.DotNet.CoreDisTools": {
-        "toolchain.osx.10.10-x64.Microsoft.DotNet.CoreDisTools": "1.0.0-prerelease"
+      "Microsoft.NETCore.CoreDisTools": {
+        "runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools": "1.0.0-prerelease-00001"
       }
     }
   }

--- a/lib/CoreDisTools/.nuget/runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,21 +1,21 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>toolchain.win7-x64.Microsoft.DotNet.CoreDisTools</id>
-    <version>1.0.0-prerelease</version>
-    <title>Microsoft .NET Instruction-wise Disassembler</title>
+    <id>runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools</id>
+    <version>1.0.0-prerelease-00001</version>
+    <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
     <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>Machine Code Disassembly Tools</description>
+    <description>Disassembly Tools for CoreCLR</description>
     <releaseNotes>Initial release</releaseNotes>
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="..\coredistools.dll" target="runtimes\win7-x64\native\coredistools.dll" />
-    <file src="..\include\coredistools.h" target="runtimes\win7-x64\native\coredistools.h" />
+    <file src="../libcoredistools.dylib" target="runtimes/osx.10.10-x64/native/libcoredistools.dylib" />
+    <file src="../include/coredistools.h" target="runtimes/osx.10.10-x64/native/coredistools.h" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.CoreDisTools</id>
-    <version>1.0.0-prerelease</version>
-    <title>Microsoft .NET Instruction-wise Disassembler</title>
+    <id>runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools</id>
+    <version>1.0.0-prerelease-00001</version>
+    <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>

--- a/lib/CoreDisTools/.nuget/runtime.win7-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win7-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Microsoft.DotNet.CoreDisTools </id>
-    <version>1.0.0-prerelease</version>
-    <title>Microsoft .NET Instruction-wise Disassembler</title>
+    <id>runtime.win7-x64.Microsoft.NETCore.CoreDisTools</id>
+    <version>1.0.0-prerelease-00001</version>
+    <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
@@ -15,6 +15,7 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="runtime.json" />
+    <file src="..\coredistools.dll" target="runtimes\win7-x64\native\coredistools.dll" />
+    <file src="..\include\coredistools.h" target="runtimes\win7-x64\native\coredistools.h" />
   </files>
 </package>


### PR DESCRIPTION
The CoreDisTools package will be pushed to Microsoft.NetCore feed.
In order to match the convention in this feed, rename the CoreDistools
package from
toolchain.arch.Microsoft.DotNet.CoreDisTools.1.0.0-prerelease.nupkg
to
runtime.arch.Microsoft.NETcore.CoreDisTools.1.0.0-prerelease.nupkg
