### PR TITLE
Extend SwitchSection API 

### DIFF
--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -431,7 +431,7 @@ enum class RelocType {
 };
 
 extern "C" int EmitSymbolRef(ObjectWriter *OW, const char *SymbolName,
-                             RelocType RelocType, int Delta) {
+                             RelocType RelocationType, int Delta) {
   assert(OW && "ObjWriter is null");
   auto *AsmPrinter = &OW->getAsmPrinter();
   auto &OST = static_cast<MCObjectStreamer &>(*AsmPrinter->OutStreamer);
@@ -441,8 +441,8 @@ extern "C" int EmitSymbolRef(ObjectWriter *OW, const char *SymbolName,
   int Size = 0;
   MCSymbolRefExpr::VariantKind Kind = MCSymbolRefExpr::VK_None;
 
-  // Convert RelocType to MCSymbolRefExpr
-  switch (RelocType) {
+  // Convert RelocationType to MCSymbolRefExpr
+  switch (RelocationType) {
   case RelocType::IMAGE_REL_BASED_ABSOLUTE:
     assert(OW->MOFI->getObjectFileType() == OW->MOFI->IsCOFF);
     Kind = MCSymbolRefExpr::VK_COFF_IMGREL32;
@@ -459,7 +459,7 @@ extern "C" int EmitSymbolRef(ObjectWriter *OW, const char *SymbolName,
     IsPCRelative = true;
     break;
   default:
-    assert(false && "NYI RelocType!");
+    assert(false && "NYI RelocationType!");
   }
 
   const MCExpr *TargetExpr = GetSymbolRefExpr(OW, SymbolName, Kind);
@@ -565,7 +565,7 @@ extern "C" void EmitCFICode(ObjectWriter *OW, int Offset, const char *Blob) {
   auto *AsmPrinter = &OW->getAsmPrinter();
   auto &OST = *AsmPrinter->OutStreamer;
 
-  CFI_CODE *CfiCode = (CFI_CODE *)Blob;
+  const CFI_CODE *CfiCode = (const CFI_CODE *)Blob;
   switch (CfiCode->CfiOpCode) {
   case CFI_ADJUST_CFA_OFFSET:
     assert(CfiCode->DwarfReg == DWARF_REG_ILLEGAL &&

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -581,7 +581,7 @@ extern "C" void EmitCFICode(ObjectWriter *OW, int Offset, const char *Blob) {
     OST.EmitCFIDefCfaRegister(CfiCode->DwarfReg);
     break;
   default:
-    assert(!"Unrecognized CFI");
+    error("Unrecognized CFI");
     break;
   }
 }
@@ -728,7 +728,7 @@ static void EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
         break;
 
       default:
-        assert(!"Unknown varloc type!");
+        error("Unknown varloc type!");
         break;
       }
     }

--- a/lib/ObjWriter/objwriter.exports
+++ b/lib/ObjWriter/objwriter.exports
@@ -16,4 +16,3 @@ EmitDebugLoc
 EmitDebugFunctionInfo
 EmitDebugModuleInfo
 EmitDebugVar
-CreateCustomSection


### PR DESCRIPTION
Provide more precise control over custom sections. Previously we would
create a custom section for Comdat data and refer to it by name when
switching to it. However we really want custom sections with the same
name as existing sections, differing only on attributes or comdat name.
To accomplish this, remove the name -> MCSection mapping and provide an
extended API for switching sections that allows Comdat / attributes to
be specified.