### PR TITLE
Fix for some types

### DIFF
--- a/lib/ObjWriter/typeBuilder.h
+++ b/lib/ObjWriter/typeBuilder.h
@@ -28,7 +28,7 @@ extern "C" struct EnumRecordTypeDescriptor {
 };
 
 extern "C" struct EnumTypeDescriptor {
-  uint64 ElementType;
+  unsigned ElementType;
   uint64 ElementCount;
   char *Name;
   char *UniqueName;
@@ -43,12 +43,12 @@ extern "C" struct ClassTypeDescriptor {
 
 extern "C" struct DataFieldDescriptor {
   unsigned FieldTypeIndex;
-  int Offset;
+  uint64 Offset;
   char *Name;
 };
 
 extern "C" struct ClassFieldsTypeDescriptior {
-  int Size;
+  uint64 Size;
   int FieldsCount;
 };
 


### PR DESCRIPTION
Type can be bigger than unsigned, Offset and SIze could be 64 bites long.