### PR TITLE
Debug function symbols for non windows

### DIFF
--- a/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.15-prerelease-00001</version>
+    <version>1.0.16-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/runtime.json
+++ b/lib/ObjWriter/.nuget/runtime.json
@@ -2,17 +2,17 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.15-prerelease-00001"
+        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.16-prerelease-00001"
       }
     },
     "ubuntu.14.04-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.15-prerelease-00001"
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.16-prerelease-00001"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.15-prerelease-00001"
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.16-prerelease-00001"
       }
     }
   }

--- a/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.15-prerelease-00001</version>
+    <version>1.0.16-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.15-prerelease-00001</version>
+    <version>1.0.16-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.win7-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.15-prerelease-00001</version>
+    <version>1.0.16-prerelease-00001</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -244,7 +244,9 @@ void ObjectWriter::SwitchSection(const char *SectionName,
     }
   }
 
-  Sections.push_back(Section);
+  if (Sections.count(Section) == 0) {
+    Sections.insert(Section);
+  }
   OST.SwitchSection(Section);
 
   if (!Section->getBeginSymbol()) {
@@ -675,7 +677,7 @@ void ObjectWriter::EmitDebugFunctionInfo(const char *FunctionName,
       OST.EmitSymbolAttribute(Sym, MCSA_ELF_TypeFunction);
       OST.emitELFSize(Sym, MCConstantExpr::create(FunctionSize, OutContext));
     }
-    // TODO: Should test it for MachO.
+    // TODO: Should test it for Macho.
   }
 }
 

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -174,8 +174,10 @@ void ObjectWriter::SwitchSection(const char *SectionName,
   Streamer->SwitchSection(Section);
   if (Sections.count(Section) == 0) {
     Sections.insert(Section);
-    if (ObjFileInfo->getObjectFileType() != ObjFileInfo->IsCOFF) {
+    if (ObjFileInfo->getObjectFileType() == ObjFileInfo->IsMachO) {
       assert(!Section->getBeginSymbol());
+      // Output a DWARF linker-local symbol.
+      // This symbol is used as a base for other symbols in a section.
       MCSymbol *SectionStartSym = OutContext->createTempSymbol();
       Streamer->EmitLabel(SectionStartSym);
       Section->setBeginSymbol(SectionStartSym);

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -670,7 +670,12 @@ void ObjectWriter::EmitDebugFunctionInfo(const char *FunctionName,
     OST.EmitCVFuncIdDirective(FuncId);
     EmitCVDebugFunctionInfo(FunctionName, FunctionSize);
   } else {
-    // TODO: Should convert this for non-Windows.
+    if (MOFI->getObjectFileType() == MOFI->IsELF) {
+      MCSymbol *Sym = OutContext.getOrCreateSymbol(Twine(FunctionName));
+      OST.EmitSymbolAttribute(Sym, MCSA_ELF_TypeFunction);
+      OST.emitELFSize(Sym, MCConstantExpr::create(FunctionSize, OutContext));
+    }
+    // TODO: Should test it for MachO.
   }
 }
 
@@ -720,6 +725,6 @@ void ObjectWriter::EmitDebugModuleInfo() {
     OST.EmitCVFileChecksumsDirective();
     OST.EmitCVStringTableDirective();
   } else {
-    MCGenDwarfInfo::Emit(&OST);
+    OutContext.setGenDwarfForAssembly(true);
   }
 }

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -351,7 +351,7 @@ void ObjectWriter::EmitWinFrameInfo(const char *FunctionName, int StartOffset,
 
   // If the function was emitted to a Comdat section, create an associative
   // section to place the frame info in. This is due to the Windows linker
-  // requirement that a function and its unwind info come from the same 
+  // requirement that a function and its unwind info come from the same
   // object file.
   MCSymbol *Fn = OutContext.getOrCreateSymbol(Twine(FunctionName));
   const MCSectionCOFF *FunctionSection = cast<MCSectionCOFF>(&Fn->getSection());
@@ -403,9 +403,8 @@ void ObjectWriter::EmitCFILsda(const char *LsdaBlobSymbolName) {
   MCSymbol *T = OutContext.getOrCreateSymbol(LsdaBlobSymbolName);
   MCAssembler &MCAsm = OST.getAssembler();
   MCAsm.registerSymbol(*T);
-  OST.EmitCFILsda(T,
-                  llvm::dwarf::Constants::DW_EH_PE_pcrel |
-                      llvm::dwarf::Constants::DW_EH_PE_sdata4);
+  OST.EmitCFILsda(T, llvm::dwarf::Constants::DW_EH_PE_pcrel |
+                         llvm::dwarf::Constants::DW_EH_PE_sdata4);
 }
 
 void ObjectWriter::EmitCFICode(int Offset, const char *Blob) {

--- a/lib/ObjWriter/objwriter.cpp
+++ b/lib/ObjWriter/objwriter.cpp
@@ -83,7 +83,7 @@ bool ObjectWriter::Init(llvm::StringRef ObjectFilePath) {
   InitializeNativeTarget();
   InitializeNativeTargetAsmPrinter();
 
-  MCOptions = InitMCTargetOptionsFromFlags();
+  TargetMOptions = InitMCTargetOptionsFromFlags();
 
   InitTripleName();
   Triple TheTriple = GetTriple();
@@ -103,52 +103,58 @@ bool ObjectWriter::Init(llvm::StringRef ObjectFilePath) {
     return error("Unable to create file for " + ObjectFilePath + ": " +
                  EC.message());
 
-  MRI.reset(TheTarget->createMCRegInfo(TripleName));
-  if (!MRI)
+  RegisterInfo.reset(TheTarget->createMCRegInfo(TripleName));
+  if (!RegisterInfo)
     return error("Unable to create target register info!");
 
-  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName));
-  if (!MAI)
+  AsmInfo.reset(TheTarget->createMCAsmInfo(*RegisterInfo, TripleName));
+  if (!AsmInfo)
     return error("Unable to create target asm info!");
 
-  MOFI.reset(new MCObjectFileInfo);
-  MC.reset(new MCContext(MAI.get(), MRI.get(), MOFI.get()));
-  MOFI->InitMCObjectFileInfo(TheTriple, false, CodeModel::Default, *MC);
+  ObjFileInfo.reset(new MCObjectFileInfo);
+  OutContext.reset(
+      new MCContext(AsmInfo.get(), RegisterInfo.get(), ObjFileInfo.get()));
+  ObjFileInfo->InitMCObjectFileInfo(TheTriple, false, CodeModel::Default,
+                                    *OutContext);
 
-  std::string FeaturesStr;
-
-  MII.reset(TheTarget->createMCInstrInfo());
-  if (!MII)
+  InstrInfo.reset(TheTarget->createMCInstrInfo());
+  if (!InstrInfo)
     return error("no instr info info for target " + TripleName);
 
+  std::string FeaturesStr;
   std::string MCPU;
-
-  MSTI.reset(TheTarget->createMCSubtargetInfo(TripleName, MCPU, FeaturesStr));
-  if (!MSTI)
+  SubtargetInfo.reset(
+      TheTarget->createMCSubtargetInfo(TripleName, MCPU, FeaturesStr));
+  if (!SubtargetInfo)
     return error("no subtarget info for target " + TripleName);
 
-  MCE = TheTarget->createMCCodeEmitter(*MII, *MRI, *MC);
-  if (!MCE)
+  CodeEmitter =
+      TheTarget->createMCCodeEmitter(*InstrInfo, *RegisterInfo, *OutContext);
+  if (!CodeEmitter)
     return error("no code emitter for target " + TripleName);
 
-  MAB = TheTarget->createMCAsmBackend(*MRI, TripleName, MCPU, MCOptions);
-  if (!MAB)
+  AsmBackend = TheTarget->createMCAsmBackend(*RegisterInfo, TripleName, MCPU,
+                                             TargetMOptions);
+  if (!AsmBackend)
     return error("no asm backend for target " + TripleName);
 
-  MS = TheTarget->createMCObjectStreamer(TheTriple, *MC, *MAB, *OS, MCE, *MSTI,
-                                         RelaxAll,
-                                         /*IncrementalLinkerCompatible*/ true,
-                                         /*DWARFMustBeAtTheEnd*/ false);
-  if (!MS)
+  Streamer = (MCObjectStreamer *)TheTarget->createMCObjectStreamer(
+      TheTriple, *OutContext, *AsmBackend, *OS, CodeEmitter, *SubtargetInfo,
+      RelaxAll,
+      /*IncrementalLinkerCompatible*/ true,
+      /*DWARFMustBeAtTheEnd*/ false);
+  if (!Streamer)
     return error("no object streamer for target " + TripleName);
+  Assembler = &Streamer->getAssembler();
 
-  TM.reset(TheTarget->createTargetMachine(TripleName, MCPU, FeaturesStr,
-                                          TargetOptions(), None));
-  if (!TM)
+  TMachine.reset(TheTarget->createTargetMachine(TripleName, MCPU, FeaturesStr,
+                                                TargetOptions(), None));
+  if (!TMachine)
     return error("no target machine for target " + TripleName);
 
-  Asm.reset(TheTarget->createAsmPrinter(*TM, std::unique_ptr<MCStreamer>(MS)));
-  if (!Asm)
+  AssemblerPrinter.reset(TheTarget->createAsmPrinter(
+      *TMachine, std::unique_ptr<MCStreamer>(Streamer)));
+  if (!AssemblerPrinter)
     return error("no asm printer for target " + TripleName);
 
   FrameOpened = false;
@@ -157,29 +163,26 @@ bool ObjectWriter::Init(llvm::StringRef ObjectFilePath) {
   return true;
 }
 
-void ObjectWriter::Finish() { MS->Finish(); }
+void ObjectWriter::Finish() { Streamer->Finish(); }
 
 void ObjectWriter::SwitchSection(const char *SectionName,
                                  CustomSectionAttributes attributes,
                                  const char *ComdatName) {
-  auto &OST = *Asm->OutStreamer;
-  MCContext &OutContext = OST.getContext();
-  const MCObjectFileInfo *MOFI = OutContext.getObjectFileInfo();
   Triple TheTriple(TripleName);
 
   MCSection *Section = nullptr;
   if (strcmp(SectionName, "text") == 0) {
-    Section = MOFI->getTextSection();
+    Section = ObjFileInfo->getTextSection();
     if (!Section->hasInstructions()) {
       Section->setHasInstructions(true);
-      OutContext.addGenDwarfSection(Section);
+      OutContext->addGenDwarfSection(Section);
     }
   } else if (strcmp(SectionName, "data") == 0) {
-    Section = MOFI->getDataSection();
+    Section = ObjFileInfo->getDataSection();
   } else if (strcmp(SectionName, "rdata") == 0) {
-    Section = MOFI->getReadOnlySection();
+    Section = ObjFileInfo->getReadOnlySection();
   } else if (strcmp(SectionName, "xdata") == 0) {
-    Section = MOFI->getXDataSection();
+    Section = ObjFileInfo->getXDataSection();
   } else {
     SectionKind Kind = (attributes & CustomSectionAttributes_Executable)
                            ? SectionKind::getText()
@@ -192,7 +195,7 @@ void ObjectWriter::SwitchSection(const char *SectionName,
       if (attributes & CustomSectionAttributes_MachO_Init_Func_Pointers) {
         typeAndAttributes |= MachO::SectionType::S_MOD_INIT_FUNC_POINTERS;
       }
-      Section = OutContext.getMachOSection(
+      Section = OutContext->getMachOSection(
           (attributes & CustomSectionAttributes_Executable) ? "__TEXT"
                                                             : "__DATA",
           SectionName, typeAndAttributes, Kind);
@@ -212,11 +215,12 @@ void ObjectWriter::SwitchSection(const char *SectionName,
       }
 
       if (ComdatName != nullptr) {
-        Section = OutContext.getCOFFSection(
+        Section = OutContext->getCOFFSection(
             SectionName, Characteristics | COFF::IMAGE_SCN_LNK_COMDAT, Kind,
             ComdatName, COFF::COMDATType::IMAGE_COMDAT_SELECT_ANY);
       } else {
-        Section = OutContext.getCOFFSection(SectionName, Characteristics, Kind);
+        Section =
+            OutContext->getCOFFSection(SectionName, Characteristics, Kind);
       }
       break;
     }
@@ -224,8 +228,8 @@ void ObjectWriter::SwitchSection(const char *SectionName,
       unsigned Flags = ELF::SHF_ALLOC;
       if (ComdatName != nullptr) {
         MCSymbolELF *GroupSym =
-            cast<MCSymbolELF>(OutContext.getOrCreateSymbol(ComdatName));
-        OutContext.createELFGroupSection(GroupSym);
+            cast<MCSymbolELF>(OutContext->getOrCreateSymbol(ComdatName));
+        OutContext->createELFGroupSection(GroupSym);
         Flags |= ELF::SHF_GROUP;
       }
       if (attributes & CustomSectionAttributes_Executable) {
@@ -234,8 +238,8 @@ void ObjectWriter::SwitchSection(const char *SectionName,
         Flags |= ELF::SHF_WRITE;
       }
       Section =
-          OutContext.getELFSection(SectionName, ELF::SHT_PROGBITS, Flags, 0,
-                                   ComdatName != nullptr ? ComdatName : "");
+          OutContext->getELFSection(SectionName, ELF::SHT_PROGBITS, Flags, 0,
+                                    ComdatName != nullptr ? ComdatName : "");
       break;
     }
     default:
@@ -247,57 +251,44 @@ void ObjectWriter::SwitchSection(const char *SectionName,
   if (Sections.count(Section) == 0) {
     Sections.insert(Section);
   }
-  OST.SwitchSection(Section);
+  Streamer->SwitchSection(Section);
 
   if (!Section->getBeginSymbol()) {
-    MCSymbol *SectionStartSym = OutContext.createTempSymbol();
-    OST.EmitLabel(SectionStartSym);
+    MCSymbol *SectionStartSym = OutContext->createTempSymbol();
+    Streamer->EmitLabel(SectionStartSym);
     Section->setBeginSymbol(SectionStartSym);
   }
 }
 
 void ObjectWriter::EmitAlignment(int ByteAlignment) {
-  auto &OST = *Asm->OutStreamer;
-  OST.EmitValueToAlignment(ByteAlignment, 0x90 /* Nop */);
+  Streamer->EmitValueToAlignment(ByteAlignment, 0x90 /* Nop */);
 }
 
 void ObjectWriter::EmitBlob(int BlobSize, const char *Blob) {
-  auto &OST = *Asm->OutStreamer;
-  OST.EmitBytes(StringRef(Blob, BlobSize));
+  Streamer->EmitBytes(StringRef(Blob, BlobSize));
 }
 
 void ObjectWriter::EmitIntValue(uint64_t Value, unsigned Size) {
-  auto &OST = *Asm->OutStreamer;
-  OST.EmitIntValue(Value, Size);
+  Streamer->EmitIntValue(Value, Size);
 }
 
 void ObjectWriter::EmitSymbolDef(const char *SymbolName) {
-  auto &OST = *Asm->OutStreamer;
-  MCContext &OutContext = OST.getContext();
-
-  MCSymbol *Sym = OutContext.getOrCreateSymbol(Twine(SymbolName));
-  OST.EmitSymbolAttribute(Sym, MCSA_Global);
-  OST.EmitLabel(Sym);
+  MCSymbol *Sym = OutContext->getOrCreateSymbol(Twine(SymbolName));
+  Streamer->EmitSymbolAttribute(Sym, MCSA_Global);
+  Streamer->EmitLabel(Sym);
 }
 
 const MCSymbolRefExpr *
 ObjectWriter::GetSymbolRefExpr(const char *SymbolName,
                                MCSymbolRefExpr::VariantKind Kind) {
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
-
   // Create symbol reference
-  MCSymbol *T = OutContext.getOrCreateSymbol(SymbolName);
-  MCAssembler &MCAsm = OST.getAssembler();
-  MCAsm.registerSymbol(*T);
-  return MCSymbolRefExpr::create(T, Kind, OutContext);
+  MCSymbol *T = OutContext->getOrCreateSymbol(SymbolName);
+  Assembler->registerSymbol(*T);
+  return MCSymbolRefExpr::create(T, Kind, *OutContext);
 }
 
 int ObjectWriter::EmitSymbolRef(const char *SymbolName,
                                 RelocType RelocationType, int Delta) {
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
-
   bool IsPCRelative = false;
   int Size = 0;
   MCSymbolRefExpr::VariantKind Kind = MCSymbolRefExpr::VK_None;
@@ -305,7 +296,7 @@ int ObjectWriter::EmitSymbolRef(const char *SymbolName,
   // Convert RelocationType to MCSymbolRefExpr
   switch (RelocationType) {
   case RelocType::IMAGE_REL_BASED_ABSOLUTE:
-    assert(MOFI->getObjectFileType() == MOFI->IsCOFF);
+    assert(ObjFileInfo->getObjectFileType() == ObjFileInfo->IsCOFF);
     Kind = MCSymbolRefExpr::VK_COFF_IMGREL32;
     Size = 4;
     break;
@@ -329,104 +320,95 @@ int ObjectWriter::EmitSymbolRef(const char *SymbolName,
     // If the fixup is pc-relative, we need to bias the value to be relative to
     // the start of the field, not the end of the field
     TargetExpr = MCBinaryExpr::createSub(
-        TargetExpr, MCConstantExpr::create(Size, OutContext), OutContext);
+        TargetExpr, MCConstantExpr::create(Size, *OutContext), *OutContext);
   }
 
   if (Delta != 0) {
     TargetExpr = MCBinaryExpr::createAdd(
-        TargetExpr, MCConstantExpr::create(Delta, OutContext), OutContext);
+        TargetExpr, MCConstantExpr::create(Delta, *OutContext), *OutContext);
   }
-  OST.EmitValueImpl(TargetExpr, Size, SMLoc(), IsPCRelative);
+  Streamer->EmitValueImpl(TargetExpr, Size, SMLoc(), IsPCRelative);
   return Size;
 }
 
 void ObjectWriter::EmitWinFrameInfo(const char *FunctionName, int StartOffset,
                                     int EndOffset, const char *BlobSymbolName) {
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
-  const MCObjectFileInfo *MOFI = OutContext.getObjectFileInfo();
-
-  assert(MOFI->getObjectFileType() == MOFI->IsCOFF);
+  assert(ObjFileInfo->getObjectFileType() == ObjFileInfo->IsCOFF);
 
   // .pdata emission
-  MCSection *Section = MOFI->getPDataSection();
+  MCSection *Section = ObjFileInfo->getPDataSection();
 
   // If the function was emitted to a Comdat section, create an associative
   // section to place the frame info in. This is due to the Windows linker
   // requirement that a function and its unwind info come from the same
   // object file.
-  MCSymbol *Fn = OutContext.getOrCreateSymbol(Twine(FunctionName));
+  MCSymbol *Fn = OutContext->getOrCreateSymbol(Twine(FunctionName));
   const MCSectionCOFF *FunctionSection = cast<MCSectionCOFF>(&Fn->getSection());
   if (FunctionSection->getCharacteristics() & COFF::IMAGE_SCN_LNK_COMDAT) {
-    Section = OutContext.getAssociativeCOFFSection(
+    Section = OutContext->getAssociativeCOFFSection(
         cast<MCSectionCOFF>(Section), FunctionSection->getCOMDATSymbol());
   }
 
-  OST.SwitchSection(Section);
-  OST.EmitValueToAlignment(4);
+  Streamer->SwitchSection(Section);
+  Streamer->EmitValueToAlignment(4);
 
   const MCExpr *BaseRefRel =
       GetSymbolRefExpr(FunctionName, MCSymbolRefExpr::VK_COFF_IMGREL32);
 
   // start offset
-  const MCExpr *StartOfs = MCConstantExpr::create(StartOffset, OutContext);
-  OST.EmitValue(MCBinaryExpr::createAdd(BaseRefRel, StartOfs, OutContext), 4);
+  const MCExpr *StartOfs = MCConstantExpr::create(StartOffset, *OutContext);
+  Streamer->EmitValue(
+      MCBinaryExpr::createAdd(BaseRefRel, StartOfs, *OutContext), 4);
 
   // end offset
-  const MCExpr *EndOfs = MCConstantExpr::create(EndOffset, OutContext);
-  OST.EmitValue(MCBinaryExpr::createAdd(BaseRefRel, EndOfs, OutContext), 4);
+  const MCExpr *EndOfs = MCConstantExpr::create(EndOffset, *OutContext);
+  Streamer->EmitValue(MCBinaryExpr::createAdd(BaseRefRel, EndOfs, *OutContext),
+                      4);
 
   // frame symbol reference
-  OST.EmitValue(
+  Streamer->EmitValue(
       GetSymbolRefExpr(BlobSymbolName, MCSymbolRefExpr::VK_COFF_IMGREL32), 4);
 }
 
 void ObjectWriter::EmitCFIStart(int Offset) {
   assert(!FrameOpened && "frame should be closed before CFIStart");
-  auto &OST = *Asm->OutStreamer;
-
-  OST.EmitCFIStartProc(false);
+  Streamer->EmitCFIStartProc(false);
   FrameOpened = true;
 }
 
 void ObjectWriter::EmitCFIEnd(int Offset) {
   assert(FrameOpened && "frame should be opened before CFIEnd");
-  auto &OST = *Asm->OutStreamer;
-  OST.EmitCFIEndProc();
+  Streamer->EmitCFIEndProc();
   FrameOpened = false;
 }
 
 void ObjectWriter::EmitCFILsda(const char *LsdaBlobSymbolName) {
   assert(FrameOpened && "frame should be opened before CFILsda");
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
 
   // Create symbol reference
-  MCSymbol *T = OutContext.getOrCreateSymbol(LsdaBlobSymbolName);
-  MCAssembler &MCAsm = OST.getAssembler();
-  MCAsm.registerSymbol(*T);
-  OST.EmitCFILsda(T, llvm::dwarf::Constants::DW_EH_PE_pcrel |
-                         llvm::dwarf::Constants::DW_EH_PE_sdata4);
+  MCSymbol *T = OutContext->getOrCreateSymbol(LsdaBlobSymbolName);
+  Assembler->registerSymbol(*T);
+  Streamer->EmitCFILsda(T, llvm::dwarf::Constants::DW_EH_PE_pcrel |
+                               llvm::dwarf::Constants::DW_EH_PE_sdata4);
 }
 
 void ObjectWriter::EmitCFICode(int Offset, const char *Blob) {
   assert(FrameOpened && "frame should be opened before CFICode");
-  auto &OST = *Asm->OutStreamer;
 
   const CFI_CODE *CfiCode = (const CFI_CODE *)Blob;
   switch (CfiCode->CfiOpCode) {
   case CFI_ADJUST_CFA_OFFSET:
     assert(CfiCode->DwarfReg == DWARF_REG_ILLEGAL &&
            "Unexpected Register Value for OpAdjustCfaOffset");
-    OST.EmitCFIAdjustCfaOffset(CfiCode->Offset);
+    Streamer->EmitCFIAdjustCfaOffset(CfiCode->Offset);
     break;
   case CFI_REL_OFFSET:
-    OST.EmitCFIRelOffset(CfiCode->DwarfReg, CfiCode->Offset);
+    Streamer->EmitCFIRelOffset(CfiCode->DwarfReg, CfiCode->Offset);
     break;
   case CFI_DEF_CFA_REGISTER:
     assert(CfiCode->Offset == 0 &&
            "Unexpected Offset Value for OpDefCfaRegister");
-    OST.EmitCFIDefCfaRegister(CfiCode->DwarfReg);
+    Streamer->EmitCFIDefCfaRegister(CfiCode->DwarfReg);
     break;
   default:
     assert(false && "Unrecognized CFI");
@@ -434,47 +416,41 @@ void ObjectWriter::EmitCFICode(int Offset, const char *Blob) {
   }
 }
 
-void ObjectWriter::EmitLabelDiff(MCStreamer &Streamer, const MCSymbol *From,
-                                 const MCSymbol *To, unsigned int Size) {
+void ObjectWriter::EmitLabelDiff(const MCSymbol *From, const MCSymbol *To,
+                                 unsigned int Size) {
   MCSymbolRefExpr::VariantKind Variant = MCSymbolRefExpr::VK_None;
-  MCContext &Context = Streamer.getContext();
-  const MCExpr *FromRef = MCSymbolRefExpr::create(From, Variant, Context),
-               *ToRef = MCSymbolRefExpr::create(To, Variant, Context);
+  const MCExpr *FromRef = MCSymbolRefExpr::create(From, Variant, *OutContext),
+               *ToRef = MCSymbolRefExpr::create(To, Variant, *OutContext);
   const MCExpr *AddrDelta =
-      MCBinaryExpr::create(MCBinaryExpr::Sub, ToRef, FromRef, Context);
-  Streamer.EmitValue(AddrDelta, Size);
+      MCBinaryExpr::create(MCBinaryExpr::Sub, ToRef, FromRef, *OutContext);
+  Streamer->EmitValue(AddrDelta, Size);
 }
 
-void ObjectWriter::EmitSymRecord(MCObjectStreamer &OST, int Size,
-                                 SymbolRecordKind SymbolKind) {
+void ObjectWriter::EmitSymRecord(int Size, SymbolRecordKind SymbolKind) {
   RecordPrefix Rec;
   Rec.RecordLen = ulittle16_t(Size + sizeof(ulittle16_t));
   Rec.RecordKind = ulittle16_t((uint16_t)SymbolKind);
-  OST.EmitBytes(StringRef((char *)&Rec, sizeof(Rec)));
+  Streamer->EmitBytes(StringRef((char *)&Rec, sizeof(Rec)));
 }
 
-void ObjectWriter::EmitCOFFSecRel32Value(MCObjectStreamer &OST,
-                                         MCExpr const *Value) {
-  MCDataFragment *DF = OST.getOrCreateDataFragment();
+void ObjectWriter::EmitCOFFSecRel32Value(MCExpr const *Value) {
+  MCDataFragment *DF = Streamer->getOrCreateDataFragment();
   MCFixup Fixup = MCFixup::create(DF->getContents().size(), Value, FK_SecRel_4);
   DF->getFixups().push_back(Fixup);
   DF->getContents().resize(DF->getContents().size() + 4, 0);
 }
 
-void ObjectWriter::EmitVarDefRange(MCObjectStreamer &OST, const MCSymbol *Fn,
+void ObjectWriter::EmitVarDefRange(const MCSymbol *Fn,
                                    LocalVariableAddrRange &Range) {
-  const MCSymbolRefExpr *BaseSym =
-      MCSymbolRefExpr::create(Fn, OST.getContext());
-  const MCExpr *Offset =
-      MCConstantExpr::create(Range.OffsetStart, OST.getContext());
-  const MCExpr *Expr =
-      MCBinaryExpr::createAdd(BaseSym, Offset, OST.getContext());
-  EmitCOFFSecRel32Value(OST, Expr);
-  OST.EmitCOFFSectionIndex(Fn);
-  OST.EmitIntValue(Range.Range, 2);
+  const MCSymbolRefExpr *BaseSym = MCSymbolRefExpr::create(Fn, *OutContext);
+  const MCExpr *Offset = MCConstantExpr::create(Range.OffsetStart, *OutContext);
+  const MCExpr *Expr = MCBinaryExpr::createAdd(BaseSym, Offset, *OutContext);
+  EmitCOFFSecRel32Value(Expr);
+  Streamer->EmitCOFFSectionIndex(Fn);
+  Streamer->EmitIntValue(Range.Range, 2);
 }
 
-void ObjectWriter::EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
+void ObjectWriter::EmitCVDebugVarInfo(const MCSymbol *Fn,
                                       DebugVarInfo LocInfos[],
                                       int NumVarInfos) {
   for (int I = 0; I < NumVarInfos; I++) {
@@ -484,13 +460,13 @@ void ObjectWriter::EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
     LocalSymFlags Flags = LocalSymFlags::None;
     unsigned SizeofSym = sizeof(Type) + sizeof(Flags);
     unsigned NameLength = Var.Name.length() + 1;
-    EmitSymRecord(OST, SizeofSym + NameLength, SymbolRecordKind::LocalSym);
+    EmitSymRecord(SizeofSym + NameLength, SymbolRecordKind::LocalSym);
     if (Var.IsParam) {
       Flags |= LocalSymFlags::IsParameter;
     }
-    OST.EmitBytes(StringRef((char *)&Type, sizeof(Type)));
-    OST.EmitIntValue(static_cast<uint16_t>(Flags), sizeof(Flags));
-    OST.EmitBytes(StringRef(Var.Name.c_str(), NameLength));
+    Streamer->EmitBytes(StringRef((char *)&Type, sizeof(Type)));
+    Streamer->EmitIntValue(static_cast<uint16_t>(Flags), sizeof(Flags));
+    Streamer->EmitBytes(StringRef(Var.Name.c_str(), NameLength));
 
     for (const auto &Range : Var.Ranges) {
       // Emit a range record
@@ -507,7 +483,7 @@ void ObjectWriter::EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
         SymbolRecordKind SymbolKind = SymbolRecordKind::DefRangeRegisterSym;
         unsigned SizeofDefRangeRegisterSym = sizeof(DefRangeRegisterSym::Hdr) +
                                              sizeof(DefRangeRegisterSym::Range);
-        EmitSymRecord(OST, SizeofDefRangeRegisterSym, SymbolKind);
+        EmitSymRecord(SizeofDefRangeRegisterSym, SymbolKind);
 
         DefRangeRegisterSym DefRangeRegisterSymbol(SymbolKind);
         DefRangeRegisterSymbol.Range.OffsetStart = Range.startOffset;
@@ -517,8 +493,9 @@ void ObjectWriter::EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
         DefRangeRegisterSymbol.Hdr.Register =
             cvRegMapAmd64[Range.loc.vlReg.vlrReg];
         unsigned Length = sizeof(DefRangeRegisterSymbol.Hdr);
-        OST.EmitBytes(StringRef((char *)&DefRangeRegisterSymbol.Hdr, Length));
-        EmitVarDefRange(OST, Fn, DefRangeRegisterSymbol.Range);
+        Streamer->EmitBytes(
+            StringRef((char *)&DefRangeRegisterSymbol.Hdr, Length));
+        EmitVarDefRange(Fn, DefRangeRegisterSymbol.Range);
         break;
       }
 
@@ -539,7 +516,7 @@ void ObjectWriter::EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
         unsigned SizeofDefRangeRegisterRelSym =
             sizeof(DefRangeRegisterRelSym::Hdr) +
             sizeof(DefRangeRegisterRelSym::Range);
-        EmitSymRecord(OST, SizeofDefRangeRegisterRelSym, SymbolKind);
+        EmitSymRecord(SizeofDefRangeRegisterRelSym, SymbolKind);
 
         DefRangeRegisterRelSym DefRangeRegisterRelSymbol(SymbolKind);
         DefRangeRegisterRelSymbol.Range.OffsetStart = Range.startOffset;
@@ -552,9 +529,9 @@ void ObjectWriter::EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
             Range.loc.vlStk.vlsOffset;
 
         unsigned Length = sizeof(DefRangeRegisterRelSymbol.Hdr);
-        OST.EmitBytes(
+        Streamer->EmitBytes(
             StringRef((char *)&DefRangeRegisterRelSymbol.Hdr, Length));
-        EmitVarDefRange(OST, Fn, DefRangeRegisterRelSymbol.Range);
+        EmitVarDefRange(Fn, DefRangeRegisterRelSymbol.Range);
         break;
       }
 
@@ -579,29 +556,26 @@ void ObjectWriter::EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
 
 void ObjectWriter::EmitCVDebugFunctionInfo(const char *FunctionName,
                                            int FunctionSize) {
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
-  const MCObjectFileInfo *MOFI = OutContext.getObjectFileInfo();
-  assert(MOFI->getObjectFileType() == MOFI->IsCOFF);
+  assert(ObjFileInfo->getObjectFileType() == ObjFileInfo->IsCOFF);
 
   // Mark the end of function.
-  MCSymbol *FnEnd = OutContext.createTempSymbol();
-  OST.EmitLabel(FnEnd);
+  MCSymbol *FnEnd = OutContext->createTempSymbol();
+  Streamer->EmitLabel(FnEnd);
 
-  MCSection *Section = MOFI->getCOFFDebugSymbolsSection();
-  OST.SwitchSection(Section);
+  MCSection *Section = ObjFileInfo->getCOFFDebugSymbolsSection();
+  Streamer->SwitchSection(Section);
   // Emit debug section magic before the first entry.
   if (FuncId == 1) {
-    OST.EmitIntValue(COFF::DEBUG_SECTION_MAGIC, 4);
+    Streamer->EmitIntValue(COFF::DEBUG_SECTION_MAGIC, 4);
   }
-  MCSymbol *Fn = OutContext.getOrCreateSymbol(Twine(FunctionName));
+  MCSymbol *Fn = OutContext->getOrCreateSymbol(Twine(FunctionName));
 
   // Emit a symbol subsection, required by VS2012+ to find function boundaries.
-  MCSymbol *SymbolsBegin = OutContext.createTempSymbol(),
-           *SymbolsEnd = OutContext.createTempSymbol();
-  OST.EmitIntValue(unsigned(ModuleSubstreamKind::Symbols), 4);
-  EmitLabelDiff(OST, SymbolsBegin, SymbolsEnd);
-  OST.EmitLabel(SymbolsBegin);
+  MCSymbol *SymbolsBegin = OutContext->createTempSymbol(),
+           *SymbolsEnd = OutContext->createTempSymbol();
+  Streamer->EmitIntValue(unsigned(ModuleSubstreamKind::Symbols), 4);
+  EmitLabelDiff(SymbolsBegin, SymbolsEnd);
+  Streamer->EmitLabel(SymbolsBegin);
   {
     ProcSym ProcSymbol(SymbolRecordKind::GlobalProcIdSym);
     ProcSymbol.CodeSize = FunctionSize;
@@ -614,68 +588,61 @@ void ObjectWriter::EmitCVDebugFunctionInfo(const char *FunctionName,
         sizeof(ProcSymbol.DbgStart) + sizeof(ProcSymbol.DbgEnd) +
         sizeof(ProcSymbol.FunctionType);
     unsigned SymbolSize = HeaderSize + 4 + 2 + 1 + FunctionNameLength;
-    EmitSymRecord(OST, SymbolSize, SymbolRecordKind::GlobalProcIdSym);
+    EmitSymRecord(SymbolSize, SymbolRecordKind::GlobalProcIdSym);
 
-    OST.EmitBytes(StringRef((char *)&ProcSymbol.Parent, HeaderSize));
+    Streamer->EmitBytes(StringRef((char *)&ProcSymbol.Parent, HeaderSize));
     // Emit relocation
-    OST.EmitCOFFSecRel32(Fn, 0);
-    OST.EmitCOFFSectionIndex(Fn);
+    Streamer->EmitCOFFSecRel32(Fn, 0);
+    Streamer->EmitCOFFSectionIndex(Fn);
 
     // Emit flags
-    OST.EmitIntValue(0, 1);
+    Streamer->EmitIntValue(0, 1);
 
     // Emit the function display name as a null-terminated string.
 
-    OST.EmitBytes(StringRef(FunctionName, FunctionNameLength));
+    Streamer->EmitBytes(StringRef(FunctionName, FunctionNameLength));
 
     // Emit local var info
     int NumVarInfos = DebugVarInfos.size();
     if (NumVarInfos > 0) {
-      EmitCVDebugVarInfo(OST, Fn, &DebugVarInfos[0], NumVarInfos);
+      EmitCVDebugVarInfo(Fn, &DebugVarInfos[0], NumVarInfos);
       DebugVarInfos.clear();
     }
 
     // We're done with this function.
-    EmitSymRecord(OST, 0, SymbolRecordKind::ProcEnd);
+    EmitSymRecord(0, SymbolRecordKind::ProcEnd);
   }
 
-  OST.EmitLabel(SymbolsEnd);
+  Streamer->EmitLabel(SymbolsEnd);
 
   // Every subsection must be aligned to a 4-byte boundary.
-  OST.EmitValueToAlignment(4);
+  Streamer->EmitValueToAlignment(4);
 
   // We have an assembler directive that takes care of the whole line table.
   // We also increase function id for the next function.
-  OST.EmitCVLinetableDirective(FuncId++, Fn, FnEnd);
+  Streamer->EmitCVLinetableDirective(FuncId++, Fn, FnEnd);
 }
 
 void ObjectWriter::EmitDebugFileInfo(int FileId, const char *FileName) {
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
-  const MCObjectFileInfo *MOFI = OutContext.getObjectFileInfo();
-
   assert(FileId > 0 && "FileId should be greater than 0.");
-  if (MOFI->getObjectFileType() == MOFI->IsCOFF) {
-    OST.EmitCVFileDirective(FileId, FileName);
+  if (ObjFileInfo->getObjectFileType() == ObjFileInfo->IsCOFF) {
+    Streamer->EmitCVFileDirective(FileId, FileName);
   } else {
-    OST.EmitDwarfFileDirective(FileId, "", FileName);
+    Streamer->EmitDwarfFileDirective(FileId, "", FileName);
   }
 }
 
 void ObjectWriter::EmitDebugFunctionInfo(const char *FunctionName,
                                          int FunctionSize) {
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
-  const MCObjectFileInfo *MOFI = OutContext.getObjectFileInfo();
-
-  if (MOFI->getObjectFileType() == MOFI->IsCOFF) {
-    OST.EmitCVFuncIdDirective(FuncId);
+  if (ObjFileInfo->getObjectFileType() == ObjFileInfo->IsCOFF) {
+    Streamer->EmitCVFuncIdDirective(FuncId);
     EmitCVDebugFunctionInfo(FunctionName, FunctionSize);
   } else {
-    if (MOFI->getObjectFileType() == MOFI->IsELF) {
-      MCSymbol *Sym = OutContext.getOrCreateSymbol(Twine(FunctionName));
-      OST.EmitSymbolAttribute(Sym, MCSA_ELF_TypeFunction);
-      OST.emitELFSize(Sym, MCConstantExpr::create(FunctionSize, OutContext));
+    if (ObjFileInfo->getObjectFileType() == ObjFileInfo->IsELF) {
+      MCSymbol *Sym = OutContext->getOrCreateSymbol(Twine(FunctionName));
+      Streamer->EmitSymbolAttribute(Sym, MCSA_ELF_TypeFunction);
+      Streamer->emitELFSize(Sym,
+                            MCConstantExpr::create(FunctionSize, *OutContext));
     }
     // TODO: Should test it for Macho.
   }
@@ -697,36 +664,28 @@ void ObjectWriter::EmitDebugVar(char *Name, int TypeIndex, bool IsParm,
 
 void ObjectWriter::EmitDebugLoc(int NativeOffset, int FileId, int LineNumber,
                                 int ColNumber) {
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
-  const MCObjectFileInfo *MOFI = OutContext.getObjectFileInfo();
-
   assert(FileId > 0 && "FileId should be greater than 0.");
-  if (MOFI->getObjectFileType() == MOFI->IsCOFF) {
-    OST.EmitCVFuncIdDirective(FuncId);
-    OST.EmitCVLocDirective(FuncId, FileId, LineNumber, ColNumber, false, true,
-                           "", SMLoc());
+  if (ObjFileInfo->getObjectFileType() == ObjFileInfo->IsCOFF) {
+    Streamer->EmitCVFuncIdDirective(FuncId);
+    Streamer->EmitCVLocDirective(FuncId, FileId, LineNumber, ColNumber, false,
+                                 true, "", SMLoc());
   } else {
-    OST.EmitDwarfLocDirective(FileId, LineNumber, ColNumber, 1, 0, 0, "");
+    Streamer->EmitDwarfLocDirective(FileId, LineNumber, ColNumber, 1, 0, 0, "");
   }
 }
 
 void ObjectWriter::EmitDebugModuleInfo() {
-  auto &OST = static_cast<MCObjectStreamer &>(*Asm->OutStreamer);
-  MCContext &OutContext = OST.getContext();
-  const MCObjectFileInfo *MOFI = OutContext.getObjectFileInfo();
-
   // Ensure ending all sections.
   for (auto Section : Sections) {
-    OST.endSection(Section);
+    Streamer->endSection(Section);
   }
 
-  if (MOFI->getObjectFileType() == MOFI->IsCOFF) {
-    MCSection *Section = MOFI->getCOFFDebugSymbolsSection();
-    OST.SwitchSection(Section);
-    OST.EmitCVFileChecksumsDirective();
-    OST.EmitCVStringTableDirective();
+  if (ObjFileInfo->getObjectFileType() == ObjFileInfo->IsCOFF) {
+    MCSection *Section = ObjFileInfo->getCOFFDebugSymbolsSection();
+    Streamer->SwitchSection(Section);
+    Streamer->EmitCVFileChecksumsDirective();
+    Streamer->EmitCVStringTableDirective();
   } else {
-    OutContext.setGenDwarfForAssembly(true);
+    OutContext->setGenDwarfForAssembly(true);
   }
 }

--- a/lib/ObjWriter/objwriter.exports
+++ b/lib/ObjWriter/objwriter.exports
@@ -1,6 +1,7 @@
 InitObjWriter
 FinishObjWriter
 SwitchSection
+SetCodeSectionAttribute
 EmitAlignment
 EmitBlob
 EmitIntValue

--- a/lib/ObjWriter/objwriter.h
+++ b/lib/ObjWriter/objwriter.h
@@ -17,6 +17,7 @@
 #include "cfi.h"
 #include "jitDebugInfo.h"
 #include <string>
+#include <set>
 
 using namespace llvm;
 using namespace llvm::codeview;
@@ -102,7 +103,7 @@ private:
   bool FrameOpened;
   std::vector<DebugVarInfo> DebugVarInfos;
 
-  std::list<MCSection *> Sections;
+  std::set<MCSection *> Sections;
   int FuncId;
 
   std::string TripleName;

--- a/lib/ObjWriter/objwriter.h
+++ b/lib/ObjWriter/objwriter.h
@@ -44,6 +44,9 @@ public:
   void SwitchSection(const char *SectionName,
                      CustomSectionAttributes attributes,
                      const char *ComdatName);
+  void SetCodeSectionAttribute(const char *SectionName,
+                               CustomSectionAttributes attributes,
+                               const char *ComdatName);
 
   void EmitAlignment(int ByteAlignment);
   void EmitBlob(int BlobSize, const char *Blob);
@@ -80,6 +83,14 @@ private:
   const MCSymbolRefExpr *GetSymbolRefExpr(
       const char *SymbolName,
       MCSymbolRefExpr::VariantKind Kind = MCSymbolRefExpr::VK_None);
+
+  MCSection *GetSection(const char *SectionName,
+                        CustomSectionAttributes attributes,
+                        const char *ComdatName);
+
+  MCSection *GetSpecificSection(const char *SectionName,
+                                CustomSectionAttributes attributes,
+                                const char *ComdatName);
 
   void InitTripleName();
   Triple GetTriple();
@@ -132,6 +143,14 @@ extern "C" void SwitchSection(ObjectWriter *OW, const char *SectionName,
                               const char *ComdatName) {
   assert(OW && "ObjWriter is null");
   OW->SwitchSection(SectionName, attributes, ComdatName);
+}
+
+extern "C" void SetCodeSectionAttribute(ObjectWriter *OW,
+                                        const char *SectionName,
+                                        CustomSectionAttributes attributes,
+                                        const char *ComdatName) {
+  assert(OW && "ObjWriter is null");
+  OW->SetCodeSectionAttribute(SectionName, attributes, ComdatName);
 }
 
 extern "C" void EmitAlignment(ObjectWriter *OW, int ByteAlignment) {

--- a/lib/ObjWriter/objwriter.h
+++ b/lib/ObjWriter/objwriter.h
@@ -67,16 +67,14 @@ public:
   void EmitCFICode(int Offset, const char *Blob);
 
 private:
-  void EmitLabelDiff(MCStreamer &Streamer, const MCSymbol *From,
-                     const MCSymbol *To, unsigned int Size = 4);
-  void EmitSymRecord(MCObjectStreamer &OST, int Size,
-                     SymbolRecordKind SymbolKind);
-  void EmitCOFFSecRel32Value(MCObjectStreamer &OST, MCExpr const *Value);
+  void EmitLabelDiff(const MCSymbol *From, const MCSymbol *To,
+                     unsigned int Size = 4);
+  void EmitSymRecord(int Size, SymbolRecordKind SymbolKind);
+  void EmitCOFFSecRel32Value(MCExpr const *Value);
 
-  void EmitVarDefRange(MCObjectStreamer &OST, const MCSymbol *Fn,
-                       LocalVariableAddrRange &Range);
-  void EmitCVDebugVarInfo(MCObjectStreamer &OST, const MCSymbol *Fn,
-                          DebugVarInfo LocInfos[], int NumVarInfos);
+  void EmitVarDefRange(const MCSymbol *Fn, LocalVariableAddrRange &Range);
+  void EmitCVDebugVarInfo(const MCSymbol *Fn, DebugVarInfo LocInfos[],
+                          int NumVarInfos);
   void EmitCVDebugFunctionInfo(const char *FunctionName, int FunctionSize);
 
   const MCSymbolRefExpr *GetSymbolRefExpr(
@@ -87,19 +85,20 @@ private:
   Triple GetTriple();
 
 private:
-  std::unique_ptr<MCRegisterInfo> MRI;
-  std::unique_ptr<MCAsmInfo> MAI;
-  std::unique_ptr<MCObjectFileInfo> MOFI;
-  std::unique_ptr<MCContext> MC;
-  MCAsmBackend *MAB; // Owned by MCStreamer
-  std::unique_ptr<MCInstrInfo> MII;
-  std::unique_ptr<MCSubtargetInfo> MSTI;
-  MCCodeEmitter *MCE; // Owned by MCStreamer
-  std::unique_ptr<TargetMachine> TM;
-  std::unique_ptr<AsmPrinter> Asm;
+  std::unique_ptr<MCRegisterInfo> RegisterInfo;
+  std::unique_ptr<MCAsmInfo> AsmInfo;
+  std::unique_ptr<MCObjectFileInfo> ObjFileInfo;
+  std::unique_ptr<MCContext> OutContext;
+  MCAsmBackend *AsmBackend; // Owned by MCStreamer
+  std::unique_ptr<MCInstrInfo> InstrInfo;
+  std::unique_ptr<MCSubtargetInfo> SubtargetInfo;
+  MCCodeEmitter *CodeEmitter; // Owned by MCStreamer
+  std::unique_ptr<TargetMachine> TMachine;
+  std::unique_ptr<AsmPrinter> AssemblerPrinter;
+  MCAssembler *Assembler; // Owned by MCStreamer
 
   std::unique_ptr<raw_fd_ostream> OS;
-  MCTargetOptions MCOptions;
+  MCTargetOptions TargetMOptions;
   bool FrameOpened;
   std::vector<DebugVarInfo> DebugVarInfos;
 
@@ -108,7 +107,7 @@ private:
 
   std::string TripleName;
 
-  MCStreamer *MS; // Owned by AsmPrinter
+  MCObjectStreamer *Streamer; // Owned by AsmPrinter
 };
 
 // When object writer is created/initialized successfully, it is returned.


### PR DESCRIPTION
Fix problem with lldb debugging.

So after this fix we emit correct attributes for function symbols and sections.
The corresponding [CoreRT PR ](https://github.com/sandreenko/corert/commit/064cee1f14d7a5958e4e98285f57a41baf7338fa).

Some examples:
```
(lldb) breakpoint set --file Hello.cs --line 14
Breakpoint 1: where = Hello`Hello_Hello_Program__Main, address = 0x00000000005366a4
(lldb) r
Process 9580 launched: '/home/sergey/git/corert/tests/src/Simple/Hello/bin/Debug/x64/native/Hello' (x86_64)
Process 9580 stopped
* thread #1, name = 'Hello', stop reason = breakpoint 1.1
    frame #0: 0x00000000005366a4 Hello`Hello_Hello_Program__Main at Hello.cs:14
   11  	    internal class Program
   12  	    {
   13  	        private static void Main(string[] args)
-> 14  	        {
   15  	            if (args.Length == 0)
   16  	            {
   17  	                Console.WriteLine("Usage: hello name");


(gdb) break Hello.cs:15
Breakpoint 1 at 0x5366bc: file /home/sergey/git/corert/tests/src/Simple/Hello/Hello.cs, line 15.
(gdb) r
Starting program: /home/sergey/git/corert/tests/src/Simple/Hello/bin/Debug/x64/native/Hello 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7fffdcbdd700 (LWP 9651)]

Breakpoint 1, Hello_Hello_Program__Main () at /home/sergey/git/corert/tests/src/Simple/Hello/Hello.cs:15
15	            if (args.Length == 0)
(gdb) 


(lldb) breakpoint set --name Hello_Hello_Program__Main
Breakpoint 1: where = Hello`Hello_Hello_Program__Main + 24, address = 0x00000000005366bc

```

There is problem with image --lookup output, it doesn't show source line for address, but it will be fixed in the other PR.

Also I want to rename all variables in camel case. gcc doesn't allow to name variables as types (TargetMachine TargetMachine; ) and it creates many problems. So I want to use the same naming rules as CoreCLR and CoreRT. 