### PR TITLE
Change Version of CoreDisTools library

### DIFF
--- a/lib/CoreDisTools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.NETCore.CoreDisTools </id>
-    <version>1.0.1-prerelease-00001</version>
+    <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.json
+++ b/lib/CoreDisTools/.nuget/runtime.json
@@ -2,32 +2,32 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.win7-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+        "runtime.win7-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
     "ubuntu.14.04-x64": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+        "runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
     "win7-x86": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.win7-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+        "runtime.win7-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
     "ubuntu.14.04-x86": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+        "runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
     "osx.10.10-x86": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00001"
+        "runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     }
   }

--- a/lib/CoreDisTools/.nuget/runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.1-prerelease-00001</version>
+    <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.1-prerelease-00001</version>
+    <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.1-prerelease-00001</version>
+    <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.1-prerelease-00001</version>
+    <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.win7-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win7-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.win7-x64.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.1-prerelease-00001</version>
+    <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.win7-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win7-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>runtime.win7-x86.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.1-prerelease-00001</version>
+    <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
Change the minor version to reflect changes in
https://github.com/dotnet/llilc/commit/cbb572ed5f404c822e9bdc1310f2842cb229acfa

There are no API changes in this version, small change to the implementation.