### PR TITLE
CoreDisTOols: Build X86 packages

### DIFF
--- a/lib/CoreDisTools/.nuget/runtime.json
+++ b/lib/CoreDisTools/.nuget/runtime.json
@@ -15,5 +15,20 @@
         "runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
       }
     }
+    "win7-x86": {
+      "Microsoft.NETCore.CoreDisTools": {
+        "runtime.win7-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+      }
+    },
+    "ubuntu.14.04-x86": {
+      "Microsoft.NETCore.CoreDisTools": {
+        "runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+      }
+    },
+    "osx.10.10-x86": {
+      "Microsoft.NETCore.CoreDisTools": {
+        "runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+      }
+    }
   }
 }

--- a/lib/CoreDisTools/.nuget/runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>runtime.win7-x64.Microsoft.NETCore.CoreDisTools</id>
+    <id>runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools</id>
     <version>1.0.1-prerelease-00001</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
@@ -15,7 +15,7 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="..\coredistools.dll" target="runtimes\win7-x64\native\coredistools.dll" />
-    <file src="..\include\coredistools.h" target="runtimes\win7-x64\native\coredistools.h" />
+    <file src="../libcoredistools.dylib" target="runtimes/osx.10.10-x86/native/libcoredistools.dylib" />
+    <file src="../include/coredistools.h" target="runtimes/osx.10.10-x86/native/coredistools.h" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>Machine Code Disassembly Tools</description>
+    <description>Disassembly Tools for CoreCLR</description>
     <releaseNotes>Initial release</releaseNotes>
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>

--- a/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>runtime.win7-x64.Microsoft.NETCore.CoreDisTools</id>
+    <id>runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools</id>
     <version>1.0.1-prerelease-00001</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
@@ -15,7 +15,7 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="..\coredistools.dll" target="runtimes\win7-x64\native\coredistools.dll" />
-    <file src="..\include\coredistools.h" target="runtimes\win7-x64\native\coredistools.h" />
+    <file src="../libcoredistools.so" target="runtimes/ubuntu.14.04-x86/native/libcoredistools.so" />
+    <file src="../include/coredistools.h" target="runtimes/ubuntu.14.04-x86/native/coredistools.h" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.win7-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win7-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>runtime.win7-x64.Microsoft.NETCore.CoreDisTools</id>
+    <id>runtime.win7-x86.Microsoft.NETCore.CoreDisTools</id>
     <version>1.0.1-prerelease-00001</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
@@ -15,7 +15,7 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="..\coredistools.dll" target="runtimes\win7-x64\native\coredistools.dll" />
-    <file src="..\include\coredistools.h" target="runtimes\win7-x64\native\coredistools.h" />
+    <file src="..\coredistools.dll" target="runtimes\win7-x86\native\coredistools.dll" />
+    <file src="..\include\coredistools.h" target="runtimes\win7-x86\native\coredistools.h" />
   </files>
 </package>


### PR DESCRIPTION
Add nuspec files to build X86 packages of the CoreDisTools library.