### PR TITLE
emit S_UDT symbols to keep all UDT alive after the linker.

### DIFF
--- a/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.18-prerelease-00001</version>
+    <version>1.0.18-prerelease-00002</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/runtime.json
+++ b/lib/ObjWriter/.nuget/runtime.json
@@ -2,17 +2,17 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.18-prerelease-00001"
+        "toolchain.win7-x64.Microsoft.DotNet.ObjectWriter": "1.0.18-prerelease-00002"
       }
     },
     "ubuntu.14.04-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.18-prerelease-00001"
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter": "1.0.18-prerelease-00002"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.DotNet.ObjectWriter": {
-        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.18-prerelease-00001"
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter": "1.0.18-prerelease-00002"
       }
     }
   }

--- a/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.osx.10.10-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.18-prerelease-00001</version>
+    <version>1.0.18-prerelease-00002</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.18-prerelease-00001</version>
+    <version>1.0.18-prerelease-00002</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
+++ b/lib/ObjWriter/.nuget/toolchain.win7-x64.Microsoft.DotNet.ObjectWriter.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.win7-x64.Microsoft.DotNet.ObjectWriter</id>
-    <version>1.0.18-prerelease-00001</version>
+    <version>1.0.18-prerelease-00002</version>
     <title>Microsoft .NET Object File Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/ObjWriter/objwriter.h
+++ b/lib/ObjWriter/objwriter.h
@@ -105,6 +105,8 @@ private:
                                 CustomSectionAttributes attributes,
                                 const char *ComdatName);
 
+  void EmitCVUserDefinedTypesSymbols();
+
   void InitTripleName();
   Triple GetTriple();
 

--- a/lib/ObjWriter/typeBuilder.cpp
+++ b/lib/ObjWriter/typeBuilder.cpp
@@ -87,6 +87,7 @@ unsigned UserDefinedTypesBuilder::GetEnumTypeIndex(
                         ElementTypeIndex);
 
   TypeIndex Type = TypeTable.writeKnownType(EnumRecord);
+  UserDefinedTypes.push_back(std::make_pair(TypeDescriptor.Name, Type));
   return Type.getIndex();
 }
 
@@ -136,6 +137,8 @@ unsigned UserDefinedTypesBuilder::GetCompleteClassTypeIndex(
                  TypeIndex(), TypeIndex(), ClassFieldsDescriptor.Size,
                  ClassDescriptor.Name, ClassDescriptor.UniqueName);
   TypeIndex ClassIndex = TypeTable.writeKnownType(CR);
+
+  UserDefinedTypes.push_back(std::make_pair(ClassDescriptor.Name, ClassIndex));
 
   if (ClassDescriptor.IsStruct == false) {
     return GetPointerType(ClassIndex);
@@ -198,6 +201,8 @@ unsigned UserDefinedTypesBuilder::GetArrayTypeIndex(
                  TypeIndex(), ArrayDescriptor.Size, ClassDescriptor.Name,
                  ClassDescriptor.UniqueName);
   TypeIndex ClassIndex = TypeTable.writeKnownType(CR);
+
+  UserDefinedTypes.push_back(std::make_pair(ClassDescriptor.Name, ClassIndex));
 
   return GetPointerType(ClassIndex);
 }

--- a/lib/ObjWriter/typeBuilder.h
+++ b/lib/ObjWriter/typeBuilder.h
@@ -91,6 +91,10 @@ public:
   unsigned GetArrayTypeIndex(const ClassTypeDescriptor &ClassDescriptor,
                              const ArrayTypeDescriptor &ArrayDescriptor);
 
+  const std::vector<std::pair<std::string, codeview::TypeIndex>> &GetUDTs() {
+    return UserDefinedTypes;
+  }
+
 private:
   void EmitCodeViewMagicVersion();
   ClassOptions GetCommonClassOptions();
@@ -108,4 +112,6 @@ private:
   unsigned TargetPointerSize;
 
   ArrayDimensionsDescriptor ArrayDimentions;
+
+  std::vector<std::pair<std::string, codeview::TypeIndex>> UserDefinedTypes;
 };


### PR DESCRIPTION
We need s_udt to guarantee that all UDT will be alive after the linker.

@nattress PTAL.
