### PR TITLE
Ending Section to Ensure Section Symbols

### DIFF
--- a/lib/CoreDisTools/coredistools.cpp
+++ b/lib/CoreDisTools/coredistools.cpp
@@ -307,7 +307,8 @@ bool CorDisasm::init() {
 
   MRI.reset(TheTarget->createMCRegInfo(TargetTriple));
   if (!MRI) {
-    Print->Error("Error: no register info for target %s\n", TargetTriple.c_str());
+    Print->Error("Error: no register info for target %s\n",
+                 TargetTriple.c_str());
     return false;
   }
 
@@ -322,13 +323,15 @@ bool CorDisasm::init() {
   string FeaturesStr; // No additional target specific attributes.
   STI.reset(TheTarget->createMCSubtargetInfo(TargetTriple, Mcpu, FeaturesStr));
   if (!STI) {
-    Print->Error("error: no subtarget info for target %s\n", TargetTriple.c_str());
+    Print->Error("error: no subtarget info for target %s\n",
+                 TargetTriple.c_str());
     return false;
   }
 
   MII.reset(TheTarget->createMCInstrInfo());
   if (!MII) {
-    Print->Error("error: no instruction info for target %s\n", TargetTriple.c_str());
+    Print->Error("error: no instruction info for target %s\n",
+                 TargetTriple.c_str());
     return false;
   }
 
@@ -338,7 +341,8 @@ bool CorDisasm::init() {
   Disassembler.reset(TheTarget->createMCDisassembler(*STI, *Ctx));
 
   if (!Disassembler) {
-    Print->Error("error: no disassembler for target %s\n", TargetTriple.c_str());
+    Print->Error("error: no disassembler for target %s\n",
+                 TargetTriple.c_str());
     return false;
   }
 
@@ -356,7 +360,8 @@ bool CorDisasm::init() {
       Triple(TargetTriple), AsmPrinterVariant, *AsmInfo, *MII, *MRI));
 
   if (!IP) {
-    Print->Error("error: No Instruction Printer for target %s\n", TargetTriple.c_str());
+    Print->Error("error: No Instruction Printer for target %s\n",
+                 TargetTriple.c_str());
     return false;
   }
 

--- a/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.11-prerelease-00001</version>
+    <version>1.0.12-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/runtime.json
+++ b/lib/ObjWriter/.nuget/runtime.json
@@ -2,17 +2,17 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.11-prerelease-00001"
+        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.12-prerelease-00001"
       }
     },
     "ubuntu.14.04-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.11-prerelease-00001"
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.12-prerelease-00001"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.11-prerelease-00001"
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.12-prerelease-00001"
       }
     }
   }

--- a/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.11-prerelease-00001</version>
+    <version>1.0.12-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.11-prerelease-00001</version>
+    <version>1.0.12-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.win7-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.11-prerelease-00001</version>
+    <version>1.0.12-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- Record sections that is used and endSection to ensure Section symbol creations.
- Register all executable sections to Dwarf sections so that debug info is created for them.