### PR TITLE
Replace Windows NuGet Rids with generic variants

### DIFF
--- a/lib/CoreDisTools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/Microsoft.NETCore.CoreDisTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.NETCore.CoreDisTools </id>
-    <version>1.0.1-prerelease-00002</version>
+    <version>1.0.1-prerelease-00004</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/lib/CoreDisTools/.nuget/runtime.json
+++ b/lib/CoreDisTools/.nuget/runtime.json
@@ -1,8 +1,8 @@
 {
   "runtimes": {
-    "win7-x64": {
+    "win-x64": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.win7-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
+        "runtime.win-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00004"
       }
     },
     "ubuntu.14.04-x64": {
@@ -25,9 +25,9 @@
         "runtime.osx.10.11-x64.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
       }
     },
-    "win7-x86": {
+    "win-x86": {
       "Microsoft.NETCore.CoreDisTools": {
-        "runtime.win7-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00002"
+        "runtime.win-x86.Microsoft.NETCore.CoreDisTools": "1.0.1-prerelease-00004"
       }
     },
     "ubuntu.14.04-x86": {

--- a/lib/CoreDisTools/.nuget/runtime.win-x64.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win-x64.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>runtime.win7-x64.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.1-prerelease-00002</version>
+    <id>runtime.win-x64.Microsoft.NETCore.CoreDisTools</id>
+    <version>1.0.1-prerelease-00004</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -15,6 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="..\coredistools.dll" target="runtimes\win7-x64\native\coredistools.dll" />
+    <file src="..\coredistools.dll" target="runtimes\win-x64\native\coredistools.dll" />
   </files>
 </package>

--- a/lib/CoreDisTools/.nuget/runtime.win-x86.Microsoft.NETCore.CoreDisTools.nuspec
+++ b/lib/CoreDisTools/.nuget/runtime.win-x86.Microsoft.NETCore.CoreDisTools.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>runtime.win7-x86.Microsoft.NETCore.CoreDisTools</id>
-    <version>1.0.1-prerelease-00002</version>
+    <id>runtime.win-x86.Microsoft.NETCore.CoreDisTools</id>
+    <version>1.0.1-prerelease-00004</version>
     <title>Microsoft.NETCore Instruction-wise Disassembler</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -15,6 +15,6 @@
     <copyright>Copyright &#169; Microsoft Corporation</copyright>
   </metadata>
   <files>
-    <file src="..\coredistools.dll" target="runtimes\win7-x86\native\coredistools.dll" />
+    <file src="..\coredistools.dll" target="runtimes\win-x86\native\coredistools.dll" />
   </files>
 </package>


### PR DESCRIPTION
win7-x86 / win7-x64 are being deprecated and replaced with the generic win-x86 / win-x64 variants.