### PR TITLE
CoreDisTools: Use Custom print API

### DIFF
--- a/include/CoreDisTools/coredistools.h
+++ b/include/CoreDisTools/coredistools.h
@@ -1,5 +1,4 @@
-//===--------- coredistools.h - Dissassembly tools for CoreClr
-//-------------===//
+//===--------- coredistools.h - Dissassembly tools for CoreClr ------------===//
 //
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
@@ -8,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// \brief Core Disassembly Tools API for CoreClr AOT/JIT
+/// \brief Core Disassembly Tools API Version 1.0.1-prerelease
 ///
 //===----------------------------------------------------------------------===//
 
@@ -42,45 +41,90 @@ enum TargetArch {
 };
 
 struct CorDisasm;
+struct CorAsmDiff;
 
+// The custom print functionality to be provide by the
+// users of this Library
+typedef void (*Printer)(const char *msg, ...);
+struct PrintControl {
+  const Printer Error;
+  const Printer Warning;
+  const Printer Log;
+  const Printer Dump;
+};
+
+// The type of a custom function provided by the user to determine
+// if two offsets are considered equivalent wrt diffing code blocks.
+// Offset1 and Offset2 are the two offsets to be compared.
+// BlockOffset is the offest of the instructions (that contain Offset1
+// and Offset2) from the beginning of their respective code blocks.
+// InstructionLength is the length of the current instruction being
+// compared for equivalency.
+typedef bool (*OffsetComparator)(const void *UserData, size_t BlockOffset,
+                                 size_t InstructionLength, uint64_t Offset1,
+                                 uint64_t Offset2);
+
+// Initialize the disassembler, using default print controls
 DllIface CorDisasm *InitDisasm(enum TargetArch Target);
+
+// Initialize the disassembler using custom print controls
+DllIface CorDisasm *NewDisasm(enum TargetArch Target,
+                              const PrintControl *PControl);
+
+// Delete the disassembler
 DllIface void FinishDisasm(const CorDisasm *Disasm);
 
 // DisasmInstruction -- Disassemble one instruction
 // Arguments:
+// Disasm -- The Disassembler
 // Address -- The address at which the bytes of the instruction
 //            are intended to execute
 // Bytes -- Pointer to the actual bytes which need to be disassembled
 // MaxLength -- Number of bytes available in Bytes buffer
-// PrintAssembly -- Whether to dump the decoded instriction to stdout
 // Returns:
 //   -- The Size of the disassembled instruction
 //   -- Zero on failure
-DllIface size_t DisasmInstruction(const CorDisasm *Disasm, size_t Address,
-                                  const uint8_t *Bytes, size_t Maxlength,
-                                  bool PrintAssembly);
+DllIface size_t DisasmInstruction(const CorDisasm *Disasm,
+                                  const uint8_t *Address, const uint8_t *Bytes,
+                                  size_t Maxlength);
 
-struct DiffControl {
-  // The disassembler to use for Diffing code blocks.
-  const CorDisasm *Disasm;
-  // Are the two offsets considered equivalent by the consumer
-  bool (*areEquivalent)(const void *userData, size_t blockOffset,
-                        uint64_t offset1, uint64_t offset2);
-  // Always dump the code blocks compared
-  bool VerboseDump;
-  // Whether to dump the entire code blocks on MisCompare
-  bool DumpBlocksOnMisCompare;
-  // Any state that the user of this library wants to pass
-  // through into areEquivalent() function.
-  void *userData;
-};
+// Initialize the Code Differ
+DllIface CorAsmDiff *NewDiffer(enum TargetArch Target,
+                               const PrintControl *PControl,
+                               const OffsetComparator Comparator);
 
-DllIface bool NearDiffCodeBlocks(const DiffControl *Control, size_t Address1,
+// Delete the Code Differ
+DllIface void FinishDiff(const CorAsmDiff *AsmDiff);
+
+// NearDiffCodeBlocks -- Compare two code blocks for semantic
+//                       equivalence
+// Arguments:
+// AsmDiff -- The Asm-differ
+// UserData -- Any data the user wishes to pass through into
+//             the OffsetComparator
+// Address1 -- Address at which first block will execute
+// Bytes1 -- Pointer to the actual bytes of the first block
+// Size1 -- The size of the first block
+// Address2 -- Address at which second block will execute
+// Bytes2 -- Pointer to the actual bytes of the second block
+// Size2 -- The size of the second block
+// Returns:
+//   -- true if the two blocks are equivalent, false if not.
+DllIface bool NearDiffCodeBlocks(const CorAsmDiff *AsmDiff,
+                                 const void *UserData, const uint8_t *Address1,
                                  const uint8_t *Bytes1, size_t Size1,
-                                 size_t Address2, const uint8_t *Bytes2,
+                                 const uint8_t *Address2, const uint8_t *Bytes2,
                                  size_t Size2);
 
-DllIface void PrintCodeBlock(const CorDisasm *Disasm, size_t Address,
-                             const uint8_t *Bytes, size_t Size);
+// Print a code block according to the Disassembler's Print Controls
+DllIface void DumpCodeBlock(const CorDisasm *Disasm, const uint8_t *Address,
+                            const uint8_t *Bytes, size_t Size);
+
+// Print the two code blocks being diffed, according to
+// AsmDiff's PrintControls.
+DllIface void DumpDiffBlocks(const CorAsmDiff *AsmDiff, const uint8_t *Address1,
+                             const uint8_t *Bytes1, size_t Size1,
+                             const uint8_t *Address2, const uint8_t *Bytes2,
+                             size_t Size2);
 
 #endif // !defined(LLILC_TOOLS_COREDISTOOLS)

--- a/lib/CoreDisTools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.NETCore.CoreDisTools </id>
-    <version>1.0.0-prerelease-00001</version>
+    <version>1.0.1-prerelease-00001</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.json
+++ b/lib/CoreDisTools/.nuget/runtime.json
@@ -2,17 +2,17 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.win7-x64.Microsoft.NETCore.CoreDisTools": "1.0.0-prerelease-00001"
+        "runtime.win7-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
       }
     },
     "ubuntu.14.04-x64": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools": "1.0.0-prerelease-00001"
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools": "1.0.0-prerelease-00001"
+        "runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
       }
     }
   }

--- a/lib/CoreDisTools/.nuget/runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.0-prerelease-00001</version>
+    <version>1.0.1-prerelease-00001</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.0-prerelease-00001</version>
+    <version>1.0.1-prerelease-00001</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.win7-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win7-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.win7-x64.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.0-prerelease-00001</version>
+    <version>1.0.1-prerelease-00001</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/coredistools.exports
+++ b/lib/CoreDisTools/coredistools.exports
@@ -1,3 +1,9 @@
 InitDisasm
+NewDisasm
 FinishDisasm
 DisasmInstruction
+NewDiffer
+FinishDiff
+NearDiffCodeBlocks
+DumpCodeBlock
+DumpDiffBlocks


### PR DESCRIPTION
This commit has the following changes:

1) Separate out Asm-diff functionality from BlockInfo to a separate class
   CorAsmDiff, which inherits from CorDisasm, to avoid passing around
   some disassebler information.

2) Use customer provided printing routines via PrintControl interface
   instead of printing ot stdout/stderr

3) Use Intel syntax for X86/X64 asm instead of the default GCC syntax