### PR TITLE
Fix build issue on NetBSD: Correct namespace of OptLevel::DEBUG_CODE

### DIFF
--- a/lib/Jit/jitoptions.cpp
+++ b/lib/Jit/jitoptions.cpp
@@ -63,7 +63,7 @@ JitOptions::JitOptions(LLILCJitContext &Context) {
 
   // Set optimization level for this JIT invocation.
   OptLevel = queryOptLevel(Context);
-  EnableOptimization = OptLevel != OptLevel::DEBUG_CODE;
+  EnableOptimization = OptLevel != ::OptLevel::DEBUG_CODE;
 
   // Set whether to use conservative GC.
   UseConservativeGC = queryUseConservativeGC(Context);


### PR DESCRIPTION
This patch addresses the following error on NetBSD-7.99.26 with GCC-4.8.5:

```
/tmp/pkgsrc-tmp/wip/llilc-git/work/llvm/tools/llilc/lib/Jit/jitoptions.cpp:
In constructor 'JitOptions::JitOptions(LLILCJitContext&)':
/tmp/pkgsrc-tmp/wip/llilc-git/work/llvm/tools/llilc/lib/Jit/jitoptions.cpp:66:36:
error: 'OptLevel' is not a class, namespace, or enumeration
   EnableOptimization = OptLevel != OptLevel::DEBUG_CODE;
                                    ^
```