### PR TITLE
Build ObjWriter/CoreDisTools Only

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
-add_subdirectory(Reader)
-add_subdirectory(Jit)
-add_subdirectory(GcInfo)
+# Enable ObjWriter/CoreDisTools only
+#add_subdirectory(Reader)
+#add_subdirectory(Jit)
+#add_subdirectory(GcInfo)
 add_subdirectory(ObjWriter)
 add_subdirectory(CoreDisTools)
 


### PR DESCRIPTION
To not track unnecessary build break, build objwriter/coredistools only.