### PR TITLE
Use the CorJitHost interface.

### DIFF
--- a/include/Jit/LLILCJit.h
+++ b/include/Jit/LLILCJit.h
@@ -74,6 +74,7 @@ public:
   /// \name CoreCLR EE information
   //@{
   ICorJitInfo *JitInfo;            ///< EE callback interface.
+  ICorJitHost *JitHost;            ///< EE Host Interface
   CORINFO_METHOD_INFO *MethodInfo; ///< Description of method to jit.
   uint32_t Flags;                  ///< Flags controlling jit behavior.
   CORINFO_EE_INFO EEInfo;          ///< Information about internal EE data.
@@ -280,6 +281,9 @@ private:
 public:
   /// A pointer to the singleton jit instance.
   static LLILCJit *TheJit;
+
+  /// A pointer to the singleton jit-host instance.
+  static ICorJitHost *TheJitHost;
 
 private:
   /// Thread local storage for the jit's per-thread state.

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -146,10 +146,9 @@ private:
   LLILCJitContext *Context;
 };
 
-
 // The one and only Jit Object.
 LLILCJit *LLILCJit::TheJit = nullptr;
-ICorJitHost * LLILCJit::TheJitHost = nullptr;
+ICorJitHost *LLILCJit::TheJitHost = nullptr;
 
 // This is guaranteed to be called by the EE
 // in single-threaded mode.
@@ -238,8 +237,7 @@ extern "C" void __stdcall sxsJitStartup(void *CcCallbacks) {
   // nothing to do
 }
 
-extern "C" void __stdcall jitStartup(ICorJitHost* JitHost)
-{
+extern "C" void __stdcall jitStartup(ICorJitHost *JitHost) {
   LLILCJit::TheJitHost = JitHost;
 }
 

--- a/lib/Jit/LLILCJit.cpp
+++ b/lib/Jit/LLILCJit.cpp
@@ -146,8 +146,10 @@ private:
   LLILCJitContext *Context;
 };
 
+
 // The one and only Jit Object.
 LLILCJit *LLILCJit::TheJit = nullptr;
+ICorJitHost * LLILCJit::TheJitHost = nullptr;
 
 // This is guaranteed to be called by the EE
 // in single-threaded mode.
@@ -234,6 +236,11 @@ BOOL WINAPI DllMain(HANDLE Instance, DWORD Reason, LPVOID Reserved) {
 
 extern "C" void __stdcall sxsJitStartup(void *CcCallbacks) {
   // nothing to do
+}
+
+extern "C" void __stdcall jitStartup(ICorJitHost* JitHost)
+{
+  LLILCJit::TheJitHost = JitHost;
 }
 
 LLILCJitContext::LLILCJitContext(LLILCJitPerThreadState *PerThreadState)

--- a/lib/Jit/LLILCJit.exports
+++ b/lib/Jit/LLILCJit.exports
@@ -1,2 +1,3 @@
 getJit
 sxsJitStartup
+jitStartup

--- a/lib/Jit/jitoptions.cpp
+++ b/lib/Jit/jitoptions.cpp
@@ -45,13 +45,14 @@ MethodSet JitOptions::CodeRangeMethodSet;
 template <typename UTF16CharT>
 char16_t *getStringConfigValue(ICorJitInfo *CorInfo, const UTF16CharT *Name) {
   static_assert(sizeof(UTF16CharT) == 2, "UTF16CharT is the wrong size!");
-  return (char16_t *)CorInfo->getStringConfigValue((const wchar_t *)Name);
+  return (char16_t *)LLILCJit::TheJitHost->getStringConfigValue(
+      (const wchar_t *)Name);
 }
 
 template <typename UTF16CharT>
 void freeStringConfigValue(ICorJitInfo *CorInfo, UTF16CharT *Value) {
   static_assert(sizeof(UTF16CharT) == 2, "UTF16CharT is the wrong size!");
-  return CorInfo->freeStringConfigValue((wchar_t *)Value);
+  return LLILCJit::TheJitHost->freeStringConfigValue((wchar_t *)Value);
 }
 
 JitOptions::JitOptions(LLILCJitContext &Context) {

--- a/lib/Reader/reader.cpp
+++ b/lib/Reader/reader.cpp
@@ -2277,7 +2277,6 @@ EHRegion *ReaderBase::fgSwitchRegion(EHRegion *OldRegion, uint32_t Offset,
   return OldRegion;
 }
 
-
 // Parse bytecode to blocks.  Incoming argument 'block' holds dummy
 // entry block. This entry block may be preceeded by another block
 // that holds IRNodes (to support monitored routines.)  When this


### PR DESCRIPTION
Set up LLIC to use CorJitHost interface to access config values.
This change fixes LLILC build break.