### PR TITLE
CoreDistools: Build packages for osx 10.11

### DIFF
--- a/lib/CoreDisTools/.nuget/runtime.json
+++ b/lib/CoreDisTools/.nuget/runtime.json
@@ -10,9 +10,9 @@
         "runtime.ubuntu.14.04-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
-    "osx.10.10-x64": {
+    "osx.10.11-x64": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
+        "runtime.osx.10.11-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
     "win7-x86": {
@@ -25,9 +25,9 @@
         "runtime.ubuntu.14.04-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
-    "osx.10.10-x86": {
+    "osx.10.11-x86": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
+        "runtime.osx.10.11-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     }
   }

--- a/lib/CoreDisTools/.nuget/runtime.osx.10.11-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.11-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>runtime.osx.10.10-x64.Microsoft.NETCore.CoreDisTools</id>
+    <id>runtime.osx.10.11-x64.Microsoft.NETCore.CoreDisTools</id>
     <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
@@ -15,6 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="../libcoredistools.dylib" target="runtimes/osx.10.10-x64/native/libcoredistools.dylib" />
+    <file src="../libcoredistools.dylib" target="runtimes/osx.10.11-x64/native/libcoredistools.dylib" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.osx.10.11-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.osx.10.11-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>runtime.osx.10.10-x86.Microsoft.NETCore.CoreDisTools</id>
+    <id>runtime.osx.10.11-x86.Microsoft.NETCore.CoreDisTools</id>
     <version>1.0.1-prerelease-00002</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
@@ -15,6 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="../libcoredistools.dylib" target="runtimes/osx.10.10-x86/native/libcoredistools.dylib" />
+    <file src="../libcoredistools.dylib" target="runtimes/osx.10.11-x86/native/libcoredistools.dylib" />
   </files>
 </package>


### PR DESCRIPTION
Change the package version for OSX from 10.10 to 10.11

Fixes: https://github.com/dotnet/coreclr/issues/5602