### PR TITLE
[WIP] Support Arm32 and Arm64 in nearDiff

### DIFF
--- a/lib/CoreDisTools/coredistools.cpp
+++ b/lib/CoreDisTools/coredistools.cpp
@@ -281,7 +281,7 @@ bool CorDisasm::setTarget() {
     break;
 
   case Target_Thumb:
-    TheTriple.setArch(Triple::thumb);
+    TheTriple.setArchName("thumbv7");
     break;
   case Target_Arm64:
     TheTriple.setArch(Triple::aarch64);

--- a/lib/CoreDisTools/coredistools.cpp
+++ b/lib/CoreDisTools/coredistools.cpp
@@ -576,8 +576,8 @@ bool CorAsmDiff::nearDiff(const BlockInfo &LeftBlock,
   const uint8_t* ConsBlockR = nullptr;
 
   while (!Left.isEmpty() && !Right.isEmpty()) {
-    const bool isAtLiteralPoolL = Left.Ptr >= ConsBlockL;
-    const bool isAtLiteralPoolR = Right.Ptr >= ConsBlockR;
+    const bool isAtLiteralPoolL = (ConsBlockL != nullptr) && (Left.Ptr == ConsBlockL);
+    const bool isAtLiteralPoolR = (ConsBlockR != nullptr) && (Right.Ptr == ConsBlockR);
 
     if (isAtLiteralPoolL || isAtLiteralPoolR) {
       if (!isAtLiteralPoolL || !isAtLiteralPoolL) {


### PR DESCRIPTION
Right now CorDisTools can not be used to disassemble JIT output during SuperPMI with ARM64 JIT due to the fact that on ARM64 the code block is appended with literal pool (https://github.com/dotnet/coreclr/blob/06f1634c3157dc279779f3dad7d2f327416e3f09/src/jit/emit.cpp#L4629-L4650) 

What happens is that the disassembler goes beyond JIT code and tries to decode data in literal pool where it obviously fails.

I couldn't find any information collected during JIT-EE interactions that can help to determine the size of  JIT code region. It seems that we are loosing such information during allocMem call by explicitly passing 0 in roDataSize (https://github.com/dotnet/coreclr/blob/06f1634c3157dc279779f3dad7d2f327416e3f09/src/jit/emit.cpp#L4645)

What I am doing here is trying to reconstruct boundary between JIT code and constant pool during instruction decoding by looking at LDR instructions that have PCRel immediate as a second operand and computing the corresponding label addresses using current value of PC. The minimum address is then assumed to be the beginning of a literal pool. 

I did experimentation with running SuperPMI with ARM64 JIT with CorDisTools with these changes and it seems that this approach works on the all framework libraries in Core_Root. 

@dotnet/jit-contrib 
Does anyone think about a better way to figure out the literal pool size?
@briansull @BruceForstall 