### PR TITLE
Support Comdat sections on Windows

### DIFF
--- a/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.9-prerelease-00001</version>
+    <version>1.0.10-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/runtime.json
+++ b/lib/ObjWriter/.nuget/runtime.json
@@ -2,17 +2,17 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.9-prerelease-00001"
+        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.10-prerelease-00001"
       }
     },
     "ubuntu.14.04-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.9-prerelease-00001"
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.10-prerelease-00001"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.9-prerelease-00001"
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.10-prerelease-00001"
       }
     }
   }

--- a/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.9-prerelease-00001</version>
+    <version>1.0.10-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.9-prerelease-00001</version>
+    <version>1.0.10-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.win7-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.9-prerelease-00001</version>
+    <version>1.0.10-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -270,6 +270,8 @@ extern "C" bool CreateCustomSection(ObjectWriter *OW, const char *SectionName,
   std::string SectionNameStr(SectionName);
   assert(OW->CustomSections.find(SectionNameStr) == OW->CustomSections.end() &&
          "Section with duplicate name already exists");
+  assert(ComdatName == nullptr ||
+         OW->MOFI->getObjectFileType() == OW->MOFI->IsCOFF);
 
   MCSection *Section = nullptr;
   SectionKind Kind = (attributes & CustomSectionAttributes_Executable)

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -259,7 +259,8 @@ enum CustomSectionAttributes : int32_t {
 };
 
 extern "C" bool CreateCustomSection(ObjectWriter *OW, const char *SectionName,
-                                    CustomSectionAttributes attributes) {
+                                    CustomSectionAttributes attributes,
+                                    const char *ComdatName) {
   assert(OW && "ObjWriter is null");
   Triple TheTriple(TripleName);
   auto *AsmPrinter = &OW->getAsmPrinter();
@@ -295,7 +296,13 @@ extern "C" bool CreateCustomSection(ObjectWriter *OW, const char *SectionName,
       Characteristics |= COFF::IMAGE_SCN_CNT_INITIALIZED_DATA;
     }
 
-    Section = OutContext.getCOFFSection(SectionName, Characteristics, Kind);
+    if (ComdatName != nullptr) {
+      Section = OutContext.getCOFFSection(SectionName, Characteristics | 
+          COFF::IMAGE_SCN_LNK_COMDAT, Kind, ComdatName,
+          COFF::COMDATType::IMAGE_COMDAT_SELECT_ANY);
+    } else {
+      Section = OutContext.getCOFFSection(SectionName, Characteristics, Kind);
+    }
     break;
   }
   case Triple::ELF: {


### PR DESCRIPTION
Add a parameter to CreateCustomSection specifying a Comdat symbol to use
for the section being created. The selection policy is left as SelectAny
to allow the linker to pick.