### PR TITLE
Remove Coredistools header from Nuget Packages

### DIFF
--- a/lib/CoreDisTools/.nuget/runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -16,6 +16,5 @@
   </metadata>
   <files>
     <file src="../libcoredistools.dylib" target="runtimes/osx.10.10-x64/native/libcoredistools.dylib" />
-    <file src="../include/coredistools.h" target="runtimes/osx.10.10-x64/native/coredistools.h" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -16,6 +16,5 @@
   </metadata>
   <files>
     <file src="../libcoredistools.dylib" target="runtimes/osx.10.10-x86/native/libcoredistools.dylib" />
-    <file src="../include/coredistools.h" target="runtimes/osx.10.10-x86/native/coredistools.h" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -16,6 +16,5 @@
   </metadata>
   <files>
     <file src="../libcoredistools.so" target="runtimes/ubuntu.14.04-x64/native/libcoredistools.so" />
-    <file src="../include/coredistools.h" target="runtimes/ubuntu.14.04-x64/native/coredistools.h" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -16,6 +16,5 @@
   </metadata>
   <files>
     <file src="../libcoredistools.so" target="runtimes/ubuntu.14.04-x86/native/libcoredistools.so" />
-    <file src="../include/coredistools.h" target="runtimes/ubuntu.14.04-x86/native/coredistools.h" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.win7-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win7-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -16,6 +16,5 @@
   </metadata>
   <files>
     <file src="..\coredistools.dll" target="runtimes\win7-x64\native\coredistools.dll" />
-    <file src="..\include\coredistools.h" target="runtimes\win7-x64\native\coredistools.h" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.win7-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win7-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -16,6 +16,5 @@
   </metadata>
   <files>
     <file src="..\coredistools.dll" target="runtimes\win7-x86\native\coredistools.dll" />
-    <file src="..\include\coredistools.h" target="runtimes\win7-x86\native\coredistools.h" />
   </files>
 </package>


### PR DESCRIPTION
Remove coredistools.h from the packages published for
CoreDistools library, since the header is checked into
the CoreCLR tree.